### PR TITLE
Convert import::Kind enum to a clap compatible arg_enum

### DIFF
--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -25,7 +25,9 @@ struct Args {
     #[structopt(
         short,
         long,
-        help = "Kind of data to extract (packages|options|apps|all)",
+        help = "Kind of data to extract",
+        possible_values = &data::import::Kind::variants(),
+        case_insensitive = true,
         default_value
     )]
     kind: data::import::Kind,

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, write, Display};
 use std::marker::PhantomData;
 use std::{path::PathBuf, str::FromStr};
 
+use clap::arg_enum;
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -103,51 +104,26 @@ pub struct Maintainer {
     pub email: Option<String>,
 }
 
-/// The type of derivation (placed in packages.<system> or apps.<system>)
-/// Used to command the extraction script
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub enum Kind {
-    App,
-    Package,
-    Option,
-    All,
+arg_enum! {
+    /// The type of derivation (placed in packages.<system> or apps.<system>)
+    /// Used to command the extraction script
+    #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+    pub enum Kind {
+        App,
+        Package,
+        Option,
+        All,
+    }
 }
 
 impl AsRef<str> for Kind {
     fn as_ref(&self) -> &str {
         match self {
-            Kind::App => "app",
+            Kind::App => "apps",
             Kind::Package => "packages",
             Kind::Option => "options",
             Kind::All => "all",
         }
-    }
-}
-
-impl Display for Kind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_ref())
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum ParseKindError {
-    #[error("Failed to parse kind: {0}")]
-    UnknownKind(String),
-}
-
-impl FromStr for Kind {
-    type Err = ParseKindError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let kind = match s {
-            "app" => Kind::App,
-            "packages" => Kind::Package,
-            "options" => Kind::Option,
-            "all" => Kind::All,
-            _ => return Err(ParseKindError::UnknownKind(s.into())),
-        };
-        Ok(kind)
     }
 }
 


### PR DESCRIPTION
The kind argument was not properly documented (possible options incorrectly listed)
This PR implements clap arg_enum for the Kind type to auto generate options