### PR TITLE
Authenticate to the GitHub API in nixpkgs workflow

### DIFF
--- a/.github/workflows/import-nixpkgs.yml
+++ b/.github/workflows/import-nixpkgs.yml
@@ -50,6 +50,8 @@ jobs:
         nix -vL build .#flake-info
 
     - name: Import ${{ matrix.channel }} channel
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         ./result/bin/flake-info --push --elastic-schema-version=$(< VERSION) nixpkgs ${{ matrix.channel }}
       if: github.repository_owner == 'NixOS'


### PR DESCRIPTION
The nixpkgs import seems to have intermittent [failures](https://github.com/NixOS/nixos-search/actions/workflows/import-nixpkgs.yml?query=is%3Afailure) (~four~ five in the past week) where the GitHub API returns 403. I think we may be hitting a rate limit of some sort, so this PR

- authenticates to GitHub in workflows using the GITHUB_TOKEN,
- prints the full response text in case of error, and
- sets the user agent to `nixos-search` as requested [here](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required).

Workflow [still running correctly](https://github.com/NixOS/nixos-search/runs/5077730932?check_suite_focus=true).