### PR TITLE
move programs to the top of the metadata display

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -504,7 +504,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
 
         programs =
             div []
-                [ h4 [] [ text "Programs in ", code [] [ text "/bin" ] ]
+                [ h4 [] [ text "Programs provided" ]
                 , if List.isEmpty item.source.programs then
                     p [] [ text "This package provides no programs." ]
 
@@ -731,8 +731,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     <|
                                         Maybe.map Tuple.first item.source.flakeUrl
                             ]
-                        :: maintainersAndPlatforms
                         :: programs
+                        :: maintainersAndPlatforms
                         :: []
                     )
                 ]

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -423,8 +423,12 @@ header .navbar.navbar-static-top {
 
               }
 
-              // maintainers and platforms
+              // programs
               & > :nth-child(3) {
+              }
+
+              // maintainers and platforms
+              & > :nth-child(4) {
                 margin-top: 1em;
                 display: grid;
                 grid-template-columns: auto auto;


### PR DESCRIPTION
rename to "programs provided", since where they are provided is an implementation detail irrelevant to users of `nix-shell -p`.

I'd actually prefer to list provided programs above the fold, because that is what users will care about much more than e.g. outputs of the derivation, which is also an implementation detail.

Related: https://github.com/NixOS/nixos-search/issues/542