### PR TITLE
flake-info: Stop relying on user's NIX_PATH for flake extraction

### DIFF
--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -25,6 +25,7 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
 
     let mut command = Command::with_args("nix", ARGS.iter());
     command.add_arg_pair("-f", script_path.as_os_str());
+    command.add_arg_pair("-I", "nixpkgs=channel:nixpkgs-unstable");
     command.add_args(["--override-flake", "input-flake", flake_ref.as_ref()].iter());
     command.add_args(["--argstr", "flake", flake_ref.as_ref()].iter());
     command.add_arg(kind.as_ref());


### PR DESCRIPTION
Makes `nix run nixos-search#flake-info flake ...` succeed with an empty `NIX_PATH`.