### PR TITLE
Add NixOS 20.09

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         channel:
           - unstable
+          - 20.09
           - 20.03
           - 19.09
 

--- a/import-scripts/import_scripts/channel.py
+++ b/import-scripts/import_scripts/channel.py
@@ -29,6 +29,7 @@ CHANNELS = {
     "unstable": "nixos/unstable/nixos-20.09pre",
     "19.09": "nixos/19.09/nixos-19.09.",
     "20.03": "nixos/20.03/nixos-20.03.",
+    "20.09": "nixos/20.09/nixos-20.09.",
 }
 ANALYSIS = {
     "normalizer": {

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -317,7 +317,7 @@ type Channel
     = Unstable
     | Release_19_09
     | Release_20_03
-
+    | Release_20_09
 
 type alias ChannelDetails =
     { id : String
@@ -339,6 +339,9 @@ channelDetails channel =
         Release_20_03 ->
             ChannelDetails "20.03" "20.03" "nixos/release-20.03" "nixos-20.03"
 
+        Release_20_09 ->
+            ChannelDetails "20.09" "20.09" "nixos/release-20.09" "nixos-20.09"
+
 
 channelFromId : String -> Maybe Channel
 channelFromId channel_id =
@@ -351,6 +354,9 @@ channelFromId channel_id =
 
         "20.03" ->
             Just Release_20_03
+
+        "20.09" ->
+            Just Release_20_09
 
         _ ->
             Nothing
@@ -366,6 +372,7 @@ channels : List String
 channels =
     [ "19.09"
     , "20.03"
+    , "20.09"
     , "unstable"
     ]
 


### PR DESCRIPTION
It might be helpful to start providing 20.09 options search already to help people that are testing the early stages of the release.

I could not actually test if this is what it takes to make it happen. 20.09 started appearing on the UI but not sure how I can test the search backend locally.