### PR TITLE
frontend: remove trailing whitespace in installation instructions

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -696,7 +696,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     [ pre [ class "code-block" ]
                                         [ text <| "  environment.systemPackages = [\n    pkgs."
                                         , strong [] [ text item.source.attr_name ]
-                                        , text <| "    \n  ];"
+                                        , text <| "\n  ];"
                                         ]
                                     ]
                                 ]


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixos-search/issues/521