### PR TITLE
Ignore `_module` options for flakes

### DIFF
--- a/flake-info/src/commands/flake_info.nix
+++ b/flake-info/src/commands/flake_info.nix
@@ -51,8 +51,6 @@ let
           (
             { ... }: {
               _module.check = false;
-              nixpkgs.system = lib.mkDefault "x86_64-linux";
-              nixpkgs.config.allowBroken = true;
             }
           )
         ];
@@ -93,7 +91,7 @@ let
         flake = modulePath;
       };
     in
-      map (cleanUpOption extraAttrs) (lib.filter (x: x.visible && !x.internal) opts);
+      map (cleanUpOption extraAttrs) (lib.filter (x: x.visible && !x.internal && lib.head x.loc != "_module") opts);
 
   readFlakeOptions = let
     nixosModulesOpts = builtins.concatLists (lib.mapAttrsToList (moduleName: module:


### PR DESCRIPTION
Having the documentation for `_module.args` in the nixpkgs options is useful, but there's no need to have a copy of it per flake module.

![](https://f.monade.li/-lC6Cp.png)

Accidentally fixes https://github.com/NixOS/nixos-search/issues/534