### PR TITLE
Remove cleanUrl and fragment hack

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -188,7 +188,7 @@ changeRouteTo currentModel url =
         Just route ->
             let
                 model =
-                    { currentModel | route = Debug.log "route" route }
+                    { currentModel | route = route }
             in
             case route of
                 Route.NotFound ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -162,15 +162,15 @@ changeRouteTo currentModel url =
     let
         attempteQuery (( newModel, cmd ) as pair) =
             case ( currentModel.route, newModel.route ) of
-                ( Route.Packages c1 q1 _ f1 s1 srt1, Route.Packages c2 q2 _ f2 s2 srt2 ) ->
-                    if c1 /= c2 || q1 /= q2 || f1 /= f2 || srt1 /= srt2 then
+                ( Route.Packages channel1 query1 _ from1 size1 sort1, Route.Packages channel2 query2 _ from2 size2 sort2 ) ->
+                    if channel1 /= channel2 || query1 /= query2 || from1 /= from2 || size1 /= size2 || sort1 /= sort2 then
                         submitQuery newModel ( newModel, cmd )
 
                     else
                         pair
 
-                ( Route.Options c1 q1 _ f1 s1 srt1, Route.Options c2 q2 _ f2 s2 srt2 ) ->
-                    if c1 /= c2 || q1 /= q2 || f1 /= f2 || srt1 /= srt2 then
+                ( Route.Options channel1 query1 _ from1 size1 sort1, Route.Options channel2 query2 _ from2 size2 sort2 ) ->
+                    if channel1 /= channel2 || query1 /= query2 || from1 /= from2 || size1 /= size2 || sort1 /= sort2 then
                         submitQuery newModel ( newModel, cmd )
 
                     else

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -160,29 +160,19 @@ changeRouteTo :
     -> ( Model, Cmd Msg )
 changeRouteTo model url =
     let
-        cleanUrl =
-            if url.fragment == Just "disabled" then
-                { url | fragment = Nothing }
-
-            else
-                url
-
-        newModel =
-            { model | url = cleanUrl }
-
         maybeRoute =
             Route.fromUrl url
     in
     case maybeRoute of
         Nothing ->
