### PR TITLE
CI: do shallow clones

### DIFF
--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -21,8 +21,6 @@ jobs:
 
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -10,15 +10,13 @@ jobs:
     steps:
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-   
+
 
     - name: Building search.nixos.org
       run: |

--- a/.github/workflows/import-flakes.yml
+++ b/.github/workflows/import-flakes.yml
@@ -26,15 +26,13 @@ jobs:
 
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-   
+
 
     - name: Building flake-info
       run: |

--- a/.github/workflows/import-nixpkgs.yml
+++ b/.github/workflows/import-nixpkgs.yml
@@ -27,15 +27,13 @@ jobs:
     steps:
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-   
+
 
     - name: Building flake-info
       run: |


### PR DESCRIPTION
Flakes don't need a deep clone. Workflows still succeed: https://github.com/NixOS/nixos-search/actions/runs/1910453681 https://github.com/NixOS/nixos-search/actions/runs/1910460271 https://github.com/NixOS/nixos-search/actions/runs/1910476017