### PR TITLE
Remove noisy prints to stderr

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> { } }: with pkgs;
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   name = "flake-info";
   src = ./.;
   cargoLock = {
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
 
   postInstall = ''
     wrapProgram $out/bin/flake-info \
-      --set NIXPKGS_PANDOC_FILTERS_PATH "${pkgs.path + "/doc/build-aux/pandoc-filters"}" \
+      --set NIXPKGS_PANDOC_FILTERS_PATH "${NIXPKGS_PANDOC_FILTERS_PATH}" \
       --prefix PATH : ${pandoc}/bin
   '';
 }

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -10,6 +10,7 @@ pub mod data;
 pub mod elastic;
 
 pub use commands::get_flake_info;
+use log::trace;
 
 pub fn process_flake(
     source: &Source,
@@ -20,8 +21,8 @@ pub fn process_flake(
     let mut info = commands::get_flake_info(source.to_flake_ref(), temp_store, extra)?;
     info.source = Some(source.clone());
     let packages = commands::get_derivation_info(source.to_flake_ref(), *kind, temp_store, extra)?;
-    eprintln!("{:#?}", info);
-    eprintln!("{:#?}", packages);
+    trace!("flake info: {:#?}", info);
+    trace!("flake content: {:#?}", packages);
 
     let exports: Vec<Export> = packages
         .into_iter()

--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,13 @@
         };
 
       devShell = system:
+        let packages_inst = (packages system);
+        in
         nixpkgs.legacyPackages.${system}.mkShell {
-          inputsFrom = builtins.attrValues (packages system);
-          NIXPKGS_PANDOC_FILTERS_PATH = "${nixpkgs + "/doc/build-aux/pandoc-filters"}";
+          inputsFrom = builtins.attrValues packages_inst;
+          shellHook = ''
+            export NIXPKGS_PANDOC_FILTERS_PATH="${packages_inst.flake_info.NIXPKGS_PANDOC_FILTERS_PATH}";
+          '';
         };
     in
       {


### PR DESCRIPTION
Flake info and dumps were printed to stderr.
These are now sent as low level logs using `log::trace` and can be optionally enabled

Also bundles pandoc and pandoc variables now for less unrelated errors in nix devShells

Resolves #384 