### PR TITLE
Refactor the loading and request management

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -122,15 +122,17 @@ attemptQuery (( model, _ ) as pair) =
                 (\cmd ->
                     Cmd.batch
                         [ cmd
-                        , Cmd.map msg <| makeRequest
-                            model.elasticsearch
-                            searchModel.channel
-                            (Maybe.withDefault "" searchModel.query)
-                            searchModel.from
-                            searchModel.size
-                            searchModel.sort
+                        , Cmd.map msg <|
+                            makeRequest
+                                model.elasticsearch
+                                searchModel.channel
+                                (Maybe.withDefault "" searchModel.query)
+                                searchModel.from
+                                searchModel.size
+                                searchModel.sort
                         ]
-                ) pair
+                )
+                pair
     in
     case model.page of
         Packages searchModel ->
@@ -217,7 +219,13 @@ update msg model =
 
                 Browser.External href ->
                     ( model
-                    , Browser.Navigation.load href
+                    , case href of
+                        -- ignore links with no `href` attribute
+                        "" ->
+                            Cmd.none
+
+                        _ ->
+                            Browser.Navigation.load href
                     )
 
         ( ChangedUrl url, _ ) ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -153,6 +153,25 @@ attemptQuery (( model, _ ) as pair) =
             pair
 
 
+pageMatch : Page -> Page -> Bool
+pageMatch m1 m2 =
+    case ( m1, m2 ) of
+        ( NotFound, NotFound ) ->
+            True
+
+        ( Home _, Home _ ) ->
+            True
+
+        ( Packages _, Packages _ ) ->
+            True
+
+        ( Options _, Options _ ) ->
+            True
+
+        _ ->
+            False
+
+
 changeRouteTo :
     Model
     -> Url.Url
@@ -168,6 +187,13 @@ changeRouteTo currentModel url =
             let
                 model =
                     { currentModel | route = route }
+
+                avoidReinit ( newModel, cmd ) =
+                    if pageMatch currentModel.page newModel.page then
+                        ( model, Cmd.none )
+
+                    else
+                        ( newModel, cmd )
             in
             case route of
                 Route.NotFound ->
@@ -190,6 +216,7 @@ changeRouteTo currentModel url =
                     in
                     Page.Packages.init searchArgs modelPage
                         |> updateWith Packages PackagesMsg model
+                        |> avoidReinit
                         |> attemptQuery
 
                 Route.Options searchArgs ->
@@ -204,6 +231,7 @@ changeRouteTo currentModel url =
                     in
                     Page.Options.init searchArgs modelPage
                         |> updateWith Options OptionsMsg model
+                        |> avoidReinit
                         |> attemptQuery
 
 

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -12,6 +12,7 @@ module Search exposing
     , init
     , makeRequest
     , makeRequestBody
+    , shouldLoad
     , update
     , view
     )
@@ -152,6 +153,20 @@ init args model =
     )
 
 
+shouldLoad : Model a -> Bool
+shouldLoad model =
+    model.result == RemoteData.Loading
+
+
+ensureLoading : Model a -> Model a
+ensureLoading model =
+    if model.query /= Nothing && model.query /= Just "" && List.member model.channel channels then
+        { model | result = RemoteData.Loading }
+
+    else
+        model
+
+
 
 -- ---------------------------
 -- UPDATE
@@ -191,14 +206,9 @@ update toRoute navKey msg model =
         ChannelChange channel ->
             { model
                 | channel = channel
-                , result =
-                    if model.query == Nothing || model.query == Just "" then
-                        RemoteData.NotAsked
-
-                    else
-                        RemoteData.Loading
                 , from = 0
             }
+                |> ensureLoading
                 |> pushUrl toRoute navKey
 
         QueryInput query ->
@@ -207,10 +217,8 @@ update toRoute navKey msg model =
             )
 
         QueryInputSubmit ->
-            { model
-                | result = RemoteData.Loading
-                , from = 0
-            }
+            { model | from = 0 }
+                |> ensureLoading
                 |> pushUrl toRoute navKey
 
         QueryResponse result ->

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -563,9 +563,9 @@ view { toRoute, categoryName } title model viewSuccess outMsg =
                                     ]
                                 ]
                             ]
-                        , viewPager outMsg model result toRoute
+                        , viewPager outMsg model result.hits.total.value toRoute
                         , viewSuccess model.channel model.show result
