### PR TITLE
Add basic support for listing texlive packages

### DIFF
--- a/import-scripts/import_scripts/channel.py
+++ b/import-scripts/import_scripts/channel.py
@@ -432,6 +432,9 @@ def get_packages(evaluation, evaluation_builds):
                 for platform in data["meta"].get("platforms", [])
             ]
 
+            if attr_name.startswith("texlive-pkgs-nixos-search."):
+                attr_name = attr_name.replace("texlive-pkgs-nixos-search.", "texlive.")
+
             attr_set = None
             if "." in attr_name:
                 attr_set = attr_name.split(".")[0]

--- a/import-scripts/import_scripts/packages-config.nix
+++ b/import-scripts/import_scripts/packages-config.nix
@@ -38,5 +38,6 @@
     "steamPackages"
     "ut2004Packages"
     "zeroadPackages"
-  ];
+  ] //
+    { texlive-pkgs-nixos-search = super.lib.mapAttrs (name: attrs: if name != "combined" && builtins.isAttrs attrs && builtins.hasAttr "pkgs" attrs then builtins.elemAt attrs.pkgs 0 else attrs) super.texlive; };
 }


### PR DESCRIPTION
Fix for issue #202. The packages show up in the nix-env listing, so the Nix part seems fine, but I don't know how to test the Python part as it seems to require setting up elasticsearch.

(and of course it's hacky, but the Texlive packaging scheme is completely different from the rest of nixpkgs...)