### PR TITLE
.github: pin nix 2.13

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -13,6 +13,7 @@ runs:
     - name: Installing Nix
       uses: cachix/install-nix-action@v18
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
         nix_path: nixpkgs=channel:nixpkgs-unstable
         extra_nix_config: |
           access-tokens = github.com=${{ inputs.GITHUB_TOKEN }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock


### PR DESCRIPTION
2.14 has a bug related to profile locations that breaks nix-env, which in turn breaks cachix. Pin to 2.13 for now.

More info at https://github.com/NixOS/nixpkgs/pull/218858#issuecomment-1448758169