### PR TITLE
Add ~dblsaiko/nix-extras

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -114,3 +114,8 @@ repo = "nix-vscode-extensions"
 type = "github"
 owner = "hyprwm"
 repo = "hyprland"
+
+[[sources]]
+type = "sourcehut"
+owner = "~dblsaiko"
+repo = "nix-extras"


### PR DESCRIPTION
This adds https://git.sr.ht/~dblsaiko/nix-extras to the index, it's a collection of packages and NixOS modules that I use in my configurations but which are also ready to be used in others'.