### PR TITLE
Added nixpkgs-esp-dev and micropython-builder to flakes index

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -141,3 +141,13 @@ repo = "microvm.nix"
 type = "github"
 owner = "Svenum"
 repo = "Solaar-Flake"
+
+[[sources]]
+type = "github"
+owner = "mirrexagon"
+repo = "nixpkgs-esp-dev"
+
+[[sources]]
+type = "github"
+owner = "jonahbron"
+repo = "micropython-builder"


### PR DESCRIPTION
- nixpkgs-esp-dev is a flake for building ESP32 firmware.
- micropython-builder is a flake for building MicroPython, currently only for ESP32.