### PR TITLE
Style links in package details consistently

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -359,10 +359,6 @@ header .navbar.navbar-static-top {
               & > li {
                 display: inline-block;
                 margin-right: 1em;
-
-                & > a {
-                  color: #666;
-                }
               }
               & > li:last-child {
                 margin-right: 0;


### PR DESCRIPTION
Making the links the same color as the non-linked text makes it hard to figure out which of the items are links and which are plain text.

This change lets the default link color apply to the links in package details.

Fixes #331.

| Before |
| ------ |
| ![Screenshot from 2021-08-01 10-43-12](https://user-images.githubusercontent.com/478237/127766540-3f07bc9d-e84b-4bc5-b248-fe710c96bfb4.png) |

| After |
| ----- |
| ![Screenshot from 2021-08-01 10-43-32](https://user-images.githubusercontent.com/478237/127766541-d1687b4d-a494-44d7-86c4-5b09a192c548.png) |

/cc @Fidgetcetera