### PR TITLE
flake-info: Adapt RFC-166 style

### DIFF
--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -145,7 +145,7 @@ impl Serialize for DocValue {
                     md.to_owned()
                 }))
             }
-            DocValue::Value(v) => serializer.serialize_str(&print_value(v.to_owned())),
+            DocValue::Value(v) => serializer.serialize_str(&print_value(v)),
         }
     }
 }

--- a/flake-info/src/data/prettyprint.rs
+++ b/flake-info/src/data/prettyprint.rs
@@ -15,7 +15,7 @@ impl Display for Indent {
     }
 }
 
-pub fn print_value(value: Value) -> String {
+pub fn print_value(value: &Value) -> String {
     print_value_indent(value, Indent(0))
 }
 
@@ -32,7 +32,7 @@ fn format_attrset_key(key: &str) -> String {
     }
 }
 
-fn print_value_indent(value: Value, indent: Indent) -> String {
+fn print_value_indent(value: &Value, indent: Indent) -> String {
     match value {
         Value::Null => "null".to_owned(),
         Value::Bool(b) => format!("{}", b),
@@ -59,7 +59,7 @@ fn print_value_indent(value: Value, indent: Indent) -> String {
             }
             if a.len() == 1 {
                 // Return early if the wrapped value fits on one line
-                let val = print_value(a.first().unwrap().clone());
+                let val = print_value(a.first().unwrap());
                 if !val.contains("\n") {
                     return format!("[ {} ]", val);
                 }
@@ -86,7 +86,7 @@ fn print_value_indent(value: Value, indent: Indent) -> String {
             }
             if o.len() == 1 {
                 // Return early if the wrapped value fits on one line
-                let val = print_value(o.values().next().unwrap().clone());
+                let val = print_value(o.values().next().unwrap());
                 if !val.contains("\n") {
                     return format!(
                         "{{ {} = {}; }}",
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn test_string() {
         let json = json!("Hello World");
-        assert_eq!(print_value(json), "\"Hello World\"");
+        assert_eq!(print_value(&json), "\"Hello World\"");
     }
 
     #[test]
@@ -139,7 +139,7 @@ World
 !!!"#
         );
         assert_eq!(
-            print_value(json),
+            print_value(&json),
             r#"''
      Hello
   World
@@ -151,32 +151,32 @@ World
     #[test]
     fn test_num() {
         let json = json!(1);
-        assert_eq!(print_value(json), "1");
+        assert_eq!(print_value(&json), "1");
     }
 
     #[test]
     fn test_bool() {
         let json = json!(true);
-        assert_eq!(print_value(json), "true");
+        assert_eq!(print_value(&json), "true");
     }
 
     #[test]
     fn test_empty_list() {
         let json = json!([]);
-        assert_eq!(print_value(json), "[ ]");
+        assert_eq!(print_value(&json), "[ ]");
     }
 
     #[test]
     fn test_list_one_item() {
         let json = json!([1]);
-        assert_eq!(print_value(json), "[ 1 ]");
+        assert_eq!(print_value(&json), "[ 1 ]");
     }
 
     #[test]
     fn test_list_one_multiline_item() {
         let json = json!(["first line\nsecond line"]);
         assert_eq!(
-            print_value(json),
+            print_value(&json),
             r#"[
   ''
     first line
@@ -190,7 +190,7 @@ World
     fn test_filled_list() {
         let json = json!([1, "hello", true, null]);
         assert_eq!(
-            print_value(json),
+            print_value(&json),
             r#"[
   1
   "hello"
@@ -203,26 +203,26 @@ World
     #[test]
     fn test_empty_set() {
         let json = json!({});
-        assert_eq!(print_value(json), "{ }");
+        assert_eq!(print_value(&json), "{ }");
     }
 
     #[test]
     fn test_set_one_item() {
         let json = json!({ "hello": "world" });
-        assert_eq!(print_value(json), "{ hello = \"world\"; }");
+        assert_eq!(print_value(&json), "{ hello = \"world\"; }");
     }
 
     #[test]
     fn test_set_number_key() {
         let json = json!({ "1hello": "world" });
-        assert_eq!(print_value(json), "{ \"1hello\" = \"world\"; }");
+        assert_eq!(print_value(&json), "{ \"1hello\" = \"world\"; }");
     }
 
     #[test]
     fn test_set_one_multiline_item() {
         let json = json!({ "hello": "pretty\nworld" });
         assert_eq!(
-            print_value(json),
+            print_value(&json),
             "{
   hello = ''
     pretty
@@ -236,7 +236,7 @@ World
     fn test_filled_set() {
         let json = json!({"hello": "world", "another": "test"});
         assert_eq!(
-            print_value(json),
+            print_value(&json),
             "{
   another = \"test\";
   hello = \"world\";
@@ -261,7 +261,7 @@ World
         ]);
 
         assert_eq!(
-            print_value(json),
+            print_value(&json),
             r#"[
   "HDMI-0"
   {


### PR DESCRIPTION
RFC-166 is merged and is going to be the default style for nixpkgs.

It makes sense to also have the official documentation look the same so people both get used to the style and can copy-paste sensibly formatted code.

The RFC is very long but since we only deal with primitive values here (no lets, functions and whatnot), the change is very easy and only affects lists and attrsets with one item.

The only other rule I can think of that would be required would be the maximum line length, but I'm honestly too lazy and I don't think this rule would apply very often in option defaults/examples.

I also added 2 more minor fixup commits for attrset names with weird characters in them and I reduced the number of clones in the pretty-printer.