### PR TITLE
Add nix-vscode-marketplace Source

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -118,3 +118,8 @@ repo = "haskell.nix"
 type = "sourcehut"
 owner = "~munksgaard"
 repo = "geomyidae-flake"
+
+[[sources]]
+type = "github"
+owner = "AmeerTaweel"
+repo = "nix-vscode-marketplace"


### PR DESCRIPTION
I tested by running:

```bash
nix run github:nixos/nixos-search#flake-info -- flake github:AmeerTaweel/nix-vscode-marketplace
```

And got no errors.