### PR TITLE
frontend: narrow down DefinePlugin into EnvironmentPlugin

### DIFF
--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -22,12 +22,12 @@ module.exports = (withDebug) => {
                 template: "./src/index.html"
             }),
             new CleanWebpackPlugin(),
-            new webpack.EnvironmentPlugin([
-                "ELASTICSEARCH_MAPPING_SCHEMA_VERSION",
-                "NIXOS_CHANNELS"
-            ]),
-            new webpack.DefinePlugin({
-                'process.env': JSON.stringify(process.env)
+            new webpack.EnvironmentPlugin({
+                ELASTICSEARCH_MAPPING_SCHEMA_VERSION: undefined,
+                ELASTICSEARCH_URL: null,
+                ELASTICSEARCH_USERNAME: null,
+                ELASTICSEARCH_PASSWORD: null,
+                NIXOS_CHANNELS: undefined
             }),
         ],
         optimization: {


### PR DESCRIPTION
the previous DefinePlugin

```js
new webpack.DefinePlugin({
    'process.env': JSON.stringify(process.env)
})
```
caused index.js

```js
elasticsearchMappingSchemaVersion: parseInt(process.env.ELASTICSEARCH_MAPPING_SCHEMA_VERSION),
elasticsearchUrl: process.env.ELASTICSEARCH_URL || '/backend',
elasticsearchUsername : process.env.ELASTICSEARCH_USERNAME || ...,
elasticsearchPassword : process.env.ELASTICSEARCH_PASSWORD || ...,
nixosChannels : JSON.parse(process.env.NIXOS_CHANNELS)
```

to compile into

```js
elasticsearchMappingSchemaVersion: parseInt('42'),
elasticsearchUrl: {
  NODE_ENV: 'production',
  SHELL: '/nix/store/0hx32wk55ml88jrb1qxwg5c5yazfm6gf-bash-5.2-p15/bin/bash',
  // the entire environment in JSON
}.ELASTICSEARCH_URL || '/backend',
elasticsearchUsername: {
  // the entire environment again
}.ELASTICSEARCH_USERNAME || ...,
elasticsearchPassword: {
  // again
}.ELASTICSEARCH_PASSWORD || ...,
nixosChannels: JSON.parse(...)
```

this removes it and puts the remaining used env vars in the existing EnvironmentPlugin:

```js
new webpack.EnvironmentPlugin({
    ELASTICSEARCH_MAPPING_SCHEMA_VERSION: undefined,
    ELASTICSEARCH_URL: null,
    ELASTICSEARCH_USERNAME: null,
    ELASTICSEARCH_PASSWORD: null,
    NIXOS_CHANNELS: undefined
}),
```

(https://webpack.js.org/plugins/environment-plugin/#usage-with-default-values `undefined` for required, `null` for optional)

so that it now compiles into this less detailed code

```js
elasticsearchMappingSchemaVersion: parseInt("42"),
elasticsearchUrl:  false || '/backend',
elasticsearchUsername:  false || ...,
elasticsearchPassword:  false || ...,
nixosChannels: JSON.parse(...)
```