### PR TITLE
Support flake attr `nixosModule`

### DIFF
--- a/flake-info/src/commands/flake_info.nix
+++ b/flake-info/src/commands/flake_info.nix
@@ -10,20 +10,14 @@ let
   withSystem = fn: lib.mapAttrs (system: drvs: (fn system drvs));
   isValid = d:
     let
-      r = builtins.tryEval (lib.isDerivation d && ! (lib.attrByPath [ "meta" "broken" ] false d) && builtins.seq d.name true && d ? outputs);
+      r = builtins.tryEval (lib.isDerivation d && ! (lib.attrByPath [ "meta" "broken" ] false d) &&
+                            builtins.seq d.name true && d ? outputs);
     in
       r.success && r.value;
-  all = pkgs:
-    let
-      validPkgs = lib.filterAttrs (k: v: isValid v) pkgs;
-    in
-      validPkgs;
-
-
+  validPkgs = lib.filterAttrs (k: v: isValid v);
 
   readPackages = system: drvs: lib.mapAttrsToList (
     attribute_name: drv: (
-      # if isValid drv then
       {
         attribute_name = attribute_name;
         system = system;
@@ -35,10 +29,8 @@ let
       }
       // lib.optionalAttrs (drv ? meta && drv.meta ? description) { inherit (drv.meta) description; }
       // lib.optionalAttrs (drv ? meta && drv.meta ? license) { inherit (drv.meta) license; }
-
-      # else {}
     )
-  ) (all drvs);
+  ) (validPkgs drvs);
   readApps = system: apps: lib.mapAttrsToList (
     attribute_name: app: (
       {

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -3,7 +3,7 @@
 /// Flakes, or Nixpkgs.
 use std::{convert::TryInto, path::PathBuf};
 
-use super::{import::DocValue, pandoc::PandocExt};
+use super::{import::{DocValue, ModulePath}, pandoc::PandocExt};
 use crate::data::import::NixOption;
 use log::error;
 use serde::{Deserialize, Serialize};
@@ -110,7 +110,7 @@ pub enum Derivation {
 
         option_example: Option<DocValue>,
 
-        option_flake: Option<(String, String)>,
+        option_flake: Option<ModulePath>,
     },
 }
 


### PR DESCRIPTION
Support extracting module options defined via flake attr `nixosModule` (see [nix/flake.cc](https://github.com/NixOS/nix/blob/0e90b13ab1df925e549b5d55853b65911b4b40d3/src/nix/flake.cc#L582)).
These options are currently ignored by nixos-search.

`nixosModule` options are now exported with a `flake` attr of the form `[ flake ]` (instead of `[ flake moduleName ]`, which is currently used for options defined via `nixosModules.moduleName`).

#### TODO
This change must also be reflected in the Elm and Rust layers.
Field [flake](https://github.com/NixOS/nixos-search/blob/63846c3e82d7d5f08c44a57347249b897fd44be1/flake-info/src/data/import.rs#L67) of struct `NixOption` currently consists of both a flake and a module name.
@ysndr, @ncfavier, could you have a look at this?

Here's what I'd propose for displaying the options in the web interface:
```
# Current format
github:foo/bar#mymodule -> services.bar.enable

# Possible format for options defined via `nixosModule`
github:foo/bar -> services.bar.enable
```