### PR TITLE
Remove Loading from title

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NixOS Search - Loading...</title>
+  <title>NixOS Search</title>
 
 
   <script type="text/javascript" src="https://nixos.org/js/jquery.min.js"></script>


### PR DESCRIPTION
Removing a small annoyance.

"Loading" used to show up in discourse links, looking silly.

"Loading" didn't really add information. If it loads slowly or not
at all, the result will be quite obvious, and often the bit that
says "Loading" doesn't even fit in the browser tab label.