### PR TITLE
Remove remaining usages of NIXPKGS_PANDOC_FILTERS_PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,6 @@
             ];
             extraShellHook = ''
               export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
-              export NIXPKGS_PANDOC_FILTERS_PATH="${packages.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
               export LINK_MANPAGES_PANDOC_FILTER="${packages.flake-info.LINK_MANPAGES_PANDOC_FILTER}";
               export PATH=$PWD/frontend/node_modules/.bin:$PATH
             '';
@@ -111,7 +110,6 @@
             extraPackages = [pkgs.rustfmt];
             extraShellHook = ''
               export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
-              export NIXPKGS_PANDOC_FILTERS_PATH="${packages.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
               export LINK_MANPAGES_PANDOC_FILTER="${packages.flake-info.LINK_MANPAGES_PANDOC_FILTER}";
             '';
           };


### PR DESCRIPTION
Following this commit https://github.com/NixOS/nixos-search/commit/1128c8fb69d4a8557baeee13053e7792339554f9,
running `nix develop` would throw an error due to remaining usages of `flake-info.NIXPKGS_PANDOC_FILTERS_PATH` though it has been removed:

```
       error: attribute 'NIXPKGS_PANDOC_FILTERS_PATH' missing

       at /nix/store/5wfjb864pkb65z8nx6mb7cln12nm1g78-source/flake.nix:103:53:

          102|               export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
          103|               export NIXPKGS_PANDOC_FILTERS_PATH="${packages.flake-info.NIXPKGS_PANDOC_FILTERS_PATH}";
             |                                                     ^
          104|               export LINK_MANPAGES_PANDOC_FILTER="${packages.flake-info.LINK_MANPAGES_PANDOC_FILTER}";
```

This PR removes the remaining exports since they aren't used anymore.