### PR TITLE
Always use NixOS/nixpkgs instead of NixOS/nixpkgs-channels

### DIFF
--- a/import-scripts/import_scripts/channel.py
+++ b/import-scripts/import_scripts/channel.py
@@ -395,7 +395,7 @@ def get_packages(evaluation, evaluation_builds):
     )
     result = subprocess.run(
         shlex.split(
-            f"nix-env -f '<nixpkgs>' -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/{evaluation['git_revision']}.tar.gz --arg config 'import {CURRENT_DIR}/packages-config.nix' -qa --json"
+            f"nix-env -f '<nixpkgs>' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/{evaluation['git_revision']}.tar.gz --arg config 'import {CURRENT_DIR}/packages-config.nix' -qa --json"
         ),
         stdout=subprocess.PIPE,
         check=True,
@@ -498,7 +498,7 @@ def get_packages(evaluation, evaluation_builds):
 def get_options(evaluation):
     result = subprocess.run(
         shlex.split(
-            f"nix-build <nixpkgs/nixos/release.nix> --no-out-link -A options -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/{evaluation['git_revision']}.tar.gz"
+            f"nix-build <nixpkgs/nixos/release.nix> --no-out-link -A options -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/{evaluation['git_revision']}.tar.gz"
         ),
         stdout=subprocess.PIPE,
         check=True,

--- a/src/Page/Options.elm
+++ b/src/Page/Options.elm
@@ -213,7 +213,7 @@ viewResultItemDetails channel item =
             code [] [ text value ]
 
         githubUrlPrefix branch =
-            "https://github.com/NixOS/nixpkgs-channels/blob/" ++ branch ++ "/"
+            "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
 
         cleanPosition value =
             if String.startsWith "source/" value then

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -254,7 +254,7 @@ viewResultItemDetails channel item =
             a [ href value ] [ text value ]
 
         githubUrlPrefix branch =
-            "https://github.com/NixOS/nixpkgs-channels/blob/" ++ branch ++ "/"
+            "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
 
         cleanPosition value =
             if String.startsWith "source/" value then


### PR DESCRIPTION
Links in the search results for NixOS 20.09 started throwing 404
otherwise. Not all channels are being pushed to nixpkgs-channels as
apparently it is being phased out.