### PR TITLE
Open issue on failing import

### DIFF
--- a/.github/failing-import-issue.md
+++ b/.github/failing-import-issue.md
@@ -1,0 +1,4 @@
+---
+title: Failing import for nixpkgs {{ env.CHANNEL }}
+labels: prio:blocker
+---

--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -5,6 +5,10 @@ on:
   schedule:
   - cron: '0 * * * *'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
 
   nixos-channels:
@@ -68,6 +72,16 @@ jobs:
         done
       if: github.repository_owner == 'NixOS'
 
+    - name: Create issue if failed
+      if: failure()
+      uses: JasonEtco/create-an-issue@v2
+      with:
+        filename: .github/failing-import-issue.md
+        search_existing: open
+        update_existing: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CHANNEL: ${{ matrix.channel }}
 
   import-flakes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Failed workflow notifications are not very reliable, so open an issue when the nixpkgs import fails. This will open one issue per failing channel, unless there's already an *open* issue for that channel.

This is enough for me to get notified because I'm watching the repository, but we can also add an explicit ping if desired.