### PR TITLE
import-scripts: fix IndexError for options with no declarations

### DIFF
--- a/import-scripts/import_scripts/channel.py
+++ b/import-scripts/import_scripts/channel.py
@@ -552,6 +552,9 @@ def get_options(evaluation):
 
             option_name_query = parse_query(name)
 
+            declarations = option.get("declarations", [])
+            option_source = declarations[0] if declarations else None
+
             yield dict(
                 type="option",
                 option_name=name,
@@ -563,7 +566,7 @@ def get_options(evaluation):
                 option_type=option.get("type"),
                 option_default=default,
                 option_example=example,
-                option_source=option.get("declarations", [None])[0],
+                option_source=option_source,
             )
 
     return len(options), gen


### PR DESCRIPTION
Example failed import: https://github.com/NixOS/nixos-search/runs/3176800851?check_suite_focus=true#step:12:304
