### PR TITLE
Support search engine escaping of spaces (+)

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,39 +1,40 @@
 {
-  "type": "application",
-  "source-directories": [
-    "src"
-  ],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-      "elm/browser": "1.0.2",
-      "elm/core": "1.0.4",
-      "elm/html": "1.0.0",
-      "elm/http": "2.0.0",
-      "elm/json": "1.1.3",
-      "elm/regex": "1.0.0",
-      "elm/url": "1.0.0",
-      "hecrj/html-parser": "2.3.4",
-      "krisajenkins/remotedata": "6.0.1",
-      "truqu/elm-base64": "2.0.4"
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.4",
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm-community/basics-extra": "4.1.0",
+            "hecrj/html-parser": "2.3.4",
+            "krisajenkins/remotedata": "6.0.1",
+            "truqu/elm-base64": "2.0.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
+            "elm/parser": "1.1.0",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "rtfeldman/elm-hex": "1.0.0"
+        }
     },
-    "indirect": {
-      "elm/bytes": "1.0.8",
-      "elm/file": "1.0.5",
-      "elm/parser": "1.1.0",
-      "elm/time": "1.0.0",
-      "elm/virtual-dom": "1.0.2",
-      "rtfeldman/elm-hex": "1.0.0"
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {
+            "elm/random": "1.0.0",
+            "elm/svg": "1.0.1"
+        }
     }
-  },
-  "test-dependencies": {
-    "direct": {
-      "elm-explorations/test": "1.2.2"
-    },
-    "indirect": {
-      "elm/random": "1.0.0",
-      "elm/svg": "1.0.1"
-    }
-  }
 }

