### PR TITLE
Follow title convention for package requests

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -885,7 +885,7 @@ viewNoResults categoryName =
         , text "You might want to "
         , Html.a [ href "https://nixos.org/manual/nixpkgs/stable/#chap-quick-start" ] [ text "add a package" ]
         , text " or "
-        , a [ href "https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=0.kind%3A+packaging+request&template=packaging_request.md&title=" ] [ text "make a packaging request" ]
+        , a [ href "https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=0.kind%3A+packaging+request&template=packaging_request.md&title=Package+request%3A+PACKAGENAME" ] [ text "make a packaging request" ]
         , text "."
         ]
 


### PR DESCRIPTION
Follow the same default title as when opening a package request from GitHub directly.