### PR TITLE
Fix perform deeper equality checks for internal links to the same model

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -191,17 +191,17 @@ pageMatch m1 m2 =
         ( Home _, Home _ ) ->
             True
 
-        ( Packages _, Packages _ ) ->
-            True
+        ( Packages model_a, Packages model_b ) ->
+            {model_a | show = Nothing } == {model_b | show = Nothing}
 
-        ( Options _, Options _ ) ->
-            True
+        ( Options model_a, Options model_b ) ->
+            {model_a | show = Nothing } == {model_b | show = Nothing}
 
-        ( Flakes (OptionModel _), Flakes (OptionModel _) ) ->
-            True
+        ( Flakes (OptionModel model_a), Flakes (OptionModel model_b) ) ->
+            {model_a | show = Nothing } == {model_b | show = Nothing}
 
-        ( Flakes (PackagesModel _), Flakes (PackagesModel _) ) ->
-            True
+        ( Flakes (PackagesModel model_a), Flakes (PackagesModel model_b) ) ->
+            {model_a | show = Nothing } == {model_b | show = Nothing}
 
         _ ->
             False


### PR DESCRIPTION
Fixes #403 on the Elm level instead of a workaround as in #404.
Also brings support for native browser navigation