### PR TITLE
Closes #220 Latest stable is now the default channel

### DIFF
--- a/src/Search.elm
+++ b/src/Search.elm
@@ -121,7 +121,7 @@ init args model =
         defaultChannel =
             model
                 |> Maybe.map (\x -> x.channel)
-                |> Maybe.withDefault "unstable"
+                |> Maybe.withDefault latest_stable
 
         defaultFrom =
             model
@@ -287,6 +287,11 @@ channelDetails channel =
         Release_20_09 ->
             ChannelDetails "20.09" "20.09" "nixos/release-20.09" "nixos-20.09"
 
+-- Concentrates logic near releases definition.
+-- Otherwise you would have remember to modify @:124 defaultChannel each time.
+-- Bump when new channel is released.
+latest_stable : String
+latest_stable = "20.09"
 
 channelFromId : String -> Maybe Channel
 channelFromId channel_id =

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -118,30 +118,30 @@ type Sort
 init : Route.SearchArgs -> Maybe (Model a) -> ( Model a, Cmd (Msg a) )
 init args model =
     let
-        defaultChannel =
+        channel =
             model
                 |> Maybe.map (\x -> x.channel)
-                |> Maybe.withDefault latest_stable
+                |> Maybe.withDefault defaultChannel
 
-        defaultFrom =
+        from =
             model
                 |> Maybe.map (\x -> x.from)
                 |> Maybe.withDefault 0
 
-        defaultSize =
+        size =
             model
                 |> Maybe.map (\x -> x.size)
                 |> Maybe.withDefault 30
     in
-    ( { channel = Maybe.withDefault defaultChannel args.channel
+    ( { channel = Maybe.withDefault channel args.channel
       , query = Maybe.andThen Route.SearchQuery.searchQueryToString args.query
       , result =
             model
                 |> Maybe.map (\x -> x.result)
                 |> Maybe.withDefault RemoteData.NotAsked
       , show = args.show
-      , from = Maybe.withDefault defaultFrom args.from
-      , size = Maybe.withDefault defaultSize args.size
+      , from = Maybe.withDefault from args.from
+      , size = Maybe.withDefault size args.size
       , sort =
             args.sort
                 |> Maybe.withDefault ""
@@ -272,6 +272,11 @@ type alias ChannelDetails =
     }
 
 
+defaultChannel : String
+defaultChannel =
+    "20.09"
+
+
 channelDetails : Channel -> ChannelDetails
 channelDetails channel =
     case channel of
@@ -287,11 +292,6 @@ channelDetails channel =
         Release_20_09 ->
             ChannelDetails "20.09" "20.09" "nixos/release-20.09" "nixos-20.09"
 
--- Concentrates logic near releases definition.
--- Otherwise you would have remember to modify @:124 defaultChannel each time.
--- Bump when new channel is released.
-latest_stable : String
-latest_stable = "20.09"
 
 channelFromId : String -> Maybe Channel
 channelFromId channel_id =


### PR DESCRIPTION
* Declared a variable `latest_stable` pointing to the latest stable channel near channels definition. (Line 293)
* Used the variable on line 124 for `defaultChannel` when unspecified.

This is imho better than only changing the line `Maybe.withDefault "unstable"` to `Maybe.withDefault "20.09"`, because if done this way we would have to change version numbers at two places (Line 124 and the definitions around Line 280)