### PR TITLE
Remove the defunct "burger menu" and always expand the navigation

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -305,20 +305,10 @@ view model =
                 [ div [ class "navbar navbar-static-top" ]
                     [ div [ class "navbar-inner" ]
                         [ div [ class "container" ]
-                            [ button
-                                [ type_ "button"
-                                , class "btn btn-navbar"
-                                , attribute "data-toggle" "collapse"
-                                , attribute "data-target" ".nav-collapse"
-                                ]
-                                [ span [ class "icon-bar" ] []
-                                , span [ class "icon-bar" ] []
-                                , span [ class "icon-bar" ] []
-                                ]
-                            , a [ class "brand", href "https://nixos.org" ]
+                            [ a [ class "brand", href "https://nixos.org" ]
                                 [ img [ src "https://nixos.org/logo/nix-wiki.png", class "logo" ] []
                                 ]
-                            , div [ class "nav-collapse collapse" ]
+                            , div [ ]
                                 [ ul [ class "nav pull-left" ]
                                     (viewNavigation model.page model.url)
                                 ]


### PR DESCRIPTION
I commonly run into a situation where the burger menu button is being
showed to me but it broke some time ago and doesn't expand the menu
anymore.

Since the snipped was probably mostly 1:1 translated from the old
nixos.org page (where we had more links than just the three we have now)
we can probably just remove it now. It is a net win as the feature was
broken and at least now you can use the website on mobile again.