-            ( { newModel
+            ( { model
                 | page = NotFound
               }
             , Cmd.none
             )
 
         Just Route.NotFound ->
-            ( { newModel
+            ( { model
                 | page = NotFound
               }
             , Cmd.none
@@ -191,12 +181,12 @@ changeRouteTo model url =
         Just Route.Home ->
             -- Always redirect to /packages until we have something to show
             -- on the home page
-            ( newModel, Browser.Navigation.pushUrl newModel.navKey "/packages" )
+            ( model, Browser.Navigation.pushUrl model.navKey "/packages" )
 
         Just (Route.Packages channel query show from size sort) ->
             let
                 modelPage =
-                    case newModel.page of
+                    case model.page of
                         Packages x ->
                             Just x
 
@@ -204,19 +194,19 @@ changeRouteTo model url =
                             Nothing
             in
             Page.Packages.init channel query show from size sort modelPage
-                |> updateWith Packages PackagesMsg newModel
+                |> updateWith Packages PackagesMsg model
                 |> (\x ->
                         if url.fragment == Just "disabled" then
                             ( Tuple.first x, Cmd.none )
 
                         else
-                            submitQuery newModel x
+                            submitQuery model x
                    )
 
         Just (Route.Options channel query show from size sort) ->
             let
                 modelPage =
-                    case newModel.page of
+                    case model.page of
                         Options x ->
                             Just x
 
@@ -224,13 +214,13 @@ changeRouteTo model url =
                             Nothing
             in
             Page.Options.init channel query show from size sort modelPage
-                |> updateWith Options OptionsMsg newModel
+                |> updateWith Options OptionsMsg model
                 |> (\x ->
                         if url.fragment == Just "disabled" then
                             ( Tuple.first x, Cmd.none )
 
                         else
-                            submitQuery newModel x
+                            submitQuery model x
                    )
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -49,7 +49,7 @@ type alias Flags =
 
 type alias Model =
     { navKey : Browser.Navigation.Key
-    , url : Url.Url
+    , route : Route.Route
     , elasticsearch : Search.Options
     , page : Page
     }
@@ -71,7 +71,6 @@ init flags url navKey =
     let
         model =
             { navKey = navKey
-            , url = url
             , elasticsearch =
                 Search.Options
                     flags.elasticsearchMappingSchemaVersion
@@ -79,6 +78,7 @@ init flags url navKey =
                     flags.elasticsearchUsername
                     flags.elasticsearchPassword
             , page = NotFound
+            , route = Route.Home
             }
     in
     changeRouteTo model url
@@ -158,70 +158,57 @@ changeRouteTo :
     Model
     -> Url.Url
     -> ( Model, Cmd Msg )
-changeRouteTo model url =
-    let
-        maybeRoute =
-            Route.fromUrl url
-    in
-    case maybeRoute of
+changeRouteTo currentModel url =
+    case Route.fromUrl url of
         Nothing ->
-            ( { model
-                | page = NotFound
-              }
+            ( { currentModel | page = NotFound }
             , Cmd.none
             )
 
-        Just Route.NotFound ->
-            ( { model
-                | page = NotFound
-              }
-            , Cmd.none
-            )
+        Just route ->
+            if currentModel.route == route then
+                -- Route did not changed - there is nothing to be initialized
+                ( currentModel, Cmd.none )
 
-        Just Route.Home ->
-            -- Always redirect to /packages until we have something to show
-            -- on the home page
-            ( model, Browser.Navigation.pushUrl model.navKey "/packages" )
+            else
+                let
+                    model =
+                        { currentModel | route = route }
+                in
+                case route of
+                    Route.NotFound ->
+                        ( { model | page = NotFound }, Cmd.none )
 
-        Just (Route.Packages channel query show from size sort) ->
-            let
-                modelPage =
-                    case model.page of
-                        Packages x ->
-                            Just x
+                    Route.Home ->
+                        -- Always redirect to /packages until we have something to show
+                        -- on the home page
+                        ( model, Browser.Navigation.pushUrl model.navKey "/packages" )
 
-                        _ ->
-                            Nothing
-            in
-            Page.Packages.init channel query show from size sort modelPage
-                |> updateWith Packages PackagesMsg model
-                |> (\x ->
-                        if url.fragment == Just "disabled" then
-                            ( Tuple.first x, Cmd.none )
+                    Route.Packages channel query show from size sort ->
+                        let
+                            modelPage =
+                                case model.page of
+                                    Packages x ->
+                                        Just x
 
-                        else
-                            submitQuery model x
-                   )
+                                    _ ->
+                                        Nothing
+                        in
+                        Page.Packages.init channel query show from size sort modelPage
+                            |> updateWith Packages PackagesMsg model
 
-        Just (Route.Options channel query show from size sort) ->
-            let
-                modelPage =
-                    case model.page of
-                        Options x ->
-                            Just x
+                    Route.Options channel query show from size sort ->
+                        let
+                            modelPage =
+                                case model.page of
+                                    Options x ->
+                                        Just x
 
-                        _ ->
-                            Nothing
-            in
-            Page.Options.init channel query show from size sort modelPage
-                |> updateWith Options OptionsMsg model
-                |> (\x ->
-                        if url.fragment == Just "disabled" then
-                            ( Tuple.first x, Cmd.none )
-
-                        else
-                            submitQuery model x
-                   )
+                                    _ ->
+                                        Nothing
+                        in
+                        Page.Options.init channel query show from size sort modelPage
+                            |> updateWith Options OptionsMsg model
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -231,11 +218,7 @@ update msg model =
             case urlRequest of
                 Browser.Internal url ->
                     ( model
-                    , if url.fragment == Just "disabled" then
-                        Cmd.none
-
-                      else
-                        Browser.Navigation.pushUrl model.navKey <| Url.toString url
+                    , Browser.Navigation.pushUrl model.navKey <| Url.toString url
                     )
 
                 Browser.External href ->
@@ -308,7 +291,7 @@ view model =
                                 ]
                             , div [ class "nav-collapse collapse" ]
                                 [ ul [ class "nav pull-left" ]
-                                    (viewNavigation model.page model.url)
+                                    (viewNavigation model.route)
                                 ]
                             ]
                         ]
@@ -339,52 +322,37 @@ view model =
     }
 
 
-viewNavigation : Page -> Url.Url -> List (Html Msg)
-viewNavigation page url =
+viewNavigation : Route.Route -> List (Html Msg)
+viewNavigation route =
     let
-        preserveSearchOptions =
-            case page of
-                Packages model ->
-                    model.query
-                        |> Maybe.map (\q -> [ Url.Builder.string "query" q ])
-                        |> Maybe.withDefault []
-                        |> List.append [ Url.Builder.string "channel" model.channel ]
+        toRoute f =
+            case route of
+                -- Preserve arguments
+                Route.Packages channel query show from size sort ->
+                    f channel query show from size sort
 
-                Options model ->
-                    model.query
-                        |> Maybe.map (\q -> [ Url.Builder.string "query" q ])
-                        |> Maybe.withDefault []
-                        |> List.append [ Url.Builder.string "channel" model.channel ]
+                Route.Options channel query show from size sort ->
+                    f channel query show from size sort
 
                 _ ->
-                    []
-
-        createUrl path =
-            []
-                |> List.append preserveSearchOptions
-                |> Url.Builder.absolute [ path ]
+                    f Nothing Nothing Nothing Nothing Nothing Nothing
     in
-    List.map
-        (viewNavigationItem url)
-        [ ( "https://nixos.org", "Back to nixos.org" )
-        , ( createUrl "packages", "Packages" )
-        , ( createUrl "options", "Options" )
-        ]
+    li [] [ a [ href "https://nixos.org" ] [ text "Back to nixos.org" ] ]
+        :: List.map
+            (viewNavigationItem route)
+            [ ( toRoute Route.Packages, "Packages" )
+            , ( toRoute Route.Options, "Options" )
+            ]
 
 
 viewNavigationItem :
-    Url.Url
-    -> ( String, String )
+    Route.Route
+    -> ( Route.Route, String )
     -> Html Msg
-viewNavigationItem url ( path, title ) =
+viewNavigationItem currentRoute ( route, title ) =
     li
-        [ classList
-            [ ( "active"
-              , String.startsWith url.path path
-              )
-            ]
-        ]
-        [ a [ href path ] [ text title ] ]
+        [ classList [ ( "active", currentRoute == route ) ] ]
+        [ a [ Route.href route ] [ text title ] ]
 
 
 viewPage : Model -> Html Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -176,8 +176,12 @@ changeRouteTo currentModel url =
                     else
                         pair
 
-                _ ->
-                    pair
+                ( a, b ) ->
+                    if a /= b then
+                        submitQuery newModel ( newModel, cmd )
+
+                    else
+                        pair
     in
     case Route.fromUrl url of
         Nothing ->

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -17,6 +17,7 @@ import Url.Parser.Query
 type Route
     = NotFound
     | Home
+      -- route | channel | (search) query | show | from | size | sort
     | Packages (Maybe String) (Maybe String) (Maybe String) (Maybe Int) (Maybe Int) (Maybe String)
     | Options (Maybe String) (Maybe String) (Maybe String) (Maybe Int) (Maybe Int) (Maybe String)
 

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -634,11 +634,11 @@ viewPager _ model result toRoute =
                 ]
             ]
             [ a
-                [ if model.from == 0 then
-                    href ""
+                [ href <|
+                    if model.from == 0 then
+                        ""
 
-                  else
-                    href <|
+                    else
                         createUrl
                             toRoute
                             model.channel

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -282,7 +282,6 @@ update toRoute navKey msg model =
                 model.from
                 model.size
                 model.sort
-                |> (\x -> x ++ "#disabled")
                 |> Browser.Navigation.pushUrl navKey
             )
 
@@ -636,7 +635,7 @@ viewPager _ model result toRoute =
             ]
             [ a
                 [ if model.from == 0 then
-                    href "#disabled"
+                    href ""
 
                   else
                     href <|
@@ -659,7 +658,7 @@ viewPager _ model result toRoute =
             [ a
                 [ href <|
                     if model.from - model.size < 0 then
-                        "#disabled"
+                        ""
 
                     else
                         createUrl
@@ -681,7 +680,7 @@ viewPager _ model result toRoute =
             [ a
                 [ href <|
                     if model.from + model.size >= result.hits.total.value then
-                        "#disabled"
+                        ""
 
                     else
                         createUrl
@@ -703,7 +702,7 @@ viewPager _ model result toRoute =
             [ a
                 [ href <|
                     if model.from + model.size >= result.hits.total.value then
-                        "#disabled"
+                        ""
 
                     else
                         let


### PR DESCRIPTION
I just removed the `cleanUrl` function and updated all the places I found where `#disabled` fragment was used. I think this is enough to remove the hack. I tested the behavior there are no refreshes going on.