### PR TITLE
Fix default group name

### DIFF
--- a/src/Search.elm
+++ b/src/Search.elm
@@ -550,7 +550,7 @@ type alias Flake =
 
 defaultFlakeId : String
 defaultFlakeId =
-    "group-01"
+    "group-manual"
 
 
 flakeFromId : String -> Maybe Flake


### PR DESCRIPTION
An old index name was used for flakes causing search results to be incomplete