### PR TITLE
flake-info: remove broken `NIXOS_CHANNELS` check

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -1,5 +1,4 @@
 { pkgs ? import <nixpkgs> {}
-, nixosChannels ? {}
 }:
 pkgs.rustPlatform.buildRustPackage rec {
   name = "flake-info";
@@ -34,7 +33,6 @@ pkgs.rustPlatform.buildRustPackage rec {
     cp -rt "$out" assets
 
     wrapProgram $out/bin/flake-info \
-      --set NIXOS_CHANNELS '${builtins.toJSON nixosChannels}' \
       --prefix PATH : ${pkgs.pandoc}/bin
   '';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
         in rec {
 
           packages.default = packages.flake-info;
-          packages.flake-info = import ./flake-info { inherit pkgs nixosChannels; };
+          packages.flake-info = import ./flake-info { inherit pkgs; };
           packages.frontend = import ./frontend { inherit pkgs nixosChannels version; };
           packages.nixosChannels = nixosChannelsFile;
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixos-search/issues/585

The feature is broken in two different ways that, by luck, cancel each other out (well, three if you count the above issue).

- The branches of the `map_or_else` call [here](https://github.com/NixOS/nixos-search/blob/d04f341a5d3b4a865249d743b80a198f55729473/flake-info/src/bin/flake-info.rs#L419-L427) are swapped, so that we only raise an error if the channel **is found** in `NIXOS_CHANNEL`
- ... luckily the `find` call just above it is also broken: we're matching a `channel` of the form `XX.YY` against a `branch` attribute that looks like `nixos-XX.YY`, so it never finds anything.

I don't think we should have this feature at all since AFAICT it serves no real purpose and would prevent people from running flake-info on older nixpkgs revisions for testing purposes. I initially asked this [here](https://github.com/NixOS/nixos-search/pull/455#discussion_r851768736) but got no answer.