### PR TITLE
flake-info: enforce minimal nix version

### DIFF
--- a/flake-info/.cargo/config.toml
+++ b/flake-info/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+MIN_NIX_VERSION = "2.7.0" # we need PRs #5878 and #5922 for package outputs

--- a/flake-info/Cargo.lock
+++ b/flake-info/Cargo.lock
@@ -335,6 +335,7 @@ dependencies = [
  "log",
  "pandoc",
  "reqwest",
+ "semver 1.0.6",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1124,7 +1125,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -1209,6 +1210,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "semver-parser"

--- a/flake-info/Cargo.toml
+++ b/flake-info/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "*", features = ["full"] }
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 sha2 = "0.9"
 pandoc = "0.8"
+semver = "1.0"
 
 elasticsearch = {git = "https://github.com/elastic/elasticsearch-rs", features = ["rustls-tls"]}
 

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -195,7 +195,6 @@ async fn main() -> Result<()> {
 
 #[derive(Debug, Error)]
 enum FlakeInfoError {
-
     #[error("Nix check failed: {0}")]
     NixCheck(#[from] NixCheckError),
 
@@ -214,9 +213,8 @@ async fn run_command(
     kind: Kind,
     extra: &[String],
 ) -> Result<(Vec<Export>, (String, String, String)), FlakeInfoError> {
-    
     flake_info::commands::check_nix_version(env!("MIN_NIX_VERSION"))?;
-    
+
     match command {
         Command::Flake {
             flake,

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -1,10 +1,12 @@
 use anyhow::{Context, Result};
 use commands::run_gc;
+use flake_info::commands::NixCheckError;
 use flake_info::data::import::{Kind, NixOption};
 use flake_info::data::{self, Export, Nixpkgs, Source};
 use flake_info::elastic::{ElasticsearchError, ExistsStrategy};
 use flake_info::{commands, elastic};
 use log::{debug, error, info, warn};
+use semver::VersionReq;
 use sha2::Digest;
 use std::path::{Path, PathBuf};
 use std::ptr::hash;
@@ -193,6 +195,10 @@ async fn main() -> Result<()> {
 
 #[derive(Debug, Error)]
 enum FlakeInfoError {
+
+    #[error("Nix check failed: {0}")]
+    NixCheck(#[from] NixCheckError),
+
     #[error("Getting flake info caused an error: {0:?}")]
     Flake(anyhow::Error),
     #[error("Getting nixpkgs info caused an error: {0:?}")]
@@ -208,6 +214,9 @@ async fn run_command(
     kind: Kind,
     extra: &[String],
 ) -> Result<(Vec<Export>, (String, String, String)), FlakeInfoError> {
+    
+    flake_info::commands::check_nix_version(env!("MIN_NIX_VERSION"))?;
+    
     match command {
         Command::Flake {
             flake,

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -1,10 +1,10 @@
+mod nix_check_version;
 mod nix_flake_attrs;
 mod nix_flake_info;
-mod nix_check_version;
 mod nix_gc;
 mod nixpkgs_info;
+pub use nix_check_version::{check_nix_version, NixCheckError};
 pub use nix_flake_attrs::get_derivation_info;
 pub use nix_flake_info::get_flake_info;
-pub use nix_check_version::{check_nix_version, NixCheckError};
 pub use nix_gc::run_gc;
 pub use nixpkgs_info::{get_nixpkgs_info, get_nixpkgs_options};

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -1,8 +1,10 @@
 mod nix_flake_attrs;
 mod nix_flake_info;
+mod nix_check_version;
 mod nix_gc;
 mod nixpkgs_info;
 pub use nix_flake_attrs::get_derivation_info;
 pub use nix_flake_info::get_flake_info;
+pub use nix_check_version::{check_nix_version, NixCheckError};
 pub use nix_gc::run_gc;
 pub use nixpkgs_info::{get_nixpkgs_info, get_nixpkgs_options};

--- a/flake-info/src/commands/nix_check_version.rs
+++ b/flake-info/src/commands/nix_check_version.rs
@@ -1,6 +1,6 @@
 use command_run::Command;
 use log::info;
-use semver::{VersionReq, Version};
+use semver::{Version, VersionReq};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -10,28 +10,33 @@ pub enum NixCheckError {
 
     #[error("SemVer error (this should not occur, please file a bug report): {0}")]
     CheckError(#[from] semver::Error),
-    
+
     #[error("Failed to run nix command: {0}")]
-    CommandError(#[from] command_run::Error)
+    CommandError(#[from] command_run::Error),
 }
 
 pub fn check_nix_version(min_version: &str) -> Result<(), NixCheckError> {
     info!("Checking nix version");
 
-    let nix_version_requirement = VersionReq::parse(&format!(">={}", min_version))?; 
-    
-    let mut command = Command::with_args("nix", &["eval", "--raw", "--expr", "builtins.nixVersion"]);
+    let nix_version_requirement = VersionReq::parse(&format!(">={}", min_version))?;
+
+    let mut command =
+        Command::with_args("nix", &["eval", "--raw", "--expr", "builtins.nixVersion"]);
     command.log_command = false;
     command.enable_capture();
     let output = command.run()?;
     let nix_version = Version::parse(
-        output.stdout_string_lossy()
-              .split(|c: char| c != '.' && !c.is_ascii_digit())
-              .next()
-              .unwrap()
+        output
+            .stdout_string_lossy()
+            .split(|c: char| c != '.' && !c.is_ascii_digit())
+            .next()
+            .unwrap(),
     )?;
     if !nix_version_requirement.matches(&nix_version) {
-        return Err(NixCheckError::IncompatibleNixVersion(nix_version, nix_version_requirement))
+        return Err(NixCheckError::IncompatibleNixVersion(
+            nix_version,
+            nix_version_requirement,
+        ));
     }
     Ok(())
 }

--- a/flake-info/src/commands/nix_check_version.rs
+++ b/flake-info/src/commands/nix_check_version.rs
@@ -1,0 +1,37 @@
+use command_run::Command;
+use log::info;
+use semver::{VersionReq, Version};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NixCheckError {
+    #[error("Installed nix doesn't match version requirement: {0} (required >={1})")]
+    IncompatibleNixVersion(Version, VersionReq),
+
+    #[error("SemVer error (this should not occur, please file a bug report): {0}")]
+    CheckError(#[from] semver::Error),
+    
+    #[error("Failed to run nix command: {0}")]
+    CommandError(#[from] command_run::Error)
+}
+
+pub fn check_nix_version(min_version: &str) -> Result<(), NixCheckError> {
+    info!("Checking nix version");
+
+    let nix_version_requirement = VersionReq::parse(&format!(">={}", min_version))?; 
+    
+    let mut command = Command::with_args("nix", &["eval", "--raw", "--expr", "builtins.nixVersion"]);
+    command.log_command = false;
+    command.enable_capture();
+    let output = command.run()?;
+    let nix_version = Version::parse(
+        output.stdout_string_lossy()
+              .split(|c: char| c != '.' && !c.is_ascii_digit())
+              .next()
+              .unwrap()
+    )?;
+    if !nix_version_requirement.matches(&nix_version) {
+        return Err(NixCheckError::IncompatibleNixVersion(nix_version, nix_version_requirement))
+    }
+    Ok(())
+}

--- a/flake-info/src/commands/nix_check_version.rs
+++ b/flake-info/src/commands/nix_check_version.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum NixCheckError {
-    #[error("Installed nix doesn't match version requirement: {0} (required >={1})")]
+    #[error("Installed nix doesn't match version requirement: {0} (required {1})")]
     IncompatibleNixVersion(Version, VersionReq),
 
     #[error("SemVer error (this should not occur, please file a bug report): {0}")]

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, Result};
-use semver::{Version, VersionReq};
 use serde_json::Deserializer;
 use std::io::Write;
-use std::{process::exit, collections::HashMap, fmt::Display, fs::File};
+use std::{collections::HashMap, fmt::Display, fs::File};
 
 use command_run::{Command, LogTo};
 use log::{debug, error};
@@ -12,22 +11,6 @@ use crate::data::import::{NixOption, NixpkgsEntry, Package};
 const FLAKE_INFO_SCRIPT: &str = include_str!("flake_info.nix");
 
 pub fn get_nixpkgs_info<T: AsRef<str> + Display>(nixpkgs_channel: T) -> Result<Vec<NixpkgsEntry>> {
-    let nix_version_requirement = VersionReq::parse(">=2.7.0")?; // we need PRs #5878 and #5922 for package outputs
-    let mut command = Command::with_args("nix", &["eval", "--raw", "--expr", "builtins.nixVersion"]);
-    command.log_command = false;
-    command.enable_capture();
-    let output = command.run()?;
-    let nix_version = Version::parse(
-        output.stdout_string_lossy()
-              .split(|c: char| c != '.' && !c.is_ascii_digit())
-              .next()
-              .unwrap()
-    )?;
-    if !nix_version_requirement.matches(&nix_version) {
-        error!("nix doesn't match version requirement {}", nix_version_requirement);
-        exit(1);
-    }
-
     let mut command = Command::new("nix-env");
     command.add_args(&[
         "-f",


### PR DESCRIPTION
We need at least nix 2.7 (or 2.7pre_old_enough) for the nixpkgs import, so give a helpful error instead of letting nix fail.

It got a bit messy because nix versions aren't quite semver-compliant (there should be a dash before pre) so I had to strip the pre-suffix.