### PR TITLE
Give more license to the license field

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -30,16 +30,19 @@ impl From<import::License> for License {
         match license {
             import::License::None { .. } => License {
                 url: None,
-                fullName: "No License Specified".to_string(),
+                fullName: "no license specified".to_string(),
             },
             import::License::Simple { license } => License {
                 url: None,
                 fullName: license,
             },
-            import::License::Full { fullName, url, .. } => License { url, fullName },
-            import::License::Url { url } => License {
-                url: Some(url),
-                fullName: "No Name".into(),
+            import::License::Full {
+                fullName,
+                shortName,
+                url,
+            } => License {
+                url,
+                fullName: fullName.unwrap_or(shortName.unwrap_or("custom".into())),
             },
         }
     }

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -264,12 +264,9 @@ pub enum License {
     },
     #[allow(non_snake_case)]
     Full {
-        fullName: String,
-        // shortName: String,
+        fullName: Option<String>,
+        shortName: Option<String>,
         url: Option<String>,
-    },
-    Url {
-        url: String,
     },
 }
 


### PR DESCRIPTION
Licenses in nixpkgs aren't required to contain a `fullName` *or* a `shortName` field: for example, [altermime](https://github.com/NixOS/nixpkgs/blob/758e5af4cd3e9d73d4f94fec1e2b02130e04c727/pkgs/tools/networking/altermime/default.nix#L29) only has a `fullName` while [getLicenseFromSpdxId](https://github.com/NixOS/nixpkgs/blob/758e5af4cd3e9d73d4f94fec1e2b02130e04c727/lib/meta.nix#L127) only returns a `shortName` for unknown SPDX IDs. Since no particular format is enforced in nixpkgs, and we want to [be resilient to upstream issues](https://github.com/NixOS/nixos-search/issues/391), we should make both fields optional for now.