--- a/elm.json
+++ b/elm.json
@@ -1,40 +1,39 @@
 {
-    "type": "application",
-    "source-directories": [
-        "src"
-    ],
-    "elm-version": "0.19.1",
-    "dependencies": {
-        "direct": {
-            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-            "elm/browser": "1.0.2",
-            "elm/core": "1.0.4",
-            "elm/html": "1.0.0",
-            "elm/http": "2.0.0",
-            "elm/json": "1.1.3",
-            "elm/regex": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm-community/basics-extra": "4.1.0",
-            "hecrj/html-parser": "2.3.4",
-            "krisajenkins/remotedata": "6.0.1",
-            "truqu/elm-base64": "2.0.4"
-        },
-        "indirect": {
-            "elm/bytes": "1.0.8",
-            "elm/file": "1.0.5",
-            "elm/parser": "1.1.0",
-            "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
-            "rtfeldman/elm-hex": "1.0.0"
-        }
+  "type": "application",
+  "source-directories": [
+    "src"
+  ],
+  "elm-version": "0.19.1",
+  "dependencies": {
+    "direct": {
+      "NoRedInk/elm-json-decode-pipeline": "1.0.0",
+      "elm/browser": "1.0.2",
+      "elm/core": "1.0.4",
+      "elm/html": "1.0.0",
+      "elm/http": "2.0.0",
+      "elm/json": "1.1.3",
+      "elm/regex": "1.0.0",
+      "elm/url": "1.0.0",
+      "hecrj/html-parser": "2.3.4",
+      "krisajenkins/remotedata": "6.0.1",
+      "truqu/elm-base64": "2.0.4"
     },
-    "test-dependencies": {
-        "direct": {
-            "elm-explorations/test": "1.2.2"
-        },
-        "indirect": {
-            "elm/random": "1.0.0",
-            "elm/svg": "1.0.1"
-        }
+    "indirect": {
+      "elm/bytes": "1.0.8",
+      "elm/file": "1.0.5",
+      "elm/parser": "1.1.0",
+      "elm/time": "1.0.0",
+      "elm/virtual-dom": "1.0.2",
+      "rtfeldman/elm-hex": "1.0.0"
     }
+  },
+  "test-dependencies": {
+    "direct": {
+      "elm-explorations/test": "1.2.2"
+    },
+    "indirect": {
+      "elm/random": "1.0.0",
+      "elm/svg": "1.0.1"
+    }
+  }
 }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,7 +1,5 @@
 module Main exposing (main)
 
---exposing (UrlRequest(..))
-
 import Browser
 import Browser.Navigation
 import Html

--- a/src/Page/Options.elm
+++ b/src/Page/Options.elm
@@ -43,6 +43,7 @@ import Html.Parser.Util
 import Json.Decode
 import Json.Encode
 import Regex
+import Route
 import Search
 
 
@@ -102,7 +103,7 @@ update navKey msg model =
             let
                 ( newModel, newCmd ) =
                     Search.update
-                        "options"
+                        Route.Options
                         navKey
                         subMsg
                         model
@@ -116,8 +117,7 @@ update navKey msg model =
 
 view : Model -> Html Msg
 view model =
-    Search.view
-        "options"
+    Search.view { toRoute = Route.Options, categoryName = "options" }
         "Search NixOS options"
         model
         viewSuccess

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -43,6 +43,7 @@ import Json.Decode
 import Json.Decode.Pipeline
 import Json.Encode
 import Regex
+import Route
 import Search
 
 
@@ -139,7 +140,7 @@ update navKey msg model =
             let
                 ( newModel, newCmd ) =
                     Search.update
-                        "packages"
+                        Route.Packages
                         navKey
                         subMsg
                         model
@@ -153,8 +154,7 @@ update navKey msg model =
 
 view : Model -> Html Msg
 view model =
-    Search.view
-        "packages"
+    Search.view { toRoute = Route.Packages, categoryName = "packages" }
         "Search NixOS packages"
         model
         viewSuccess

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,6 +1,5 @@
 module Route exposing (Route(..), fromUrl, href, replaceUrl, routeToString)
 
-import Basics.Extra exposing (uncurry)
 import Browser.Navigation
 import Html
 import Html.Attributes
@@ -83,7 +82,7 @@ fromUrl url =
 
 routeToString : Route -> String
 routeToString =
-    uncurry Builder.absolute << routeToPieces
+    (\( path, query ) -> Builder.absolute path query) << routeToPieces
 
 
 {-| Fixes issue with elm/url not properly escaping string

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -4,9 +4,9 @@ import Browser.Navigation
 import Html
 import Html.Attributes
 import Url
-import Url.Builder as Builder exposing (QueryParameter)
+import Url.Builder exposing (QueryParameter)
 import Url.Parser exposing ((<?>))
-import Url.Parser.Query as Query
+import Url.Parser.Query
 
 
 
@@ -22,9 +22,9 @@ type Route
 
 {-| Fixes issue with elm/url not properly escaping string
 -}
-queryString : String -> Query.Parser (Maybe String)
+queryString : String -> Url.Parser.Query.Parser (Maybe String)
 queryString =
-    Query.map (Maybe.andThen Url.percentDecode) << Query.string
+    Url.Parser.Query.map (Maybe.andThen Url.percentDecode) << Url.Parser.Query.string
 
 
 parser : Url.Parser.Parser (Route -> msg) msg
@@ -37,8 +37,8 @@ parser =
                 <?> queryString "channel"
                 <?> queryString "query"
                 <?> queryString "show"
-                <?> Query.int "from"
-                <?> Query.int "size"
+                <?> Url.Parser.Query.int "from"
+                <?> Url.Parser.Query.int "size"
                 <?> queryString "sort"
             )
         , Url.Parser.map Options
@@ -46,8 +46,8 @@ parser =
                 <?> queryString "channel"
                 <?> queryString "query"
                 <?> queryString "show"
-                <?> Query.int "from"
-                <?> Query.int "size"
+                <?> Url.Parser.Query.int "from"
+                <?> Url.Parser.Query.int "size"
                 <?> queryString "sort"
             )
         ]
@@ -82,14 +82,14 @@ fromUrl url =
 
 routeToString : Route -> String
 routeToString =
-    (\( path, query ) -> Builder.absolute path query) << routeToPieces
+    (\( path, query ) -> Url.Builder.absolute path query) << routeToPieces
 
 
 {-| Fixes issue with elm/url not properly escaping string
 -}
 builderString : String -> String -> QueryParameter
 builderString name =
-    Builder.string name << Url.percentEncode
+    Url.Builder.string name << Url.percentEncode
 
 
 routeToPieces : Route -> ( List String, List QueryParameter )
@@ -105,10 +105,10 @@ routeToPieces page =
             Maybe.map (builderString "show")
 
         fromQ =
-            Maybe.map (Builder.int "from")
+            Maybe.map (Url.Builder.int "from")
 
         sizeQ =
-            Maybe.map (Builder.int "size")
+            Maybe.map (Url.Builder.int "size")
 
         sortQ =
             Maybe.map (builderString "sort")

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,11 +1,13 @@
 module Route exposing (Route(..), fromUrl, href, replaceUrl)
 
+import Basics.Extra exposing (uncurry)
 import Browser.Navigation
 import Html
 import Html.Attributes
 import Url
+import Url.Builder as Builder exposing (QueryParameter)
 import Url.Parser exposing ((<?>))
-import Url.Parser.Query
+import Url.Parser.Query as Query
 
 
 
@@ -19,34 +21,35 @@ type Route
     | Options (Maybe String) (Maybe String) (Maybe String) (Maybe Int) (Maybe Int) (Maybe String)
 
 
