### PR TITLE
add COPYING license under MIT

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,20 @@
+Copyright (c) 2020-2024 Rok Garbas and the nixos-search contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Fixes #722

This repository has no license on it at the top level. ([The frontend code is MIT licensed](https://github.com/NixOS/nixos-search/blob/744ec58e082a3fcdd741b2c9b0654a0f7fda4603/frontend/package.json#L6))  I copied the license from nixpkgs, which uses the MIT license. If this isn't the license people want to use, let's discuss that here. 

Since this work was done in the context of the NixOS organization, which is dedicated to open source, I think it makes sense for this to have an open source license. I think that the contributors had a reasonable expectation that their work was being done under some open source license, but we should get approvals anyway. If you are okay with the MIT license please respond below:

> I license all of my past contributions to the nixos-search repository under the MIT license.

Contributors that added more than 100 lines that have accepted the license:

- [x] @garbas 
- [x] @ncfavier 
- [x] @ysndr 
- [x] @turboMaCk 
- [x] @erikarvstedt 
- [x] @adisbladis 
- [x] @andir 
- [x] @MatthewCroughan 
- [x] @MarcoDaniels 
- [x] @figsoda 
- [x] @mweinelt 
- [x] @dasJ