### PR TITLE
Replace PolyMC with PrismLauncher in the index

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -84,8 +84,8 @@ url = "git+https://git.sr.ht/~kerstin/sway-timetracker?ref=main"
 
 [[sources]]
 type = "github"
-owner = "PolyMC"
-repo = "PolyMC"
+owner = "PrismLauncher"
+repo = "PrismLauncher"
 
 [[sources]]
 type = "gitlab"


### PR DESCRIPTION
- PolyMC was marked as insecure in nixpkgs after one of its maintainers went rogue, removing all of the other maintainers
- The removed maintainers made a fork, [PrismLauncher](https://github.com/PrismLauncher/PrismLauncher)
- As by design PolyMC downloads code from a server (now controlled by that maintainer), [this warranted replacing PolyMC in nixpkgs with its successor, prismlauncher](https://github.com/NixOS/nixpkgs/pull/196624#issuecomment-1284449789)

This PR makes the same change to the flakes search index that has already been made in nixpkgs.

###### Reference issues/PRs:
- https://github.com/NixOS/nixpkgs/issues/196460
- https://github.com/NixOS/nixpkgs/pull/196624
- https://github.com/NixOS/nixpkgs/issues/196480