### PR TITLE
facet search update item hover interaction

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -12,14 +12,6 @@
   }
 }
 
-.search-result-item() {
-  &:hover {
-    .search-result-button {
-      text-decoration: underline;
-    }
-  }
-}
-
 /* ------------------------------------------------------------------------- */
 /* -- Layout --------------------------------------------------------------- */
 /* ------------------------------------------------------------------------- */
@@ -146,6 +138,13 @@ header .navbar.navbar-static-top {
      & > h2 {
        margin-top: 0;
      }
+  }
+
+
+  .search-result-button {
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   & > .search-results {
@@ -315,8 +314,6 @@ header .navbar.navbar-static-top {
           }
 
           &.package {
-            .search-result-item();
-
             // short details of a pacakge
             & > :nth-child(3) {
               color: #666;
@@ -410,8 +407,6 @@ header .navbar.navbar-static-top {
           }
 
           &.option {
-            .search-result-item();
-
             // short details of a pacakge
             & > :nth-child(3) {
               margin-top: 1em;

--- a/src/index.less
+++ b/src/index.less
@@ -343,8 +343,8 @@ header .navbar.navbar-static-top {
           }
 
           &.package {
-            .search-result-item()
-            
+            .search-result-item();
+
             // short details of a pacakge
             & > :nth-child(3) {
               color: #666;
@@ -414,8 +414,8 @@ header .navbar.navbar-static-top {
           }
 
           &.option {
-            .search-result-item()
-            
+            .search-result-item();
+
             // short details of a pacakge
             & > :nth-child(4) {
               margin: 2em 0 1em 1em;


### PR DESCRIPTION
This partially reverts the change I made in https://github.com/NixOS/nixos-search/pull/262 - the hover action on whole result item. Now the underline hover applies only on new clickable area (button itself).

![image](https://user-images.githubusercontent.com/2130305/104836939-9fe56a00-58b1-11eb-9d0d-20a7795401ff.png)

![update-hover](https://user-images.githubusercontent.com/2130305/104836959-c4d9dd00-58b1-11eb-85a9-a46f816111b7.gif)
