### PR TITLE
Don't fail import of groups as long as some imports succeed

### DIFF
--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -270,7 +270,7 @@ async fn run_command(
                     return Err(FlakeInfoError::Group(errors));
                 }
                 warn!("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
-                warn!("Some group memebers could not be evaluated: {}", FlakeInfoError::Group(errors));
+                warn!("Some group members could not be evaluated: {}", FlakeInfoError::Group(errors));
                 warn!("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
 
             }

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -265,7 +265,14 @@ async fn run_command(
                 .collect::<Vec<_>>();
 
             if !errors.is_empty() {
-                return Err(FlakeInfoError::Group(errors));
+
+                if exports.is_empty() {
+                    return Err(FlakeInfoError::Group(errors));
+                }
+                warn!("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
+                warn!("Some group memebers could not be evaluated: {}", FlakeInfoError::Group(errors));
+                warn!("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
+
             }
 
             let hash = {


### PR DESCRIPTION
Currently, imports of groups fail if any flake in the group fails
This PR changes to a fail silent-model where imports succeed as long as some flake succeeds.

We should have a way to notify about failing flakes nevertheless