### PR TITLE
Make search query default to `show` if given

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -313,6 +313,9 @@ init args defaultNixOSChannel nixosChannels maybeModel =
       , query =
             args.query
                 |> Maybe.andThen Route.SearchQuery.searchQueryToString
+                |> \ x -> case x of
+                    Just q -> Just q
+                    Nothing -> args.show
       , result = getField .result RemoteData.NotAsked
       , show = args.show
       , from =


### PR DESCRIPTION
This allows for shorter permalinks for displaying a given package, see https://github.com/NixOS/nixos-search/issues/540.