### PR TITLE
Pass --meta to nix-env

### DIFF
--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -27,6 +27,7 @@ pub fn get_nixpkgs_info<T: AsRef<str> + Display>(nixpkgs_channel: T) -> Result<V
         "config",
         format!("import {}", script_path.to_str().unwrap()).as_str(),
         "-qa",
+        "--meta",
         "--json",
     ]);
 


### PR DESCRIPTION
Since Nix 2.6 (https://github.com/NixOS/nix/pull/5883) nix-env doesn't output the `meta` attribute unless this flag is passed.

Unblocks the import: https://github.com/NixOS/nixos-search/actions/runs/1744880186