+{-| Fixes issue with elm/url not properly escaping string
+-}
+queryString : String -> Query.Parser (Maybe String)
+queryString =
+    Query.map (Maybe.andThen Url.percentDecode) << Query.string
+
+
 parser : Url.Parser.Parser (Route -> msg) msg
 parser =
     Url.Parser.oneOf
-        [ Url.Parser.map
-            Home
-            Url.Parser.top
-        , Url.Parser.map
-            NotFound
-            (Url.Parser.s "not-found")
-        , Url.Parser.map
-            Packages
+        [ Url.Parser.map Home Url.Parser.top
+        , Url.Parser.map NotFound (Url.Parser.s "not-found")
+        , Url.Parser.map Packages
             (Url.Parser.s "packages"
-                <?> Url.Parser.Query.string "channel"
-                <?> Url.Parser.Query.string "query"
-                <?> Url.Parser.Query.string "show"
-                <?> Url.Parser.Query.int "from"
-                <?> Url.Parser.Query.int "size"
-                <?> Url.Parser.Query.string "sort"
+                <?> queryString "channel"
+                <?> queryString "query"
+                <?> queryString "show"
+                <?> Query.int "from"
+                <?> Query.int "size"
+                <?> queryString "sort"
             )
-        , Url.Parser.map
-            Options
+        , Url.Parser.map Options
             (Url.Parser.s "options"
-                <?> Url.Parser.Query.string "channel"
-                <?> Url.Parser.Query.string "query"
-                <?> Url.Parser.Query.string "show"
-                <?> Url.Parser.Query.int "from"
-                <?> Url.Parser.Query.int "size"
-                <?> Url.Parser.Query.string "sort"
+                <?> queryString "channel"
+                <?> queryString "query"
+                <?> queryString "show"
+                <?> Query.int "from"
+                <?> Query.int "size"
+                <?> queryString "sort"
             )
         ]
 
@@ -79,41 +82,64 @@ fromUrl url =
 
 
 routeToString : Route -> String
-routeToString page =
-    let
-        ( path, query ) =
-            routeToPieces page
-    in
-    "/" ++ String.join "/" path ++ "?" ++ String.join "&" (List.filterMap Basics.identity query)
+routeToString =
+    uncurry Builder.absolute << routeToPieces
 
 
-routeToPieces : Route -> ( List String, List (Maybe String) )
+{-| Fixes issue with elm/url not properly escaping string
+-}
+builderString : String -> String -> QueryParameter
+builderString name =
+    Builder.string name << Url.percentEncode
+
+
+routeToPieces : Route -> ( List String, List QueryParameter )
 routeToPieces page =
-    case page of
-        Home ->
-            ( [], [] )
+    let
+        channelQ =
+            Maybe.map (builderString "channel")
 
-        NotFound ->
-            ( [ "not-found" ], [] )
+        queryQ =
+            Maybe.map (builderString "query")
 
-        Packages channel query show from size sort ->
-            ( [ "packages" ]
-            , [ channel
-              , query
-              , show
-              , Maybe.map String.fromInt from
-              , Maybe.map String.fromInt size
-              , sort
-              ]
-            )
+        showQ =
+            Maybe.map (builderString "show")
 
-        Options channel query show from size sort ->
-            ( [ "options" ]
-            , [ channel
-              , query
-              , show
-              , Maybe.map String.fromInt from
-              , Maybe.map String.fromInt size
-              , sort
-              ]
-            )
+        fromQ =
+            Maybe.map (Builder.int "from")
+
+        sizeQ =
+            Maybe.map (Builder.int "size")
+
+        sortQ =
+            Maybe.map (builderString "sort")
+    in
+    Tuple.mapSecond (List.filterMap identity) <|
+        case page of
+            Home ->
+                ( [], [] )
+
+            NotFound ->
+                ( [ "not-found" ], [] )
+
+            Packages channel query show from size sort ->
+                ( [ "packages" ]
+                , [ channelQ channel
+                  , queryQ query
+                  , showQ show
+                  , fromQ from
+                  , sizeQ size
+                  , sortQ sort
+                  ]
+                )
+
+            Options channel query show from size sort ->
+                ( [ "options" ]
+                , [ channelQ channel
+                  , queryQ query
+                  , showQ show
+                  , fromQ from
+                  , sizeQ size
+                  , sortQ sort
+                  ]
+                )

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,4 +1,4 @@
-module Route exposing (Route(..), fromUrl, href, replaceUrl)
+module Route exposing (Route(..), fromUrl, href, replaceUrl, routeToString)
 
 import Basics.Extra exposing (uncurry)
 import Browser.Navigation

--- a/src/Route/SearchQuery.elm
+++ b/src/Route/SearchQuery.elm
@@ -1,0 +1,87 @@
+module Route.SearchQuery exposing
+    ( RawQuery
+    , SearchQuery
+    , absolute
+    , searchQueryToString
+    , searchString
+    , toRawQuery
+    , toSearchQuery
+    )
+
+import Dict exposing (Dict)
+import Url
+import Url.Builder
+
+
+
+-- RawQuery
+
+
+type RawQuery
+    = RawQuery (Dict String String)
+
+
+chunk : String -> String -> Maybe ( String, String )
+chunk sep str =
+    case String.split sep str of
+        [] ->
+            Nothing
+
+        [ key ] ->
+            Just ( key, "" )
+
+        key :: xs ->
+            Just ( key, String.join sep xs )
+
+
+toRawQuery : Url.Url -> Maybe RawQuery
+toRawQuery =
+    Maybe.map (RawQuery << Dict.fromList << List.filterMap (chunk "=") << String.split "&")
+        << .query
+
+
+
+-- SearchQuery
+
+
+{-| This is type safe wrapper for working with search queries in url
+-}
+type SearchQuery
+    = SearchQuery String
+
+
+searchString : String -> RawQuery -> Maybe SearchQuery
+searchString name (RawQuery dict) =
+    Maybe.map SearchQuery <| Dict.get name dict
+
+
+searchQueryToString : SearchQuery -> Maybe String
+searchQueryToString (SearchQuery str) =
+    Url.percentDecode <| String.replace "+" "%20" str
+
+
+toSearchQuery : String -> String -> ( String, SearchQuery )
+toSearchQuery name query =
+    ( name, SearchQuery <| String.replace "%20" "+" <| Url.percentEncode query )
+
+
+{-| Build absolute URL with support for search query strings
+-}
+absolute : List String -> List Url.Builder.QueryParameter -> List ( String, SearchQuery ) -> String
+absolute path query searchQuery =
+    let
+        searchStrings =
+            List.map (\( name, SearchQuery val ) -> name ++ "=" ++ val) searchQuery
+                |> String.join "&"
+    in
+    Url.Builder.absolute path query
+        |> (\str ->
+                str
+                    ++ (case query of
+                            [] ->
+                                "?" ++ searchStrings
+
+                            _ ->
+                                "&" ++ searchStrings
+                       )
+           )

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -39,7 +39,7 @@ import Html
         , text
         , ul
         )
