### PR TITLE
Improve short package details readability

### DIFF
--- a/src/Page/Packages.elm
+++ b/src/Page/Packages.elm
@@ -20,6 +20,8 @@ import Html
     exposing
         ( Html
         , a
+        , br
+        , code
         , div
         , em
         , h4
@@ -330,11 +332,27 @@ viewResultItem channel showInstallDetails show item =
                             |> Maybe.map
                                 (\x ->
                                     [ li [ trapClick ]
-                                        [ createShortDetailsItem "Homepage" x ]
+                                        [ createShortDetailsItem "🏡 Homepage" x ]
                                     ]
                                 )
                             |> Maybe.withDefault []
                         )
+                    |> List.append
+                        (if item.source.pversion == "" then
+                            []
+
+                         else
+                            [ text "Version: "
+                            , li [] [ strong [] [ text item.source.pversion ] ]
+                            ]
+                        )
+                    |> List.append
+                        [ text "Name: "
+                        , li [] [ code [] [ text item.source.pname ] ]
+                        ]
+                    |> List.append
+                        [ br [] []
+                        ]
                     |> List.append
                         (item.source.licenses
                             |> List.filterMap
@@ -352,22 +370,9 @@ viewResultItem channel showInstallDetails show item =
                                         ( Just fullName, Just url ) ->
                                             Just (createShortDetailsItem fullName url)
                                 )
-                            |> List.intersperse (text ", ")
-                            |> (\x -> [ li [] (List.append [ text "Licenses: " ] x) ])
+                            |> List.intersperse (text " ▪ ")
+                            |> (\x -> [ li [] (List.append [ text "License(s): " ] x) ])
                         )
-                    |> List.append
-                        (if item.source.pversion == "" then
-                            []
-
-                         else
-                            [ text "Version: "
-                            , li [] [ text item.source.pversion ]
-                            ]
-                        )
-                    |> List.append
-                        [ text "Name: "
-                        , li [] [ text item.source.pname ]
-                        ]
                 )
 
         showMaintainer maintainer =
@@ -637,7 +642,7 @@ renderSource item channel trapClick createShortDetailsItem createGithubUrl =
                             Just channelDetails ->
                                 [ li [ trapClick ]
                                     [ createShortDetailsItem
-                                        "Source"
+                                        "📦 Source"
                                         (createGithubUrl channelDetails.branch position)
                                     ]
                                 ]


### PR DESCRIPTION
#### Disclaimer

I am not a web dev and have no knowledge of Elm beyond hacking this locally on a lazy afternoon. :p
It works but of course I welcome your reviews on code style, validity of the approach, ...


#### Motivation:
The package details are a bit hard to read :
* names and versions are visually similar to the rest of the text
* hard to distinguish licenses when there is more than one (the coma is buried)
* Homepage and Source are visually similar and too close the the last license (all links)
* depending on the length of the license list, Homepage **and/or** Source can be pushed onto the second line

Last point is really my main complaint with the current display of results.
Sometimes you have Homepage on the first line and Source on the second. Sometimes you have both on the second line.
The unpredictable position makes them hard to use when rapidly scanning several results.

All in all I felt the UX could be improved.


#### Things done

* put licenses list on it own line and separate each license with a small black square
* display package name as a code block
* display version number in bold
* add a 'house with garden' emoji before "Homepage"
* add a 'package' emoji before "Source"

#### Rendered with examples

![image](https://user-images.githubusercontent.com/24417923/153935280-8fbfdcf0-1ccb-4d29-9bb7-69b332d7a363.png)

![image](https://user-images.githubusercontent.com/24417923/153935306-0871421a-9721-4631-91c3-3a6165306b26.png)

#### Gains
- [x] Names and version are immediately recognisable
- [x] Multiple licenses are easier to distinguish
- [x] Homepage and Source links are always in a predictable position and easier to locate visually