### PR TITLE
Add Nix-security for flakes

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -98,3 +98,8 @@ url = "git+https://codeberg.org/wolfangaukang/python-trovo?ref=main"
 [[sources]]
 type = "git"
 url = "git+https://codeberg.org/wolfangaukang/multifirefox?ref=main"
+
+[[sources]]
+type = "github"
+owner = "juliosueiras-nix"
+repo = "nix-security"


### PR DESCRIPTION
By the way, probably a good idea to indicate that the flakes-info doesn't check nested set(as far as I am aware), and `Package Set` is actually via the attribute name itself and not nesting

so like this 

```nix
{ 
  "base.some-package" = some-package;
}
```