### PR TITLE
Bundle `link-manpages.nix`

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -24,7 +24,7 @@ pkgs.rustPlatform.buildRustPackage rec {
 
   ROOTDIR = builtins.placeholder "out";
   NIXPKGS_PANDOC_FILTERS_PATH = pkgs.path + "/doc/build-aux/pandoc-filters";
-  LINK_MANPAGES_PANDOC_FILTER = import (pkgs.path + "/doc/build-aux/pandoc-filters/link-manpages.nix") { inherit pkgs; };
+  LINK_MANPAGES_PANDOC_FILTER = import src/data/link-manpages.nix { inherit pkgs; };
 
   checkFlags = [
     "--skip elastic::tests"

--- a/flake-info/src/data/link-manpages.nix
+++ b/flake-info/src/data/link-manpages.nix
@@ -1,0 +1,28 @@
+{ pkgs }:
+let
+  inherit (pkgs) lib;
+  manpageURLs = lib.importJSON (pkgs.path + "/doc/manpage-urls.json");
+in pkgs.writeText "link-manpages.lua" ''
+  --[[
+  Adds links to known man pages that aren't already in a link.
+  ]]
+
+  local manpage_urls = {
+  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (man: url:
+    "  [${builtins.toJSON man}] = ${builtins.toJSON url},") manpageURLs)}
+  }
+
+  traverse = 'topdown'
+
+  -- Returning false as the second value aborts processing of child elements.
+  function Link(elem)
+    return elem, false
+  end
+
+  function Code(elem)
+    local is_man_role = elem.classes:includes('interpreted-text') and elem.attributes['role'] == 'manpage'
+    if is_man_role and manpage_urls[elem.text] ~= nil then
+      return pandoc.Link(elem, manpage_urls[elem.text]), false
+    end
+  end
+''


### PR DESCRIPTION
It's being [removed](https://github.com/NixOS/nixpkgs/pull/239636#discussion_r1248903109) from nixpkgs as part of the dedocbookification process. Eventually we'll want to use nixos-render-docs to render options.