### PR TITLE
flake-info: remove `--read-only`

### DIFF
--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -9,7 +9,12 @@ use std::io::Write;
 use std::path::PathBuf;
 
 const SCRIPT: &str = include_str!("flake_info.nix");
-const ARGS: [&str; 5] = ["eval", "--json", "--no-allow-import-from-derivation", "--read-only", "--no-write-lock-file"];
+const ARGS: [&str; 4] = [
+    "eval",
+    "--json",
+    "--no-allow-import-from-derivation",
+    "--no-write-lock-file",
+];
 
 /// Uses `nix` to fetch the provided flake and read general information
 /// about it using `nix flake info`


### PR DESCRIPTION
For reasons I don't fully understand, some flakes succeed being indexed with `--no-allow-import-from-derivation` but fail if `--read-only` is added. See https://github.com/NixOS/nixos-search/pull/502#issuecomment-1193277053