### PR TITLE
flake: add nixos-search.cachix.org to substituters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Code behind search.nixos.org";
 
+  nixConfig = {
+    extra-substituters = [ "https://nixos-search.cachix.org" ];
+    extra-trusted-public-keys = [ "nixos-search.cachix.org-1:1HV3YF8az4fywnH+pAd+CXFEdpTXtv9WpoivPi+H70o=" ];
+  };
+
   inputs = {
     nixpkgs = { url = "nixpkgs/nixos-unstable"; };
   };


### PR DESCRIPTION
Allows `nix build .#...` locally to fetch build products from the cache without having to modify `nix.conf`