### PR TITLE
Add flake app and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,15 @@ application.
 - GitHub Action can also be triggered via Pull Request, which if Pull Request
   was created from a non-forked repo's branch, will provide a preview url in a
   comment.
+
+## Adding flakes
+
+To add your own flakes to the search index edit [./flakes/manual.toml](./flakes/manual.toml).
+
+Possible types are `github`, `gitlab`, and `git` (which is the fallback for any kind of git repository but requires to set a revision key manually as of now).
+
+To test whether your flake is compatible with nix flake-info you can try running `flake-info` against it
+
+```
+$ nix run github:nixos/nixos-search#apps.flake-info -- flake <your flake handle>
+```

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ ];
+            overlays = [];
           };
         in
           import path { inherit pkgs; };
@@ -28,10 +28,20 @@
           inputsFrom = builtins.attrValues (packages system);
           NIXPKGS_PANDOC_FILTERS_PATH = "${nixpkgs + "/doc/build-aux/pandoc-filters"}";
         };
+
+      apps = system:
+        {
+          flake-info = {
+            type = "app";
+            program = "${(packages system).flake_info}/bin/flake-info";
+          };
+        };
     in
       {
         defaultPackage = forAllSystems (mkPackage ./.);
         packages = forAllSystems packages;
         devShell = forAllSystems devShell;
+        apps = forAllSystems apps;
+        defaultApp = forAllSystems (system: (apps system).flake-info);
       };
 }


### PR DESCRIPTION
I added a flake-info app attribute to the flake.

Given this I could also add some Instructions to add and test user's own flakes