### PR TITLE
Do not show legacy aliases

### DIFF
--- a/import-scripts/import_scripts/packages-config.nix
+++ b/import-scripts/import_scripts/packages-config.nix
@@ -1,6 +1,6 @@
 {
   # Ensures no aliases are in the results.
-  allowAliases = true;
+  allowAliases = false;
 
   # Also list unfree packages
   allowUnfree = true;


### PR DESCRIPTION
Legacy aliases are slated for removal and should not be used.

https://github.com/NixOS/nixos-search/issues/306