### PR TITLE
flake: Remove app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,20 +28,10 @@
           inputsFrom = builtins.attrValues (packages system);
           NIXPKGS_PANDOC_FILTERS_PATH = "${nixpkgs + "/doc/build-aux/pandoc-filters"}";
         };
-
-      apps = system:
-        {
-          flake-info = {
-            type = "app";
-            program = "${(packages system).flake-info}/bin/flake-info";
-          };
-        };
     in
       {
         defaultPackage = forAllSystems (mkPackage ./.);
         packages = forAllSystems packages;
         devShell = forAllSystems devShell;
-        apps = forAllSystems apps;
-        defaultApp = forAllSystems (system: (apps system).flake-info);
       };
 }


### PR DESCRIPTION
This helps promoting Nix best practices.

#### Copy of commit msg
As pointed out by Yannik Sander, defining the app is redundant because the package of the same name is used automatically.