-import Html.Attributes as Attrs
+import Html.Attributes
     exposing
         ( attribute
         , autofocus
@@ -523,10 +523,7 @@ view { toRoute, categoryName } title model viewSuccess outMsg =
                         []
                     , div [ class "loader" ] []
                     , div [ class "btn-group" ]
-                        [ button
-                            [ class "btn"
-                            , Attrs.type_ "submit"
-                            ]
+                        [ button [ class "btn", type_ "submit" ]
                             [ text "Search" ]
                         ]
                     ]

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -39,7 +39,7 @@ import Html
         , text
         , ul
         )
-import Html.Attributes
+import Html.Attributes as Attrs
     exposing
         ( attribute
         , autofocus
@@ -62,8 +62,10 @@ import Http
 import Json.Decode
 import Json.Encode
 import RemoteData
+import Route
 import Set
 import Task
+import Url
 import Url.Builder
 
 
@@ -320,6 +322,7 @@ type Channel
     | Release_20_03
     | Release_20_09
 
+
 type alias ChannelDetails =
     { id : String
     , title : String
@@ -521,13 +524,17 @@ view path title model viewSuccess outMsg =
                         , id "search-query-input"
                         , autofocus True
                         , placeholder <| "Search for " ++ path
-                        , onInput (\x -> outMsg (QueryInput x))
+                        , onInput (outMsg << QueryInput)
                         , value <| Maybe.withDefault "" model.query
                         ]
                         []
                     , div [ class "loader" ] []
                     , div [ class "btn-group" ]
-                        [ button [ class "btn" ] [ text "Search" ]
+                        [ button
+                            [ class "btn"
+                            , Attrs.type_ "submit"
+                            ]
+                            [ text "Search" ]
                         ]
                     ]
                 ]


### PR DESCRIPTION
resolves #200

Interpret `+` in seaerch query string as space.

**There is a limitation imposed by elm URL parser** we can't access get the raw urls string even when using `Url.Parser.Query.custom` -- the string argument is already decoded. this means we can't tell if the `+` comes from url or was decoded from percent string (`%2B`). All `+` are replaced with space.

### Showcase

![updated-search](https://user-images.githubusercontent.com/2130305/97358018-eae77680-189a-11eb-8374-e62a2898c3ed.gif)


previous PR: https://github.com/NixOS/nixos-search/pull/214
