### PR TITLE
Allow plain strings for nixpkgs maintainer fields

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -216,10 +216,13 @@ impl From<import::NixpkgsEntry> for Derivation {
                     .map(|l: &License| l.fullName.to_owned())
                     .collect();
 
-                let package_maintainers = package
+                let package_maintainers: Vec<Maintainer> = package
                     .meta
                     .maintainers
-                    .map_or(Default::default(), Flatten::flatten);
+                    .map_or(Default::default(), Flatten::flatten)
+                    .into_iter()
+                    .map(Into::into)
+                    .collect();
 
                 let package_maintainers_set = package_maintainers
                     .iter()
@@ -342,7 +345,27 @@ impl From<import::NixOption> for Derivation {
     }
 }
 
-type Maintainer = import::Maintainer;
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Maintainer {
+    name: Option<String>,
+    github: Option<String>,
+    email: Option<String>,
+}
+
+impl From<import::Maintainer> for Maintainer {
+    fn from(import: import::Maintainer) -> Self {
+        match import {
+            import::Maintainer::Full { name, github, email } => Maintainer {
+                name, github, email
+            },
+            import::Maintainer::Simple(name) => Maintainer {
+                name: Some(name),
+                github: None,
+                email: None,
+            },
+        }
+    }
+}
 
 impl From<super::Flake> for Maintainer {
     fn from(flake: super::Flake) -> Self {

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 
 use crate::data::import::NixOption;
 use log::error;
-use pandoc::{InputFormat, InputKind, OutputFormat, OutputKind, PandocOption, PandocOutput, PandocError};
+use pandoc::{
+    InputFormat, InputKind, OutputFormat, OutputKind, PandocError, PandocOption, PandocOutput,
+};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -319,7 +321,10 @@ impl From<import::NixOption> for Derivation {
                 PandocOption::LuaFilter(man_filter),
             ]);
 
-            let result = pandoc.execute().expect(&format!("Pandoc could not parse documentation of '{}'", name));
+            let result = pandoc.execute().expect(&format!(
+                "Pandoc could not parse documentation of '{}'",
+                name
+            ));
 
             match result {
                 PandocOutput::ToBuffer(description) => Some(description),
@@ -355,8 +360,14 @@ pub struct Maintainer {
 impl From<import::Maintainer> for Maintainer {
     fn from(import: import::Maintainer) -> Self {
         match import {
-            import::Maintainer::Full { name, github, email } => Maintainer {
-                name, github, email
+            import::Maintainer::Full {
+                name,
+                github,
+                email,
+            } => Maintainer {
+                name,
+                github,
+                email,
             },
             import::Maintainer::Simple(name) => Maintainer {
                 name: Some(name),

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -105,7 +105,7 @@ pub enum Maintainer {
         github: Option<String>,
         email: Option<String>,
     },
-    Simple(String)
+    Simple(String),
 }
 
 arg_enum! {

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -98,10 +98,14 @@ pub struct Meta {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Maintainer {
-    pub name: Option<String>,
-    pub github: Option<String>,
-    pub email: Option<String>,
+#[serde(untagged)]
+pub enum Maintainer {
+    Full {
+        name: Option<String>,
+        github: Option<String>,
+        email: Option<String>,
+    },
+    Simple(String)
 }
 
 arg_enum! {
@@ -267,7 +271,8 @@ mod tests {
                     "github": "AndersonTorres",
                     "githubId": 5954806,
                     "name": "Anderson Torres"
-                  }
+                  },
+                  "Fred Flintstone"
                 ],
                 "name": "0verkill-unstable-2011-01-13",
                 "outputsToInstall": [


### PR DESCRIPTION
Implements first point as mentioned in #391 to prevent issues with plain maintainer names (#389) from happening

cc. @garbas @ncfavier 