### PR TITLE
Fix redirect from / to /packages breaking browser back button

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -202,7 +202,7 @@ changeRouteTo currentModel url =
                 Route.Home ->
                     -- Always redirect to /packages until we have something to show
                     -- on the home page
-                    ( model, Browser.Navigation.pushUrl model.navKey "/packages" )
+                    ( model, Browser.Navigation.replaceUrl model.navKey "/packages" )
 
                 Route.Packages searchArgs ->
                     let


### PR DESCRIPTION
Previously, navigating to https://search.nixos.org/ would use history.pushState
to redirect to /packages and add a new entry to the browser history.
This meant that if you pressed the back button, you would navigate back to /
which would of course then redirect to /packages again.

Now history.replaceState is used instead of pushState, so the / history entry
is replaced entirely by a /packages history entry and the back button works.