### PR TITLE
Add dolphin-emu-nix to the flakes index

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -128,3 +128,8 @@ repo = "geomyidae-flake"
 type = "github"
 owner = "matthewcroughan"
 repo = "filestash-nix"
+
+[[sources]]
+type = "github"
+owner = "matthewcroughan"
+repo = "dolphin-emu-nix"


### PR DESCRIPTION
Adds an auto updating Flake to the index for dolphin-emu, it is similar to flake-firefox-nightly in what it achieves.