### PR TITLE
Add Java Mission Control flake to public flakes search

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -138,3 +138,8 @@ repo = "geomyidae-flake"
 type = "github"
 owner = "matthewcroughan"
 repo = "filestash-nix"
+
+[[sources]]
+type = "github"
+owner = "SeineEloquenz"
+repo = "java-mission-control-nix"


### PR DESCRIPTION
This flake packages a binary distribution of [Adoptium Java Mission Control/Eclipse Mission Control](https://adoptium.net/jmc/). Flake source can be found [here](https://github.com/SeineEloquenz/java-mission-control-nix)