### PR TITLE
flake-info: update manpage filter

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -24,7 +24,8 @@ pkgs.rustPlatform.buildRustPackage rec {
   checkInputs = with pkgs; [ pandoc ];
 
   ROOTDIR = builtins.placeholder "out";
-  NIXPKGS_PANDOC_FILTERS_PATH = "${pkgs.path + "/doc/build-aux/pandoc-filters"}";
+  NIXPKGS_PANDOC_FILTERS_PATH = pkgs.path + "/doc/build-aux/pandoc-filters";
+  LINK_MANPAGES_PANDOC_FILTER = import (pkgs.path + "/doc/build-aux/pandoc-filters/link-manpages.nix") { inherit pkgs; };
 
   checkFlags = [
     "--skip elastic::tests"

--- a/flake-info/src/data/pandoc.rs
+++ b/flake-info/src/data/pandoc.rs
@@ -10,8 +10,7 @@ lazy_static! {
         Path::new(FILTERS_PATH).join("docbook-reader/citerefentry-to-rst-role.lua");
     static ref MARKDOWN_ROLES_FILTER: PathBuf =
         Path::new(FILTERS_PATH).join("myst-reader/roles.lua");
-    static ref MANPAGE_LINK_FILTER: PathBuf =
-        Path::new(FILTERS_PATH).join("link-unix-man-references.lua");
+    static ref MANPAGE_LINK_FILTER: PathBuf = PathBuf::from(env!("LINK_MANPAGES_PANDOC_FILTER"));
     static ref XREF_FILTER: PathBuf = crate::DATADIR.join("data/fix-xrefs.lua");
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667629849,
-        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "lastModified": 1673315479,
+        "narHash": "sha256-GNCFRtDHjTygXGJp/H+f2XQPMGxpYSmNiibIqYzihtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "rev": "c07552f6f7d4eead7806645ec03f7f1eb71ba6bd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
             extraShellHook = ''
               export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
               export NIXPKGS_PANDOC_FILTERS_PATH="${packages.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
+              export LINK_MANPAGES_PANDOC_FILTER="${packages.flake-info.LINK_MANPAGES_PANDOC_FILTER}";
               export PATH=$PWD/frontend/node_modules/.bin:$PATH
             '';
           };
@@ -111,6 +112,7 @@
             extraShellHook = ''
               export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
               export NIXPKGS_PANDOC_FILTERS_PATH="${packages.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
+              export LINK_MANPAGES_PANDOC_FILTER="${packages.flake-info.LINK_MANPAGES_PANDOC_FILTER}";
             '';
           };
 


### PR DESCRIPTION
Update nixpkgs and adapt to the changes in https://github.com/NixOS/nixpkgs/pull/208762: the link-manpages filter is now generated using Nix.

NixOS options already have manpage links in `options.json`, but we should still keep the filter for flakes. The filter does not add [double links](https://github.com/NixOS/nixpkgs/pull/208762/files#diff-69364cc9f324cdeb2698134a3cb943a44b656981bfc943b7bec030df45e288dfR17-R20) any more so this is harmless.