### PR TITLE
include query item in search suggestions

### DIFF
--- a/src/Search.elm
+++ b/src/Search.elm
@@ -641,17 +641,30 @@ getSuggestions query querySuggest =
     in
     case querySuggest of
         RemoteData.Success result ->
-            result.suggest
-                |> maybeList (\x -> x.query |> maybeList (List.map .options))
-                |> List.concat
-                |> List.filter
-                    (\x ->
-                        if String.endsWith "." (Maybe.withDefault "" query) then
-                            x.text /= query
+            let
+                suggestions =
+                    result.suggest
+                        |> maybeList (\x -> x.query |> maybeList (List.map .options))
+                        |> List.concat
+                        |> List.filter
+                            (\x ->
+                                if String.endsWith "." (Maybe.withDefault "" query) then
+                                    x.text /= query
 
-                        else
-                            True
-                    )
+                                else
+                                    True
+                            )
+
+                firstItemText items =
+                    items
+                        |> List.head
+                        |> Maybe.andThen .text
+            in
+            if List.length suggestions == 1 && firstItemText suggestions == query then
+                []
+
+            else
+                suggestions
 
         _ ->
             []

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -644,7 +644,14 @@ getSuggestions query querySuggest =
             result.suggest
                 |> maybeList (\x -> x.query |> maybeList (List.map .options))
                 |> List.concat
-                |> List.filter (\x -> x.text /= query)
+                |> List.filter
+                    (\x ->
+                        if String.endsWith "." (Maybe.withDefault "" query) then
+                            x.text /= query
+
+                        else
+                            True
+                    )
 
         _ ->
             []


### PR DESCRIPTION
but only if it does not end with ".", since items with "." are partial
names only used to drill down to the actual package/option name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixos-search/117)
<!-- Reviewable:end -->
