### PR TITLE
Ignore result data

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -37,6 +37,7 @@ import Search exposing (defaultFlakeId)
 import Search exposing (channels)
 import Html exposing (sup)
 import Html exposing (small)
+import RemoteData exposing (RemoteData(..))
 
 
 
@@ -192,16 +193,16 @@ pageMatch m1 m2 =
             True
 
         ( Packages model_a, Packages model_b ) ->
-            {model_a | show = Nothing } == {model_b | show = Nothing}
+            {model_a | show = Nothing, result = NotAsked } == {model_b | show = Nothing, result = NotAsked}
 
         ( Options model_a, Options model_b ) ->
-            {model_a | show = Nothing } == {model_b | show = Nothing}
+            {model_a | show = Nothing, result = NotAsked } == {model_b | show = Nothing, result = NotAsked}
 
         ( Flakes (OptionModel model_a), Flakes (OptionModel model_b) ) ->
-            {model_a | show = Nothing } == {model_b | show = Nothing}
+            {model_a | show = Nothing, result = NotAsked } == {model_b | show = Nothing, result = NotAsked}
 
         ( Flakes (PackagesModel model_a), Flakes (PackagesModel model_b) ) ->
-            {model_a | show = Nothing } == {model_b | show = Nothing}
+            {model_a | show = Nothing, result = NotAsked } == {model_b | show = Nothing, result = NotAsked}
 
         _ ->
             False


### PR DESCRIPTION
#406 would unnecessarily reload pages if `show=` was toggled.
The checking function compares pages but the new page will be loading while the old one has results already. Hence also ignore `resultz state.

Sorry @ncfavier to have another PR on the same issue 