### PR TITLE
Adds ow-mod-man-flake

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -148,3 +148,8 @@ repo = "nix-vscode-extensions"
 type = "github"
 owner = "hyprwm"
 repo = "hyprland"
+
+[[sources]]
+type = "github"
+owner = "ShoosGun"
+repo = "ow-mod-man-flake"


### PR DESCRIPTION
Add to the manual sources [ShoosGun/ow-mod-man-flake](https://github.com/ShoosGun/ow-mod-man-flake). A flake that allows the installation of the cli and gui versions of the [mod manager](https://github.com/Bwc9876/ow-mod-man) for the game outer wilds.