### PR TITLE
Make search result elements keyboard focusable

### DIFF
--- a/src/Page/Options.elm
+++ b/src/Page/Options.elm
@@ -33,6 +33,7 @@ import Html.Attributes
         ( class
         , colspan
         , href
+        , style
         , target
         )
 import Html.Events
@@ -174,8 +175,11 @@ viewResultItem channel show item =
         -- DEBUG:         ]
         -- DEBUG:     ]
         |> List.append
-            (tr
-                [ onClick (SearchMsg (Search.ShowDetails item.source.name))
+            (a
+                [ style "display" "table-row"
+                , style "color" "unset"
+                , style "text-decoration" "none"
+                , onClick (SearchMsg (Search.ShowDetails item.source.name))
                 , Search.elementId item.source.name
                 ]
                 [ td [] [ text item.source.name ]

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -34,6 +34,7 @@ import Html.Attributes
         ( class
         , colspan
         , href
+        , style
         , target
         )
 import Html.Events
@@ -221,16 +222,18 @@ viewResultItem channel show item =
         -- DEBUG:         ]
         -- DEBUG:     ]
         |> List.append
-            (tr
-                [ onClick (SearchMsg (Search.ShowDetails item.source.attr_name))
+            (a
+                [ style "display" "table-row"
+                , style "color" "unset"
+                , style "text-decoration" "none"
+                , onClick (SearchMsg (Search.ShowDetails item.source.attr_name))
                 , Search.elementId item.source.attr_name
                 ]
                 [ td [] [ text <| item.source.attr_name ]
                 , td [] [ text item.source.pname ]
                 , td [] [ text item.source.pversion ]
                 , td [] [ text <| Maybe.withDefault "" item.source.description ]
-                ]
-                :: packageDetails
+                ] :: packageDetails
             )
 
 


### PR DESCRIPTION
Closes #258 
- Replaced `<tr/>` element with `<a/>`
- Styled `<a/>` like `<tr/>`

This may not be a comprehensive fix, but it works well with Vimium.
If there are any style conventions I should follow please let me know!