### PR TITLE
Import Nixpkgs from path

### DIFF
--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -43,6 +43,7 @@ struct Args {
 
 #[derive(StructOpt, Debug)]
 enum Command {
+    #[structopt(about = "Import a flake")]
     Flake {
         #[structopt(help = "Flake identifier passed to nix to gather information about")]
         flake: String,
@@ -56,10 +57,13 @@ enum Command {
         #[structopt(long, help = "Whether to gc the store after info or not")]
         gc: bool,
     },
+    #[structopt(about = "Import official nixpkgs channel")]
     Nixpkgs {
         #[structopt(help = "Nixpkgs channel to import")]
         channel: String,
     },
+
+    #[structopt(about = "Load and import a group of flakes from a file")]
     Group {
         #[structopt(
             help = "Points to a TOML or JSON file containing info targets. If file does not end in 'toml' json is assumed"

--- a/flake-info/src/data/source.rs
+++ b/flake-info/src/data/source.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     ffi::OsStr,
     fs::{self, File},
-    io::{Read, self},
+    io::{self, Read},
     path::Path,
 };
 
@@ -115,15 +115,14 @@ impl Source {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            Err(anyhow::anyhow!("GitHub returned {:?} {}", response.status(), response.text().await?))
+            Err(anyhow::anyhow!(
+                "GitHub returned {:?} {}",
+                response.status(),
+                response.text().await?
+            ))
         } else {
-            let git_ref = response.json::<ApiResult>()
-                .await?
-                .commit
-                .sha;
-
+            let git_ref = response.json::<ApiResult>().await?.commit.sha;
             let nixpkgs = Nixpkgs { channel, git_ref };
-
             Ok(nixpkgs)
         }
     }
@@ -132,5 +131,6 @@ impl Source {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Nixpkgs {
     pub channel: String,
+
     pub git_ref: String,
 }


### PR DESCRIPTION
Add a subcommand that allows to import nixpkgs from a local repository or archive file

I wanted to have this earlier and #442 brought this back up.
To test changes to nixpkgs (i.e. the all-packages.nix) file, we need to point to an arbitrary source of nixpkgs.

What remains is a way to see changes in a (testing) frontend but that is a separate issue

USAGE:

```
$ nix run github:nixos/nixos-search/cli/nixpkgs-archive-import -- nixpkgs-archive <path-to-archive or folder> [other options]`
```
