### PR TITLE
Add home-manager to flake sources

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -92,6 +92,11 @@ repo = "nix-security"
 
 [[sources]]
 type = "github"
+owner = "nix-community"
+repo = "home-manager"
+
+[[sources]]
+type = "github"
 owner = "lnbits"
 repo = "lnbits-legend"
 


### PR DESCRIPTION
Is there any reason why home-manager is still not in here? I feel like there are a lot of people using it and having it's options listed here could be very helpful