### PR TITLE
Improve nix.py

### DIFF
--- a/import-scripts/import_scripts/nix.py
+++ b/import-scripts/import_scripts/nix.py
@@ -4,6 +4,9 @@ def prettyPrintAttrName(attr_name):
     return attr_name
 
 
+stringEscapes = str.maketrans({"\\": "\\\\", '"': '\\"'})
+
+
 def prettyPrint(item, level=""):
     next_level = level + "  "
     if item is None:
@@ -19,15 +22,21 @@ def prettyPrint(item, level=""):
 
     elif type(item) == str:
         if "\n" in item:
-            return f"''{item}''"
-        return f'"{item}"'
+            return (
+                "''\n"
+                + "".join(
+                    [f"{next_level}{line}" for line in item.splitlines(keepends=True)]
+                )
+                + f"{level}''"
+            )
+        return f'"{item.translate(stringEscapes)}"'
 
     elif type(item) == list:
         if len(item) == 0:
             return "[ ]"
         return (
             "[\n"
-            + ("".join([f"{level}  {prettyPrint(i, next_level)}\n" for i in item]))
+            + ("".join([f"{next_level}{prettyPrint(i, next_level)}\n" for i in item]))
             + f"{level}]"
         )
 
@@ -38,13 +47,13 @@ def prettyPrint(item, level=""):
             if type(item["text"]) == str:
                 return item["text"]
             else:
-                return prettyPrint(item["text"], next_level)
+                return prettyPrint(item["text"], level)
         return (
             "{\n"
             + (
                 "".join(
                     [
-                        f"{level}  {prettyPrintAttrName(n)} = {prettyPrint(v, next_level)};\n"
+                        f"{next_level}{prettyPrintAttrName(n)} = {prettyPrint(v, next_level)};\n"
                         for n, v in item.items()
                     ]
                 )

--- a/import-scripts/import_scripts/nix.py
+++ b/import-scripts/import_scripts/nix.py
@@ -9,6 +9,7 @@ stringEscapes = str.maketrans({"\\": "\\\\", '"': '\\"'})
 
 def prettyPrint(item, level=""):
     next_level = level + "  "
+
     if item is None:
         return "null"
 
@@ -21,13 +22,19 @@ def prettyPrint(item, level=""):
         return f"{item}"
 
     elif type(item) == str:
+        item = item.strip()
         if "\n" in item:
-            return (
-                "''\n"
-                + "".join(
-                    [f"{next_level}{line}" for line in item.splitlines(keepends=True)]
-                )
-                + (f"{level}''" if item[-1] == "\n" else "''")
+            return "".join(
+                [
+                    "''",
+                    "".join(
+                        [
+                            f"{next_level}{line}"
+                            for line in item.splitlines(keepends=True)
+                        ]
+                    )[len(next_level) :],
+                    f"\n{level}''",
+                ]
             )
         return f'"{item.translate(stringEscapes)}"'
 

--- a/import-scripts/import_scripts/nix.py
+++ b/import-scripts/import_scripts/nix.py
@@ -27,7 +27,7 @@ def prettyPrint(item, level=""):
                 + "".join(
                     [f"{next_level}{line}" for line in item.splitlines(keepends=True)]
                 )
-                + f"{level}''"
+                + (f"{level}''" if item[-1] == "\n" else "''")
             )
         return f'"{item.translate(stringEscapes)}"'
 

--- a/import-scripts/import_scripts/nix.py
+++ b/import-scripts/import_scripts/nix.py
@@ -26,13 +26,13 @@ def prettyPrint(item, level=""):
         if "\n" in item:
             return "".join(
                 [
-                    "''",
+                    "''\n",
                     "".join(
                         [
                             f"{next_level}{line}"
                             for line in item.splitlines(keepends=True)
                         ]
-                    )[len(next_level) :],
+                    ),
                     f"\n{level}''",
                 ]
             )

--- a/import-scripts/tests/test_nix.py
+++ b/import-scripts/tests/test_nix.py
@@ -7,9 +7,26 @@ import pytest  # type: ignore
         (None, "null",),
         (True, "true",),
         ("text", '"text"',),
+        (
+            "\nnew line is ignored at start and end\n",
+            '"new line is ignored at start and end"',
+        ),
+        ('"double quotes"', '"\\"double quotes\\""',),
+        ("multi\nline\ntext", "''multi\n  line\n  text\n''",),
+        ('"multi line\ndouble quotes"', "''\"multi line\n  double quotes\"\n''",),
         (123, "123",),
         (123.123, "123.123",),
-        ([False, "text"], ("[\n" "  false\n" '  "text"\n' "]"),),
+        (
+            [False, "text", "multi\nline\ntext"],
+            "".join(
+                [
+                    "[\n",
+                    "  false\n",
+                    '  "text"\n',
+                    "  ''multi\n" "    line\n" "    text\n" "  ''\n" "]",
+                ]
+            ),
+        ),
         (
             {"name1": "value1", "name.2": True, "name3": [False, "text"]},
             (

--- a/import-scripts/tests/test_nix.py
+++ b/import-scripts/tests/test_nix.py
@@ -12,8 +12,8 @@ import pytest  # type: ignore
             '"new line is ignored at start and end"',
         ),
         ('"double quotes"', '"\\"double quotes\\""',),
-        ("multi\nline\ntext", "''multi\n  line\n  text\n''",),
-        ('"multi line\ndouble quotes"', "''\"multi line\n  double quotes\"\n''",),
+        ("multi\nline\ntext", "''\n  multi\n  line\n  text\n''",),
+        ('"multi line\ndouble quotes"', "''\n  \"multi line\n  double quotes\"\n''",),
         (123, "123",),
         (123.123, "123.123",),
         (
@@ -23,7 +23,7 @@ import pytest  # type: ignore
                     "[\n",
                     "  false\n",
                     '  "text"\n',
-                    "  ''multi\n" "    line\n" "    text\n" "  ''\n" "]",
+                    "  ''\n    multi\n" "    line\n" "    text\n" "  ''\n" "]",
                 ]
             ),
         ),


### PR DESCRIPTION
Adds escaping of `\` and `"` inside double-quoted strings (see `system.name`), and fixes indentation for double-single-quoted strings and `literalExample`s (see `services.snapper.configs`).