### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -17,18 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649314464,
-        "narHash": "sha256-dU/Ed+VXtCAWbwRtHg9KPnskhRypB0nMb9Av/OOrV84=",
-        "owner": "aforemny",
+        "lastModified": 1649986882,
+        "narHash": "sha256-cNsInUFq1MbuvaEmv8x6jetWnmAU+osMpnwKumtjksI=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d88f74c9d13e599d1bd3633e8afb197b8378071",
+        "rev": "5181d5945eda382ff6a9ca3e072ed6ea9b547fee",
         "type": "github"
       },
       "original": {
-        "owner": "aforemny",
-        "ref": "fix/elm-format",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,7 @@
   nixConfig.extra-substituters = [ "https://nixos-search.cachix.org" ];
   nixConfig.extra-trusted-public-keys = [ "nixos-search.cachix.org-1:1HV3YF8az4fywnH+pAd+CXFEdpTXtv9WpoivPi+H70o=" ];
 
-  # TODO: follow nixos-unstable once elm-format fix is merged and release 
-  #       on nixos-unstable channels:
-  #         https://github.com/NixOS/nixpkgs/pull/167642
-  # inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
-  inputs.nixpkgs.url = "github:aforemny/nixpkgs/fix/elm-format";
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self


### PR DESCRIPTION
The nixpkgs PR has [landed](https://nixpk.gs/pr-tracker.html?pr=167642) so go back to following nixos-unstable