### PR TITLE
Fix extra arrow outside the flake context

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -183,7 +183,7 @@ header .navbar.navbar-static-top {
     & > li {
       display: inline-block;
 
-      &:nth-child(1):after {
+      &:first-child:not(:last-child):after {
         content: "→";
         margin: 0 0.2em;
       }


### PR DESCRIPTION
Fix excess arrow for non flake items as seen below

![image](https://user-images.githubusercontent.com/7040031/130876757-dc746ac7-6f59-41fb-a065-a3a3a30f331b.png)
 