### PR TITLE
Fix mobile only interactions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,11 +6,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>NixOS Search - Loading...</title>
 
+
+  <script type="text/javascript" src="https://nixos.org/js/jquery.min.js"></script>
+  <script type="text/javascript" src="https://nixos.org/js/jquery-ui.min.js"></script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+  <script type="text/javascript" src="https://nixos.org/bootstrap/js/bootstrap.min.js"></script>
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap.min.css" />
 
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap-responsive.min.css" />
+
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" />
 
   <link rel="shortcut icon" type="image/png" href="https://nixos.org/favicon.png" />
 

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@
 
 
   <script type="text/javascript" src="https://nixos.org/js/jquery.min.js"></script>
-  <script type="text/javascript" src="https://nixos.org/js/jquery-ui.min.js"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
@@ -16,8 +15,6 @@
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap.min.css" />
 
   <link rel="stylesheet" href="https://nixos.org/bootstrap/css/bootstrap-responsive.min.css" />
-
-  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" />
 
   <link rel="shortcut icon" type="image/png" href="https://nixos.org/favicon.png" />
 


### PR DESCRIPTION
This reverts https://github.com/NixOS/nixos-search/commit/4d505f34022154a1f193f012c11eb08d07c90271 and removes only unused dependencies of bootstrap (jquery-ui and font awesome). Responsive parts of bootstrap depends on javascript which itself depends on jQuery. We need to be careful around these areas though because Elm doesn't like when something mutates the dom (causes exceptions in function that applies vdom to the dom). https://github.com/NixOS/nixos-search/issues/266

I think these changes should not conflict with https://github.com/NixOS/nixos-search/pull/261 and thus this patch can be merged while faceted-search is being worked on.