### PR TITLE
Render DocBook strings containing < but not </

### DIFF
--- a/flake-info/src/data/pandoc.rs
+++ b/flake-info/src/data/pandoc.rs
@@ -18,7 +18,7 @@ pub trait PandocExt {
 
 impl<T: AsRef<str>> PandocExt for T {
     fn render(&self) -> Result<String, PandocError> {
-        if !self.as_ref().contains("</") {
+        if !self.as_ref().contains("<") {
             return Ok(format!(
                 "<rendered-docbook>{}</rendered-docbook>",
                 self.as_ref()


### PR DESCRIPTION
The current check is too restrictive and will not match strings containing only self-closing tags, for example the description of [`time.timeZone`](https://search.nixos.org/options?channel=unstable&show=time.timeZone&from=0&size=50&sort=alpha_asc&type=packages&query=time.timeZone).

This change still only renders about 20% of the NixOS option descriptions. I think it's now complete, i.e. there are no strings not containing `<` that would be substantially changed by the DocBook-to-HTML conversion; I could be wrong though.