### PR TITLE
CI: don't fail-fast

### DIFF
--- a/.github/workflows/import-flakes.yml
+++ b/.github/workflows/import-flakes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         group:
           - "manual"

--- a/.github/workflows/import-nixpkgs.yml
+++ b/.github/workflows/import-nixpkgs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         channel:
           - unstable


### PR DESCRIPTION
Import failing for a channel/group doesn't mean it will fail for the other channels/groups