### PR TITLE
Fix/devshell Fixes 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,11 +24,14 @@
         };
 
       devShell = system:
-        let packages_inst = (packages system);
+        let
+          packages_inst = (packages system);
+          pkgs = nixpkgs.legacyPackages.${system};
         in
-        nixpkgs.legacyPackages.${system}.mkShell {
+        pkgs.mkShell {
           inputsFrom = builtins.attrValues packages_inst;
           shellHook = ''
+            export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
             export NIXPKGS_PANDOC_FILTERS_PATH="${packages_inst.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,10 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [];
+            overlays = [ ];
           };
         in
-          import path { inherit pkgs; };
+        import path { inherit pkgs; };
       packages = system:
         {
           flake-info = mkPackage ./flake-info system;
@@ -36,9 +36,9 @@
           '';
         };
     in
-      {
-        defaultPackage = forAllSystems (mkPackage ./.);
-        packages = forAllSystems packages;
-        devShell = forAllSystems devShell;
-      };
+    {
+      defaultPackage = forAllSystems (mkPackage ./.);
+      packages = forAllSystems packages;
+      devShell = forAllSystems devShell;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
         nixpkgs.legacyPackages.${system}.mkShell {
           inputsFrom = builtins.attrValues packages_inst;
           shellHook = ''
-            export NIXPKGS_PANDOC_FILTERS_PATH="${packages_inst.flake_info.NIXPKGS_PANDOC_FILTERS_PATH}";
+            export NIXPKGS_PANDOC_FILTERS_PATH="${packages_inst.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
           '';
         };
     in


### PR DESCRIPTION
Flake had some regressions w.r.t. the latest rename of the `flake-info` attribute and not exporting the rust stdlib path (for tools like rust-analzer)