### PR TITLE
flake-info: support platform patterns

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -202,19 +202,11 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     .map(|l: &License| l.fullName.to_owned())
                     .collect();
 
-                let platforms: HashSet<String> = package
-                    .meta
-                    .platforms
-                    .map_or(Default::default(), Flatten::flatten)
-                    .into_iter()
-                    .collect();
+                let platforms: HashSet<String> =
+                    package.meta.platforms.unwrap_or_default().collect();
 
-                let bad_platforms: HashSet<String> = package
-                    .meta
-                    .bad_platforms
-                    .map_or(Default::default(), Flatten::flatten)
-                    .into_iter()
-                    .collect();
+                let bad_platforms: HashSet<String> =
+                    package.meta.bad_platforms.unwrap_or_default().collect();
 
                 let platforms: Vec<String> =
                     platforms.difference(&bad_platforms).cloned().collect();

--- a/flake-info/src/data/utility.rs
+++ b/flake-info/src/data/utility.rs
@@ -39,6 +39,12 @@ impl<T: Clone> Flatten<T> {
     }
 }
 
+impl<T> Default for Flatten<T> {
+    fn default() -> Self {
+        Flatten::Deep(Vec::new())
+    }
+}
+
 // TODO: use this or a to_ist function?
 /// Serialization helper that serializes single elements as a list with a single
 /// item


### PR DESCRIPTION
nixpkgs currently [defines](https://github.com/NixOS/nixpkgs/blob/6877dd6b9e85d2d0d538042db3f8d20eac6865a2/lib/meta.nix#L72-L85) three ways of specifying elements of `meta.{platforms,badPlatforms}`:

1. as a string; this is okay
2. as a *pattern*, which is an attribute set meant to match a platform's `parsed` field (or possibly in the future an entire platform, see https://github.com/NixOS/nixpkgs/pull/212939). This has apparently been a thing for a long time but wasn't used until [about a week ago](https://github.com/NixOS/nixpkgs/pull/210259). For now, just skip them without causing an error. Later, maybe figure out a way to display them properly.
3. as a function platform → bool; this causes nix-env to emit `null` which is [not great](https://github.com/NixOS/nixpkgs/pull/192197#issuecomment-1402244780) but at least we support it fine.

For reference, the `isGnu` list of patterns looks like this:

```nix
[
  { abi = { _type = "abi"; abi = "64"; name = "gnuabi64"; }; }
  { abi = { _type = "abi"; name = "gnu"; }; }
  { abi = { _type = "abi"; float = "soft"; name = "gnueabi"; }; }
  { abi = { _type = "abi"; float = "hard"; name = "gnueabihf"; }; }
  { abi = { _type = "abi"; abi = "elfv1"; name = "gnuabielfv1"; }; }
  { abi = { _type = "abi"; abi = "elfv2"; name = "gnuabielfv2"; }; }
]
```

so the old `System` struct we removed in https://github.com/NixOS/nixos-search/pull/580 wouldn't have helped here.