### PR TITLE
Flakes index: Add nix-bitcoin

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -19,6 +19,11 @@ owner = "ngi-nix"
 repo = "openpgp-ca"
 
 [[sources]]
+type = "github"
+owner = "fort-nix"
+repo = "nix-bitcoin"
+
+[[sources]]
 type = "gitlab"
 owner = "pi-lar"
 repo = "neuropil"


### PR DESCRIPTION
https://github.com/fort-nix/nix-bitcoin
`nix-bitcoin` also adds service modules for some apps that are already part of nixpkgs: btcpayserver, electrs, clightning, lnd (among others).