### PR TITLE
CI: enable globstar

### DIFF
--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -33,6 +33,7 @@ jobs:
 
     - name: Try importing all custom flakes
       run: |
+        shopt -s globstar
         for flake_group in flakes/**/*.toml
         do
           ./result/bin/flake-info group "$flake_group" "$(basename "$flake_group" .toml)"

--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -21,8 +21,6 @@ jobs:
 
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -10,15 +10,13 @@ jobs:
     steps:
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-   
+
 
     - name: Building search.nixos.org
       run: |

--- a/.github/workflows/import-flakes.yml
+++ b/.github/workflows/import-flakes.yml
@@ -26,15 +26,13 @@ jobs:
 
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-   
+
 
     - name: Building flake-info
       run: |

--- a/.github/workflows/import-nixpkgs.yml
+++ b/.github/workflows/import-nixpkgs.yml
@@ -27,15 +27,13 @@ jobs:
     steps:
     - name: Checking out the repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
-   
+
 
     - name: Building flake-info
       run: |


### PR DESCRIPTION
I forgot that using `**` in bash requires an option to be enabled.

Alternatively, do we really need to *recursively* look for `.toml` files? Otherwise we could just go with `flakes/*.toml`.

Workflow now succeeds: https://github.com/NixOS/nixos-search/runs/5360158285?check_suite_focus=true