### PR TITLE
Disallow Import From Derivation in flakes

### DIFF
--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 const SCRIPT: &str = include_str!("flake_info.nix");
-const ARGS: [&str; 3] = ["eval", "--json", "--no-write-lock-file"];
+const ARGS: [&str; 5] = ["eval", "--json", "--no-allow-import-from-derivation", "--read-only", "--no-write-lock-file"];
 
 /// Uses `nix` to fetch the provided flake and read general information
 /// about it using `nix flake info`


### PR DESCRIPTION
I think it is surprising that `flake-info` tries to build things in order to index flakes. Hence, forbid IFD.

`--read-only` is for performance, see https://github.com/NixOS/nix/pull/6323

Ping @srid since your flake (emanote) is currently the only one that uses IFD (but note that it fails even with IFD: `error: a 'aarch64-darwin' with features {} is required to build ...`, so it's not indexed currently)

Ping @erikarvstedt because why not