### PR TITLE
faceted search trap click

### DIFF
--- a/src/Page/Options.elm
+++ b/src/Page/Options.elm
@@ -136,7 +136,7 @@ viewSuccess :
     -> Html Msg
 viewSuccess channel showNixOSDetails show hits =
     ul []
-        (List.concatMap
+        (List.map
             (viewResultItem channel showNixOSDetails show)
             hits
         )
@@ -147,7 +147,7 @@ viewResultItem :
     -> Bool
     -> Maybe String
     -> Search.ResultItem ResultItemSource
-    -> List (Html Msg)
+    -> Html Msg
 viewResultItem channel _ show item =
     let
         showHtml value =
@@ -230,7 +230,7 @@ viewResultItem channel _ show item =
         open =
             SearchMsg (Search.ShowDetails item.source.name)
     in
-    [ li
+    li
         [ class "option"
         , onClick open
         , Search.elementId item.source.name
@@ -247,7 +247,6 @@ viewResultItem channel _ show item =
                     [ text item.source.name ]
                 ]
         )
-    ]
 
 
 

--- a/src/Page/Options.elm
+++ b/src/Page/Options.elm
@@ -167,7 +167,7 @@ viewResultItem channel _ show item =
             pre [] [ text value ]
 
         asPreCode value =
-            div [] [ pre [] [ code [] [ text value ] ] ]
+            div [] [ pre [] [ code [ class "code-block" ] [ text value ] ] ]
 
         githubUrlPrefix branch =
             "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
@@ -186,7 +186,7 @@ viewResultItem channel _ show item =
                         [ href <| githubUrlPrefix channelDetails.branch ++ (value |> String.replace ":" "#L")
                         , target "_blank"
                         ]
-                        [ text <| value ]
+                        [ text value ]
 
                 Nothing ->
                     text <| cleanPosition value
@@ -212,7 +212,7 @@ viewResultItem channel _ show item =
 
         showDetails =
             if Just item.source.name == show then
