### PR TITLE
IPv6.

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,4 +1,11 @@
 [[redirects]]
+  # Use a proxy because bonsai doesn't support IPv6.
+  from = "/backend/*"
+  to = "https://nixos-search-7-1733963800.us-east-1.bonsaisearch.net/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -7,7 +7,7 @@ const {Elm} = require('./Main');
 Elm.Main.init({
   flags: {
     elasticsearchMappingSchemaVersion: parseInt(process.env.ELASTICSEARCH_MAPPING_SCHEMA_VERSION),
-    elasticsearchUrl: process.env.ELASTICSEARCH_URL || 'https://nixos-search-7-1733963800.us-east-1.bonsaisearch.net:443',
+    elasticsearchUrl: process.env.ELASTICSEARCH_URL || '/backend',
     elasticsearchUsername : process.env.ELASTICSEARCH_USERNAME || 'aWVSALXpZv',
     elasticsearchPassword : process.env.ELASTICSEARCH_PASSWORD || 'X8gPHnzL52wFEekuxsfQ9cSh',
     nixosChannels : JSON.parse(process.env.NIXOS_CHANNELS)


### PR DESCRIPTION
Bonsai doesn't support IPv6, so use Netlify as a proxy. Fixes https://github.com/NixOS/nixos-search/issues/52