### PR TITLE
Auto-link bare URIs in MarkDown

### DIFF
--- a/flake-info/src/data/pandoc.rs
+++ b/flake-info/src/data/pandoc.rs
@@ -63,6 +63,7 @@ impl<T: AsRef<str>> PandocExt for T {
             InputFormat::Commonmark,
             [
                 MarkdownExtension::Attributes,
+                MarkdownExtension::AutolinkBareUris,
                 MarkdownExtension::BracketedSpans,
                 MarkdownExtension::DefinitionLists,
                 MarkdownExtension::FencedDivs,


### PR DESCRIPTION
E.g. [weechat](https://search.nixos.org/packages?channel=unstable&show=weechat&from=0&size=50&sort=relevance&type=packages&query=weechat)'s long description