### PR TITLE
Revert "flake-info: remove `--read-only` (#504)"

### DIFF
--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -9,10 +9,11 @@ use std::io::Write;
 use std::path::PathBuf;
 
 const SCRIPT: &str = include_str!("flake_info.nix");
-const ARGS: [&str; 4] = [
+const ARGS: [&str; 5] = [
     "eval",
     "--json",
     "--no-allow-import-from-derivation",
+    "--read-only",
     "--no-write-lock-file",
 ];
 


### PR DESCRIPTION
Reverts NixOS/nixos-search#504, see https://github.com/NixOS/nixos-search/pull/502#issuecomment-1193305553

The issue with some flakes is really a bug with those flakes (needlessly copying paths to the store for evaluation) rather than a bug with Nix.

(sorry for the back-and-forth)