-                        , viewPager outMsg model result toRoute
+                        , viewPager outMsg model result.hits.total.value toRoute
                         ]
 
             RemoteData.Failure error ->
@@ -597,10 +597,10 @@ view { toRoute, categoryName } title model viewSuccess outMsg =
 viewPager :
     (Msg a -> b)
     -> Model a
-    -> SearchResult a
+    -> Int
     -> Route.SearchRoute
     -> Html b
-viewPager msg model result toRoute =
+viewPager msg model total toRoute =
     Html.map msg <|
         ul [ class "pager" ]
             [ li [ classList [ ( "disabled", model.from == 0 ) ] ]
@@ -625,10 +625,10 @@ viewPager msg model result toRoute =
                     ]
                     [ text "Previous" ]
                 ]
-            , li [ classList [ ( "disabled", model.from + model.size >= result.hits.total.value ) ] ]
+            , li [ classList [ ( "disabled", model.from + model.size >= total ) ] ]
                 [ a
                     [ Html.Events.onClick <|
-                        if model.from + model.size >= result.hits.total.value then
+                        if model.from + model.size >= total then
                             NoOp
 
                         else
@@ -636,22 +636,22 @@ viewPager msg model result toRoute =
                     ]
                     [ text "Next" ]
                 ]
-            , li [ classList [ ( "disabled", model.from + model.size >= result.hits.total.value ) ] ]
+            , li [ classList [ ( "disabled", model.from + model.size >= total ) ] ]
                 [ a
                     [ Html.Events.onClick <|
-                        if model.from + model.size >= result.hits.total.value then
+                        if model.from + model.size >= total then
                             NoOp
 
                         else
                             let
                                 remainder =
-                                    if remainderBy model.size result.hits.total.value == 0 then
+                                    if remainderBy model.size total == 0 then
                                         1
 
                                     else
                                         0
                             in
-                            ChangePage <| ((result.hits.total.value // model.size) - remainder) * model.size
+                            ChangePage <| ((total // model.size) - remainder) * model.size
                     ]
                     [ text "Last" ]
                 ]

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -203,6 +203,7 @@ update toRoute navKey msg model =
                 | sort = fromSortId sortId |> Maybe.withDefault Relevance
                 , from = 0
             }
+                |> ensureLoading
                 |> pushUrl toRoute navKey
 
         ChannelChange channel ->

--- a/src/index.less
+++ b/src/index.less
@@ -116,7 +116,6 @@ header .navbar.navbar-static-top {
 }
 .loader {
   color: #000000;
-  height: 50px;
   text-indent: -9999em;
   margin: 88px auto;
   position: relative;

--- a/src/index.less
+++ b/src/index.less
@@ -1,6 +1,7 @@
 body {
   position: relative;
   min-height: 100vh;
+  overflow-y: scroll;
 }
 
 #content {
@@ -89,6 +90,21 @@ header .navbar.navbar-static-top {
   }
 }
 
+.sort-form,
+.sort-form > .sort-group {
+  margin-bottom: 0;
+}
+.pager {
+  & > li > a {
+    cursor: pointer;
+    margin: 0 2px;
+  }
+}
+
+.loader-wrapper {
+  height: 200px;
+  overflow: hidden;
+}
 .loader,
 .loader:before,
 .loader:after {
@@ -100,6 +116,7 @@ header .navbar.navbar-static-top {
 }
 .loader {
   color: #000000;
+  height: 50px;
   text-indent: -9999em;
   margin: 88px auto;
   position: relative;


### PR DESCRIPTION
resolves #224

TODO:

- [x] Unify the source of truth between loading and request sending
- [x] Update pagination for compatibility with new approach
- [x] Update sorting for compatibility with new approach

This changes the way we handle Loading:

- `result : RemoteData` is now source of truth for if we should or should not trigger the search
- `resut = Loading` is set only when right conditions are met (eg term is not empty)
- `Main.elm` queries data only when result state is `Loading`
- Unlike before, we now need to set `Loading` also for pagination. Because of this I made a small layout changes so that pagination is visible even in loading state for better UI.

This PR could be improved further - for instance we can avoid having `prev` button enabled during loading etc. However I didin't want to introduce way too many changes in single PR.