### PR TITLE
flake: set flake-info as default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
         };
     in
     {
-      defaultPackage = forAllSystems (mkPackage ./.);
+      defaultPackage = forAllSystems (mkPackage ./flake-info);
       packages = forAllSystems packages;
       devShell = forAllSystems devShell;
     };


### PR DESCRIPTION
Makes more sense to have the CLI tool as default package.