### PR TITLE
flakes: Add sway-timetracker

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -42,3 +42,7 @@ repo = "nixos"
 type = "github"
 owner = "PaddiM8"
 repo = "kalker"
+
+[[sources]]
+type = "git"
+url = "git+https://git.sr.ht/~kerstin/sway-timetracker?ref=main"


### PR DESCRIPTION
I'd also like to add my side project to the index.
Could also be the first example on how to add non-gitlab/github flakes.

Did I understand the readme right, that I *have* to add the `rev` attribute?