### PR TITLE
Add a new public flake to the list

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -108,3 +108,8 @@ url = "git+https://codeberg.org/wolfangaukang/multifirefox?ref=main"
 type = "github"
 owner = "juliosueiras-nix"
 repo = "nix-security"
+
+[[sources]]
+type = "github"
+owner = "SpyHoodle"
+repo = "pridefetch"


### PR DESCRIPTION
Pridefetch is a small terminal app to print out a pride flag and some system information in a terminal. I've written a flake for it, and I'd like that to be added to the nixos search. (See NixOS/flake-registry#24 for a similar pull adding this to the flake registry)