### PR TITLE
Don't panic during export

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -1,11 +1,17 @@
 /// This module defines the unified putput format as expected by the elastic search
 /// Additionally, we implement converseions from the two possible input formats, i.e.
 /// Flakes, or Nixpkgs.
-use std::{convert::{TryInto, TryFrom}, path::PathBuf};
+use std::{
+    convert::{TryFrom, TryInto},
+    path::PathBuf,
+};
 
-use super::{import::{DocValue, ModulePath}, pandoc::PandocExt};
-use anyhow::Context;
+use super::{
+    import::{DocValue, ModulePath},
+    pandoc::PandocExt,
+};
 use crate::data::import::NixOption;
+use anyhow::Context;
 use log::error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -499,6 +499,7 @@ mod tests {
         let exports = sources
             .iter()
             .flat_map(|s| process_flake(s, &Kind::All, false, &[]))
+            .map(|(info, exports)| exports)
             .flatten()
             .collect::<Vec<Export>>();
         println!("{}", serde_json::to_string(&exports[1]).unwrap());

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use data::{import::Kind, Export, Source, Flake};
+use data::{import::Kind, Export, Flake, Source};
 
 pub mod commands;
 pub mod data;
@@ -48,6 +48,9 @@ pub fn process_nixpkgs(nixpkgs: &Source, kind: &Kind) -> Result<Vec<Export>, any
     let mut all = drvs;
     all.append(&mut options);
 
-    let exports = all.into_iter().map(Export::nixpkgs).collect::<Result<Vec<Export>>>()?;
+    let exports = all
+        .into_iter()
+        .map(Export::nixpkgs)
+        .collect::<Result<Vec<Export>>>()?;
     Ok(exports)
 }

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use data::{import::Kind, Export, Source};
+use data::{import::Kind, Export, Source, Flake};
 
 pub mod commands;
 pub mod data;
@@ -17,7 +17,7 @@ pub fn process_flake(
     kind: &data::import::Kind,
     temp_store: bool,
     extra: &[String],
-) -> Result<Vec<Export>> {
+) -> Result<(Flake, Vec<Export>)> {
     let mut info = commands::get_flake_info(source.to_flake_ref(), temp_store, extra)?;
     info.source = Some(source.clone());
     let packages = commands::get_derivation_info(source.to_flake_ref(), *kind, temp_store, extra)?;
@@ -27,9 +27,9 @@ pub fn process_flake(
     let exports: Vec<Export> = packages
         .into_iter()
         .map(|p| Export::flake(info.clone(), p))
-        .collect();
+        .collect::<Result<Vec<Export>>>()?;
 
-    Ok(exports)
+    Ok((info, exports))
 }
 
 pub fn process_nixpkgs(nixpkgs: &Source, kind: &Kind) -> Result<Vec<Export>, anyhow::Error> {
@@ -48,6 +48,6 @@ pub fn process_nixpkgs(nixpkgs: &Source, kind: &Kind) -> Result<Vec<Export>, any
     let mut all = drvs;
     all.append(&mut options);
 
-    let exports = all.into_iter().map(Export::nixpkgs).collect();
+    let exports = all.into_iter().map(Export::nixpkgs).collect::<Result<Vec<Export>>>()?;
     Ok(exports)
 }


### PR DESCRIPTION
Avoid panicking if export fails for a single flake, e.g. if Pandoc fails to render the description. (Flake import is currently stuck because of nix-bitcoin...)

Also make sure that `get_flake_info` is only called once per flake.