### PR TITLE
Remove unnecessary jquery-ui reference

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,12 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>NixOS Search - Loading...</title>
 
-
-  <script type="text/javascript" src="https://nixos.org/js/jquery.min.js"></script>
-
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <script type="text/javascript" src="https://nixos.org/bootstrap/js/bootstrap.min.js"></script>
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap.min.css" />
 
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap-responsive.min.css" />

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@
 
 
   <script type="text/javascript" src="https://nixos.org/js/jquery.min.js"></script>
-  <script type="text/javascript" src="https://nixos.org/js/jquery-ui.min.js"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,6 @@
 
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap-responsive.min.css" />
 
-  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" />
-
   <link rel="shortcut icon" type="image/png" href="https://nixos.org/favicon.png" />
 
   <link rel="search" type="application/opensearchdescription+xml" title="NixOS packages"


### PR DESCRIPTION
This file seems to be missing since 2020-09-22:
https://web.archive.org/web/20200922051906/https://nixos.org/js/jquery-ui.min.js

As there are no bug reports since then, I think it may be save to remove the reference?