### PR TITLE
Improve accessibility for screenreader users

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -1056,7 +1056,7 @@ viewResults nixosChannels model result viewSuccess _ outMsg categoryName =
     in
     [ div []
         [ Html.map outMsg <| viewSortSelection model
-        , div []
+        , h2 []
             (List.append
                 [ text "Showing results "
                 , text from

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -320,8 +320,9 @@ header .navbar.navbar-static-top {
         }
 
         // Text that displays number of results
-        & > div:nth-child(2) {
+        & > h2:nth-child(2) {
           font-size: 1.7em;
+          font-weight: normal;
           line-height: 1.3em;
 
           & > p {


### PR DESCRIPTION
People that navigate the web using a screenreader use headings to navigate faster on a website.

With this change, blind users can more easily go to the search results.

