### PR TITLE
Accessibility fixes

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -17,7 +17,15 @@ import Html
         , text
         , ul
         )
-import Html.Attributes exposing (alt, class, classList, href, id, src)
+import Html.Attributes
+    exposing
+        ( alt
+        , class
+        , classList
+        , href
+        , id
+        , src
+        )
 import Json.Decode
 import Page.Flakes exposing (Model(..))
 import Page.Home

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -17,14 +17,7 @@ import Html
         , text
         , ul
         )
-import Html.Attributes
-    exposing
-        ( class
-        , classList
-        , href
-        , id
-        , src
-        )
+import Html.Attributes exposing (alt, class, classList, href, id, src)
 import Json.Decode
 import Page.Flakes exposing (Model(..))
 import Page.Home
@@ -375,7 +368,7 @@ view model =
                     [ div [ class "navbar-inner" ]
                         [ div [ class "container" ]
                             [ a [ class "brand", href "https://nixos.org" ]
-                                [ img [ src "https://nixos.org/logo/nix-wiki.png", class "logo" ] []
+                                [ img [ alt "NixOS brand logo" ,src "https://nixos.org/logo/nix-wiki.png", class "logo" ] []
                                 ]
                             , div []
                                 [ ul [ class "nav pull-left" ]

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -376,7 +376,7 @@ view model =
                     [ div [ class "navbar-inner" ]
                         [ div [ class "container" ]
                             [ a [ class "brand", href "https://nixos.org" ]
-                                [ img [ alt "NixOS brand logo" ,src "https://nixos.org/logo/nix-wiki.png", class "logo" ] []
+                                [ img [ alt "NixOS logo", src "https://nixos.org/logo/nix-wiki.png", class "logo" ] []
                                 ]
                             , div []
                                 [ ul [ class "nav pull-left" ]

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -56,7 +56,19 @@ import Html
         , text
         , ul
         )
-import Html.Attributes exposing (attribute, autofocus, class, classList, disabled, href, id, placeholder, type_, value)
+import Html.Attributes
+    exposing
+        ( attribute
+        , autofocus
+        , class
+        , classList
+        , disabled
+        , href
+        , id
+        , placeholder
+        , type_
+        , value
+        )
 import Html.Events
     exposing
         ( onClick

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -56,18 +56,7 @@ import Html
         , text
         , ul
         )
-import Html.Attributes
-    exposing
-        ( attribute
-        , autofocus
-        , class
-        , classList
-        , href
-        , id
-        , placeholder
-        , type_
-        , value
-        )
+import Html.Attributes exposing (attribute, autofocus, class, classList, disabled, href, id, placeholder, type_, value)
 import Html.Events
     exposing
         ( onClick
@@ -1138,9 +1127,11 @@ viewPager :
 viewPager model total =
     div []
         [ ul [ class "pager" ]
-            [ li [ classList [ ( "disabled", model.from == 0 ) ] ]
-                [ a
-                    [ onClick <|
+            [ li []
+                [ button
+                    [ class "btn"
+                    , disabled (model.from == 0)
+                    , onClick <|
                         if model.from == 0 then
                             NoOp
 
@@ -1149,9 +1140,11 @@ viewPager model total =
                     ]
                     [ text "First" ]
                 ]
-            , li [ classList [ ( "disabled", model.from == 0 ) ] ]
-                [ a
-                    [ onClick <|
+            , li []
+                [ button
+                    [ class "btn"
+                    , disabled (model.from == 0)
+                    , onClick <|
                         if model.from - model.size < 0 then
                             NoOp
 
@@ -1160,9 +1153,11 @@ viewPager model total =
                     ]
                     [ text "Previous" ]
                 ]
-            , li [ classList [ ( "disabled", model.from + model.size >= total ) ] ]
-                [ a
-                    [ onClick <|
+            , li []
+                [ button
+                    [ class "btn"
+                    , disabled (model.from + model.size >= total)
+                    , onClick <|
                         if model.from + model.size >= total then
                             NoOp
 
@@ -1171,9 +1166,11 @@ viewPager model total =
                     ]
                     [ text "Next" ]
                 ]
-            , li [ classList [ ( "disabled", model.from + model.size >= total ) ] ]
-                [ a
-                    [ onClick <|
+            , li []
+                [ button
+                    [ class "btn"
+                    , disabled (model.from + model.size >= total)
+                    , onClick <|
                         if model.from + model.size >= total then
                             NoOp
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -977,7 +977,7 @@ viewChannels nixosChannels outMsg selectedChannel =
     in
     List.append
         [ div []
-            [ h4 [] [ text "Channel: " ]
+            [ h2 [] [ text "Channel: " ]
             , div
                 [ class "btn-group"
                 , attribute "data-toggle" "buttons-radio"

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>NixOS Search</title>
-
 
   <script type="text/javascript" src="https://nixos.org/js/jquery.min.js"></script>
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -549,3 +549,23 @@ header .navbar.navbar-static-top {
     height: 5em;
   }
 }
+
+/* ------------------------------------------------------------------------- */
+/* -- Accessibility overrides ---------------------------------------------- */
+/* ------------------------------------------------------------------------- */
+.label-info {
+  background: #007dbb;
+}
+
+a {
+  color: #007dbb;
+}
+
+.pager {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 20em;
+  margin: 0 auto;
+  padding: 20px 0;
+}

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -151,11 +151,12 @@ header .navbar.navbar-static-top {
       margin-bottom: 0.5em;
 
       // "Channels: " label
-      & > div > h4 {
+      & > div > h2 {
         display: inline;
         vertical-align: middle;
         font-size: 1.2em;
         margin-left: 0.2em;
+        line-height: 20px
       }
     }
   }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -570,3 +570,7 @@ a {
   margin: 0 auto;
   padding: 20px 0;
 }
+
+.badge {
+  background-color: #757575
+}


### PR DESCRIPTION
This pull request fixes some of the major issues related to Accessibility, it also resolves #332.

The fix handles all pages (packages, options, flakes):
- Use `button` instead empty `a` tag for pagination, also fixes contrast-ratio.
- Added logo alt and lang
- Accessibility overrides in `frontend/src/index.scss`:
  - A better fix for this would be to use a newer version of bootstrap (current using version 2)

Used "chrome lighthouse" and "axe devtools" to measure accessibility, screenshots with before and after:

<details>
  <summary>Before</summary>

![Screenshot 2023-04-26 at 19 38 08](https://user-images.githubusercontent.com/6098957/234965922-5ac9e256-6ac1-4c90-bde5-7930d6847535.png)

</details>

<details>
  <summary>After</summary>

![Screenshot 2023-04-26 at 20 54 27](https://user-images.githubusercontent.com/6098957/234965899-da9ba1b5-c9eb-438d-9626-71dd08808227.png)

</details>