-                [ div []
+                [ div [ Html.Attributes.map SearchMsg Search.trapClick ]
                     [ div [] [ text "Default value" ]
                     , div [] [ withEmpty (wrapped asPreCode) item.source.default ]
                     , div [] [ text "Type" ]
@@ -235,8 +235,7 @@ viewResultItem channel _ show item =
         , onClick open
         , Search.elementId item.source.name
         ]
-        ([]
-            |> List.append showDetails
+        (showDetails
             |> List.append
                 (item.source.description
                     |> Maybe.map showHtml

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -32,10 +32,7 @@ import Html.Attributes
         , id
         , target
         )
-import Html.Events
-    exposing
-        ( onClick
-        )
+import Html.Events exposing (onClick)
 import Json.Decode
 import Json.Decode.Pipeline
 import Json.Encode
@@ -308,14 +305,6 @@ viewResultItem :
     -> List (Html Msg)
 viewResultItem channel showNixOSDetails show item =
     let
-        onClickStop message =
-            Html.Events.custom "click" <|
-                Json.Decode.succeed
-                    { message = message
-                    , stopPropagation = True
-                    , preventDefault = True
-                    }
-
         cleanPosition =
             Regex.fromString "^[0-9a-f]+\\.tar\\.gz\\/"
                 |> Maybe.withDefault Regex.never
@@ -331,7 +320,7 @@ viewResultItem channel showNixOSDetails show item =
             "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/" ++ uri
 
         createShortDetailsItem title url =
-            [ li []
+            [ li [ Html.Attributes.map SearchMsg Search.trapClick ]
                 [ a
                     [ href url
                     , target "_blank"
@@ -448,9 +437,8 @@ viewResultItem channel showNixOSDetails show item =
 
         longerPackageDetails =
             if Just item.source.attr_name == show then
-                [ div []
-                    ([]
-                        |> List.append maintainersAndPlatforms
+                [ div [ Html.Attributes.map SearchMsg Search.trapClick ]
+                    (maintainersAndPlatforms
                         |> List.append
                             (item.source.longDescription
                                 |> Maybe.map (\desc -> [ p [] [ text desc ] ])
@@ -472,7 +460,9 @@ viewResultItem channel showNixOSDetails show item =
                                         ]
                                         [ a
                                             [ href "#"
-                                            , onClickStop <| SearchMsg (Search.ShowNixOSDetails True)
+                                            , Search.onClickStop <|
+                                                SearchMsg <|
+                                                    Search.ShowNixOSDetails True
                                             ]
                                             [ text "On NixOS" ]
                                         ]
@@ -484,12 +474,15 @@ viewResultItem channel showNixOSDetails show item =
                                         ]
                                         [ a
                                             [ href "#"
-                                            , onClickStop <| SearchMsg (Search.ShowNixOSDetails False)
+                                            , Search.onClickStop <|
+                                                SearchMsg <|
+                                                    Search.ShowNixOSDetails False
                                             ]
                                             [ text "On non-NixOS" ]
                                         ]
                                     ]
-                                , div [ class "tab-content" ]
+                                , div
+                                    [ class "tab-content" ]
                                     [ div
                                         [ classList
                                             [ ( "tab-pane", True )

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -291,7 +291,7 @@ viewSuccess :
     -> Html Msg
 viewSuccess channel showNixOSDetails show hits =
     ul []
-        (List.concatMap
+        (List.map
             (viewResultItem channel showNixOSDetails show)
             hits
         )
@@ -302,7 +302,7 @@ viewResultItem :
     -> Bool
     -> Maybe String
     -> Search.ResultItem ResultItemSource
-    -> List (Html Msg)
+    -> Html Msg
 viewResultItem channel showNixOSDetails show item =
     let
         cleanPosition =
@@ -516,7 +516,7 @@ viewResultItem channel showNixOSDetails show item =
         open =
             SearchMsg (Search.ShowDetails item.source.attr_name)
     in
-    [ li
+    li
         [ class "package"
         , onClick open
         , Search.elementId item.source.attr_name
@@ -531,7 +531,6 @@ viewResultItem channel showNixOSDetails show item =
                 , shortPackageDetails
                 ]
         )
-    ]
 
 
 

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -331,22 +331,20 @@ viewResultItem channel showNixOSDetails show item =
 
         shortPackageDetails =
             ul []
-                ([]
-                    |> List.append
-                        (item.source.position
-                            |> Maybe.map
-                                (\position ->
-                                    case Search.channelDetailsFromId channel of
-                                        Nothing ->
-                                            []
+                ((item.source.position
+                    |> Maybe.map
+                        (\position ->
+                            case Search.channelDetailsFromId channel of
+                                Nothing ->
+                                    []
 
-                                        Just channelDetails ->
-                                            createShortDetailsItem
-                                                "source"
-                                                (createGithubUrl channelDetails.branch position)
-                                )
-                            |> Maybe.withDefault []
+                                Just channelDetails ->
+                                    createShortDetailsItem
+                                        "source"
+                                        (createGithubUrl channelDetails.branch position)
                         )
+                    |> Maybe.withDefault []
+                 )
                     |> List.append
                         (item.source.homepage
                             |> List.head

--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -483,12 +483,12 @@ viewResultItem channel showNixOSDetails show item =
                                     [ class "tab-content" ]
                                     [ div
                                         [ classList
-                                            [ ( "tab-pane", True )
-                                            , ( "active", not showNixOSDetails )
+                                            [ ( "active", not showNixOSDetails )
                                             ]
+                                        , class "tab-pane"
                                         , id "package-details-nixpkgs"
                                         ]
-                                        [ pre []
+                                        [ pre [ class "code-block" ]
                                             [ text "nix-env -iA nixpkgs."
                                             , strong [] [ text item.source.attr_name ]
                                             ]

--- a/src/Search.elm
+++ b/src/Search.elm
@@ -16,7 +16,9 @@ module Search exposing
     , init
     , makeRequest
     , makeRequestBody
+    , onClickStop
     , shouldLoad
+    , trapClick
     , update
     , view
     )
@@ -1164,3 +1166,23 @@ decodeAggregationBucketItem =
     Json.Decode.map2 AggregationsBucketItem
         (Json.Decode.field "doc_count" Json.Decode.int)
         (Json.Decode.field "key" Json.Decode.string)
+
+
+
+-- Html Event Helpers
+
+
+onClickStop : msg -> Html.Attribute msg
+onClickStop message =
+    Html.Events.custom "click" <|
+        Json.Decode.succeed
+            { message = message
+            , stopPropagation = True
+            , preventDefault = True
+            }
+
+
+trapClick : Html.Attribute (Msg a b)
+trapClick =
+    Html.Events.stopPropagationOn "click" <|
+        Json.Decode.succeed ( NoOp, True )

--- a/src/index.less
+++ b/src/index.less
@@ -27,6 +27,11 @@ body {
   }
 }
 
+.code-block {
+  display: block;
+  cursor: text;
+}
+
 #content {
   padding-bottom: 4rem;
 }
@@ -341,7 +346,7 @@ header .navbar.navbar-static-top {
 
                 div.tab-content {
                   padding: 1em;
-                  border: 1px solid #ddd; 
+                  border: 1px solid #ddd;
                   border-top: 0;
                 }
 
@@ -366,13 +371,20 @@ header .navbar.navbar-static-top {
           }
 
           &.option {
+            &:hover {
+              cursor: pointer;
+
+              .search-result-button {
+                  text-decoration: underline;
+              }
+            }
 
             // short details of a pacakge
             & > :nth-child(3) {
               margin-top: 1em;
               margin-left: 1em;
               display: grid;
-              grid-template-columns: 100px max-content;
+              grid-template-columns: 100px 1fr;
               column-gap: 1em;
               row-gap: 0.5em;
 

--- a/src/index.less
+++ b/src/index.less
@@ -12,6 +12,16 @@
   }
 }
 
+.search-result-item() {
+  &:hover {
+    cursor: pointer;
+
+    .search-result-button {
+      text-decoration: underline;
+    }
+  }
+}
+
 /* ------------------------------------------------------------------------- */
 /* -- Layout --------------------------------------------------------------- */
 /* ------------------------------------------------------------------------- */
@@ -303,6 +313,7 @@ header .navbar.navbar-static-top {
           }
 
           &.package {
+              .search-result-item();
 
             // short details of a pacakge
             & > :nth-child(3) {
@@ -371,13 +382,7 @@ header .navbar.navbar-static-top {
           }
 
           &.option {
-            &:hover {
-              cursor: pointer;
-
-              .search-result-button {
-                  text-decoration: underline;
-              }
-            }
+            .search-result-item();
 
             // short details of a pacakge
             & > :nth-child(3) {


### PR DESCRIPTION
This is the quickfix for:

- Click actions propagation
- tiny improvement to visibility of clickable area.

## Small improvement to display of Options details

![image](https://user-images.githubusercontent.com/2130305/104815781-f2257d00-5816-11eb-9e26-b76a57c4a7fb.png)


## Make additional thinks in detail clickable and selectable

![search-selectable](https://user-images.githubusercontent.com/2130305/104815835-66f8b700-5817-11eb-9881-4a7cdcbf939a.gif)

## Change Cursor and underline text on hover

![search-cursor](https://user-images.githubusercontent.com/2130305/104815958-39603d80-5818-11eb-929d-d0aa5d40a01e.gif)


Especially the hover actions will need some additional improvements but I think this might be good enough to unblock the feature.
