### PR TITLE
frontend: sort platforms

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -493,7 +493,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                             [ p [] [ text "This package is not available on any platform." ] ]
 
                          else
-                            [ ul [] (List.map showPlatform item.source.platforms) ]
+                            [ ul [] (List.map showPlatform (List.sort item.source.platforms)) ]
                         )
                     )
                 ]


### PR DESCRIPTION
![image](https://github.com/NixOS/nixos-search/assets/382796/be79093d-0c4e-4edf-a290-8c46c6c8fbdb)

the one you want to click varies in position, which makes it actually take some effort to find each time.

this sorts them so you can get used to clicking in a certain place if you usually use only one architecture

![image](https://github.com/NixOS/nixos-search/assets/382796/9258a8a4-fe89-49c6-82e6-f48dce65d30a)
