### PR TITLE
.github: remove deprecated `set-output` command

### DIFF
--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -32,8 +32,8 @@ jobs:
       run: |
         nix build -L .#nixosChannels
         channels="{\"channel\": $(< ./result)}"
-        echo $channels
-        echo "::set-output name=matrix::$channels"
+        echo "$channels"
+        echo "matrix=$channels" >> "$GITHUB_OUTPUT"
 
   import-nixpkgs:
     needs: nixos-channels


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

`set-output` currently triggers a warning and would start failing on June 1st.