### PR TITLE
Improve search results with underscore and dash/hyphen package names

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -1240,6 +1240,18 @@ searchFields query mainField fields =
                     )
                 |> List.concat
 
+        queryWordsWildCard =
+            (String.replace "_" "-" query :: String.replace "-" "_" query :: queryWords)
+                |> List.foldl
+                    (\acc uniques ->
+                        if List.member acc uniques then
+                            uniques
+
+                        else
+                            uniques ++ [ acc ]
+                    )
+                    []
+
         queryWords =
             String.words (String.toLower query)
     in
@@ -1271,7 +1283,7 @@ searchFields query mainField fields =
                   )
                 ]
             )
-            queryWords
+            queryWordsWildCard
         )
 
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -1242,15 +1242,8 @@ searchFields query mainField fields =
 
         queryWordsWildCard =
             (String.replace "_" "-" query :: String.replace "-" "_" query :: queryWords)
-                |> List.foldl
-                    (\acc uniques ->
-                        if List.member acc uniques then
-                            uniques
-
-                        else
-                            uniques ++ [ acc ]
-                    )
-                    []
+                |> Set.fromList
+                |> Set.toList
 
         queryWords =
             String.words (String.toLower query)


### PR DESCRIPTION
This improvement creates extra "variants" for the wildcard search allowing us to search (fx) for `nodejs_18` and get the result `nodejs-18_x`. Should resolve #644 that also contains more examples of these punctuation cases. 