### PR TITLE
Flakes search: Include flake name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ better queries which in turn will produce better results.
 To start developing open a terminal and run:
 
 ```
-nix-shell --run "cd frontend && yarn dev"
+env --chdir=frontend nix develop -c yarn dev
 ```
 
 You can point your browser to `http://localhost:3000` and start developing.

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -402,6 +402,7 @@ makeRequestBody query from size sort =
         [ ( "option_name", 6.0 )
         , ( "option_name_query", 3.0 )
         , ( "option_description", 1.0 )
+        , ( "flake_name", 0.5 )
         ]
 
 

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -807,6 +807,7 @@ makeRequestBody query from size maybeBuckets sort =
         , ( "package_attr_name_query", 4.0 )
         , ( "package_description", 1.3 )
         , ( "package_longDescription", 1.0 )
+        , ( "flake_name", 0.5 )
         ]
 
 


### PR DESCRIPTION
This allows listing all packages or options of a specific flake.

To test this, compare
- [localhost:3000/flakes/cargo](http://localhost:3000/flakes?channel=22.05&from=0&size=50&sort=relevance&type=packages&query=cargo)
- [search.nixos.org/flakes/cargo](https://search.nixos.org/flakes?channel=unstable&from=0&size=30&sort=relevance&type=packages&query=cargo)

#### Backend issues
The elasticsearch backend doesn't work properly with hyphens in Flake names:
```bash
# This only queries field `flake_name` 
queryPackages() {
    query=$1
    curl -fsS 'https://nixos-search-5886075189.us-east-1.bonsaisearch.net/latest-31-group-manual/_search' \
         -X POST -H 'Authorization: Basic ejNaRko2eTJtUjpkczhDRXZBTFBmOXB1aTdYRw==' \
         -H 'Content-Type: application/json' \
         --data-raw '
           {
             "query": {
               "bool": {
                 "filter": [ {"term": {"type": {"value": "package", "_name": "filter_packages"}}} ],
                 "must": [
                   {
                     "dis_max": {
                       "queries": [
                         {
                           "multi_match": {
                             "query": "'"$query"'",
                             "type": "cross_fields",
                             "analyzer": "whitespace",
                             "auto_generate_synonyms_phrase_query": false,
                             "operator": "and",
                             "fields": [
                               "flake_name"
                             ]
                           }
                         }
                       ]
                     }
                   }
                 ]
               }
             }
           }
         ' | jq '.hits.hits | map("\(._source.flake_name) - \(._source.package_attr_name)")'
}

queryPackages nickel
#=> all packages from `nickel`

queryPackages hydra
#=> all packages from `hydra`

queryPackages nix-cargo-integration
#=> none

queryPackages cargo
#=> all packages from `nix-cargo-integration`

queryPackages integration
#=> none
```
Is there a simple way to fix this?