### PR TITLE
.github: re-add access token

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,5 +1,8 @@
 name: Setup Environment
 inputs:
+  GITHUB_TOKEN:
+    required: true
+    description: 'GitHub access token'
   CACHIX_SIGNING_KEY: # determines what node version to install
     required: true
     description: 'Cachix Signing Key'
@@ -8,11 +11,13 @@ runs:
   steps:
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
+        extra_nix_config: |
+          access-tokens = github.com=${{ inputs.GITHUB_TOKEN }}
 
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v12
       with:
         name: nixos-search
         signingKey: '${{ inputs.CACHIX_SIGNING_KEY }}'

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -2,7 +2,7 @@ name: Setup Environment
 inputs:
   GITHUB_TOKEN:
     required: true
-    description: 'GitHub access token'
+    description: 'GitHub access token used to prevent GitHub's rate limit for unauthenticated requests'
   CACHIX_SIGNING_KEY: # determines what node version to install
     required: true
     description: 'Cachix Signing Key'

--- a/.github/workflows/build-flake-info.yml
+++ b/.github/workflows/build-flake-info.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
 

--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
     - name: Try importing all custom flakes

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
 

--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
     - name: NixOS Channels
@@ -50,6 +51,7 @@ jobs:
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
     - name: Import ${{ matrix.channel }} channel
@@ -89,6 +91,7 @@ jobs:
     - name: Setup
       uses: ./.github/actions/common-setup
       with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
     - name: Import ${{ matrix.group }} group


### PR DESCRIPTION
Prevents [hitting](https://github.com/NixOS/nixos-search/actions/runs/3345951892/jobs/5542138556#step:4:57) GitHub's API rate limits.

This was removed in https://github.com/NixOS/nixos-search/pull/415 because I didn't understand what it was for.

~N.B. I don't know if accessing `secrets` in the action file works, do we need an `inputs.GITHUB_TOKEN`?~ EDIT: nope, it [doesn't](https://github.com/NixOS/nixos-search/actions/runs/3346133543/jobs/5542554665#step:3:2).

EDIT 2: [works fine now](https://github.com/NixOS/nixos-search/actions/runs/3346157934/jobs/5542610636).