### PR TITLE
encourage NixOS configuration, nix-shell and discourage nix-env

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -616,8 +616,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     , class "tab-pane"
                                     , id "package-details-nixpkgs"
                                     ]
-                                    [ pre [ class "code-block" ]
-                                        [ text "$ nix-env -iA nixos."
+                                    [ pre [ class "code-block shell-command" ]
+                                        [ text "nix-env -iA nixos."
                                         , strong [] [ text item.source.attr_name ]
                                         ]
                                     ]
@@ -638,8 +638,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     , class "tab-pane"
                                     , id "package-details-nixpkgs"
                                     ]
-                                    [ pre [ class "code-block" ]
-                                        [ text "$ nix-env -iA nixpkgs."
+                                    [ pre [ class "code-block shell-command" ]
+                                        [ text "nix-env -iA nixpkgs."
                                         , strong [] [ text item.source.attr_name ]
                                         ]
                                     ]
@@ -666,8 +666,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     , class "tab-pane"
                                     , id "package-details-nixpkgs"
                                     ]
-                                    [ pre [ class "code-block" ]
-                                        [ text "$ nix-shell -p "
+                                    [ pre [ class "code-block shell-command" ]
+                                        [ text "nix-shell -p "
                                         , strong [] [ text item.source.attr_name ]
                                         ]
                                     ]
@@ -704,8 +704,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                                 , ( "active", True )
                                                 ]
                                             ]
-                                            [ pre [ class "code-block" ]
-                                                [ text "$ nix build "
+                                            [ pre [ class "code-block shell-command" ]
+                                                [ text "nix build "
                                                 , strong [] [ text url ]
                                                 , text "#"
                                                 , em [] [ text item.source.attr_name ]

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -515,7 +515,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                             Maybe.withDefault
                                 [ li
                                     [ classList
-                                        [ ( "active", List.member showInstallDetails [ Search.Unset, Search.FromNixOS, Search.FromFlake ] )
+                                        [ ( "active", List.member showInstallDetails [ Search.Unset, Search.ViaNixOS, Search.FromFlake ] )
                                         , ( "pull-right", True )
                                         ]
                                     ]
@@ -523,13 +523,13 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         [ href "#"
                                         , Search.onClickStop <|
                                             SearchMsg <|
-                                                Search.ShowInstallDetails Search.FromNixOS
+                                                Search.ShowInstallDetails Search.ViaNixOS
                                         ]
-                                        [ text "On NixOS" ]
+                                        [ text "NixOS Configuration" ]
                                     ]
                                 , li
                                     [ classList
-                                        [ ( "active", showInstallDetails == Search.FromNixpkgs )
+                                        [ ( "active", showInstallDetails == Search.ViaNixShell )
                                         , ( "pull-right", True )
                                         ]
                                     ]
@@ -537,9 +537,23 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         [ href "#"
                                         , Search.onClickStop <|
                                             SearchMsg <|
-                                                Search.ShowInstallDetails Search.FromNixpkgs
+                                                Search.ShowInstallDetails Search.ViaNixShell
                                         ]
-                                        [ text "On non-NixOS" ]
+                                        [ text "nix-shell" ]
+                                    ]
+                                , li
+                                    [ classList
+                                        [ ( "active", showInstallDetails == Search.ViaNixEnv )
+                                        , ( "pull-right", True )
+                                        ]
+                                    ]
+                                    [ a
+                                        [ href "#"
+                                        , Search.onClickStop <|
+                                            SearchMsg <|
+                                                Search.ShowInstallDetails Search.ViaNixEnv
+                                        ]
+                                        [ text "nix-env" ]
                                     ]
                                 ]
                             <|
@@ -568,25 +582,116 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                             Maybe.withDefault
                                 [ div
                                     [ classList
-                                        [ ( "active", showInstallDetails == Search.FromNixpkgs )
+                                        [ ( "tab-pane", True )
+                                        , ( "active", showInstallDetails == Search.ViaNixEnv )
+                                        ]
+                                    ]
+                                    [ p []
+                                        [ strong [] [ text "Warning:" ]
+                                        , text """
+                                            Using nix-env permanently modifies a
+                                            local profile of installed packages.
+                                            This must be cleaned up, updated and
+                                            maintained by the user, in the same
+                                            way as a traditional package
+                                            manager. Using nix-shell or a NixOS
+                                            configuration is recommended
+                                            instead.
+                                          """
+                                        ]
+                                    ]
+                                , div
+                                    [ classList
+                                        [ ( "active", showInstallDetails == Search.ViaNixEnv )
+                                        ]
+                                    , class "tab-pane"
+                                    ]
+                                    [ p []
+                                        [ strong [] [ text "On NixOS:" ] ]
+                                    ]
+                                , div
+                                    [ classList
+                                        [ ( "active", showInstallDetails == Search.ViaNixEnv )
                                         ]
                                     , class "tab-pane"
                                     , id "package-details-nixpkgs"
                                     ]
                                     [ pre [ class "code-block" ]
-                                        [ text "nix-env -iA nixpkgs."
+                                        [ text "$ nix-env -iA nixos."
+                                        , strong [] [ text item.source.attr_name ]
+                                        ]
+                                    ]
+                                , div [] [ p [] [] ]
+                                , div
+                                    [ classList
+                                        [ ( "active", showInstallDetails == Search.ViaNixEnv )
+                                        ]
+                                    , class "tab-pane"
+                                    ]
+                                    [ p []
+                                        [ strong [] [ text "On Non NixOS:" ] ]
+                                    ]
+                                , div
+                                    [ classList
+                                        [ ( "active", showInstallDetails == Search.ViaNixEnv )
+                                        ]
+                                    , class "tab-pane"
+                                    , id "package-details-nixpkgs"
+                                    ]
+                                    [ pre [ class "code-block" ]
+                                        [ text "$ nix-env -iA nixpkgs."
                                         , strong [] [ text item.source.attr_name ]
                                         ]
                                     ]
                                 , div
                                     [ classList
                                         [ ( "tab-pane", True )
-                                        , ( "active", List.member showInstallDetails [ Search.Unset, Search.FromNixOS, Search.FromFlake ] )
+                                        , ( "active", showInstallDetails == Search.ViaNixShell )
+                                        ]
+                                    ]
+                                    [ p []
+                                        [ text """
+                                            A nix-shell will temporarily modify
+                                            your $PATH environment variable.
+                                            This can be used to try a piece of
+                                            software before deciding to
+                                            permanently install it.
+                                          """
+                                        ]
+                                    ]
+                                , div
+                                    [ classList
+                                        [ ( "active", showInstallDetails == Search.ViaNixShell )
+                                        ]
+                                    , class "tab-pane"
+                                    , id "package-details-nixpkgs"
+                                    ]
+                                    [ pre [ class "code-block" ]
+                                        [ text "$ nix-shell -p "
+                                        , strong [] [ text item.source.attr_name ]
+                                        ]
+                                    ]
+                                , div
+                                    [ classList
+                                        [ ( "tab-pane", True )
+                                        , ( "active", List.member showInstallDetails [ Search.Unset, Search.ViaNixOS, Search.FromFlake ] )
+                                        ]
+                                    ]
+                                    [ p []
+                                        [ text "Add the following Nix code to your NixOS Configuration, usually located in "
+                                        , strong [] [ text "/etc/nixos/configuration.nix" ]
+                                        ]
+                                    ]
+                                , div
+                                    [ classList
+                                        [ ( "tab-pane", True )
+                                        , ( "active", List.member showInstallDetails [ Search.Unset, Search.ViaNixOS, Search.FromFlake ] )
                                         ]
                                     ]
                                     [ pre [ class "code-block" ]
-                                        [ text <| "nix-env -iA nixos."
+                                        [ text <| "  environment.systemPackages = [\n    pkgs."
                                         , strong [] [ text item.source.attr_name ]
+                                        , text <| "    \n  ];"
                                         ]
                                     ]
                                 ]
@@ -600,7 +705,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                                 ]
                                             ]
                                             [ pre [ class "code-block" ]
-                                                [ text "nix build "
+                                                [ text "$ nix build "
                                                 , strong [] [ text url ]
                                                 , text "#"
                                                 , em [] [ text item.source.attr_name ]

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -506,6 +506,11 @@ viewResultItem nixosChannels channel showInstallDetails show item =
             optionals (Just item.source.attr_name == show)
                 [ div [ trapClick ]
                     (div []
+                        (item.source.longDescription
+                            |> Maybe.map (\desc -> [ p [] [ text desc ] ])
+                            |> Maybe.withDefault []
+                        )
+                    :: div []
                         [ h4 []
                             [ text "How to install "
                             , em [] [ text item.source.attr_name ]
@@ -716,12 +721,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                 <|
                                     Maybe.map Tuple.first item.source.flakeUrl
                         ]
-                        :: ((item.source.longDescription
-                                |> Maybe.map (\desc -> [ p [] [ text desc ] ])
-                                |> Maybe.withDefault []
-                            )
-                                ++ maintainersAndPlatforms
-                           )
+                        :: maintainersAndPlatforms
                     )
                 ]
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -384,8 +384,9 @@ type Msg a b
 
 
 type Details
-    = FromNixpkgs
-    | FromNixOS
+    = ViaNixShell
+    | ViaNixOS
+    | ViaNixEnv
     | FromFlake
     | Unset
 

--- a/frontend/src/index.less
+++ b/frontend/src/index.less
@@ -388,8 +388,13 @@ header .navbar.navbar-static-top {
               margin: 2em 0 1em 1em;
               text-align: left;
 
-              // how to install a package
+              // long description of a package
               & > :nth-child(1) {
+                margin-top: 1em;
+              }
+
+              // how to install a package
+              & > :nth-child(2) {
 
                 h4 {
                   font-size: 1.2em;
@@ -415,11 +420,6 @@ header .navbar.navbar-static-top {
                   .terminal();
                 }
 
-              }
-
-              // long description of a package
-              & > :nth-child(2) {
-                margin-top: 1em;
               }
 
               // maintainers and platforms

--- a/frontend/src/index.less
+++ b/frontend/src/index.less
@@ -63,6 +63,10 @@ body {
   cursor: text;
 }
 
+.shell-command:before {
+  content: "$ ";
+}
+
 #content {
   padding-bottom: 4rem;
 }

--- a/frontend/src/index.less
+++ b/frontend/src/index.less
@@ -6,10 +6,6 @@
   background: #333;
   color: #fff;
   margin: 0;
-
-  &:before {
-    content: "$ "
-  }
 }
 
 


### PR DESCRIPTION
This would close https://github.com/NixOS/nixos-search/issues/508

# High level changes

1. `nix-env` now has a warning associated with it, which explains that it has side-effects which may require cleanup by the user manually after usage like a traditional package manager.
2. NixOS configuration(s) and nix-shell have now got a tab on each package, which explains how to use `environment.systemPackages` or `nix-shell -p`.

# Internal changes

1. I have replaced `FromNixOS` and `FromNixpkgs` with `ViaNixOS`, `ViaNixShell` and `ViaNixEnv`
2. I have removed the `$` before every instance of `.terminal` in `frontend/src/index.less` because I was not easily able to case split on imperative cmds like `nix-shell -p` and the code for a NixOS configuration. Instead, `$` has been placed manually into each text field where a command is imperative, such as `nix build` for flakes and `nix-shell`.
3. I'm no ELM expert, so have likely made wrong use of the `div` function, and would appreciate someone to help with that

# What it looks like

### NixOS Configuration
![image](https://user-images.githubusercontent.com/26458780/183269139-f1be60e3-5eae-4853-b93e-bea5dbaa3866.png)

### nix-shell
![image](https://user-images.githubusercontent.com/26458780/183269551-560abca3-5c1f-411c-9221-8ff037c68f38.png)

### nix-env
![image](https://user-images.githubusercontent.com/26458780/183269142-3919c45e-b117-4302-9888-cf8f5f5cf268.png)

