### PR TITLE
Allow elastic feature to be disabled

### DIFF
--- a/flake-info/Cargo.toml
+++ b/flake-info/Cargo.toml
@@ -27,7 +27,11 @@ sha2 = "0.9"
 pandoc = "0.8"
 semver = "1.0"
 
-elasticsearch = {git = "https://github.com/elastic/elasticsearch-rs", features = ["rustls-tls"]}
+elasticsearch = {git = "https://github.com/elastic/elasticsearch-rs", features = ["rustls-tls"], optional = true}
+
+[features]
+default = ["elastic"]
+elastic = ["elasticsearch"]
 
 [lib]
 name = "flake_info"

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -5,6 +5,8 @@ use data::{import::Kind, Export, Flake, Source};
 
 pub mod commands;
 pub mod data;
+
+#[cfg(feature = "elastic")]
 pub mod elastic;
 
 pub use commands::get_flake_info;


### PR DESCRIPTION
If using flake-info as a library, the elastic dependency is likely to be undesirable.
This allows to disable the elastic feature and in turn compiles libflox-info without support for elasticsearch

resolves #523