### PR TITLE
fix: code block in long description of a package in dark mode

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -755,6 +755,10 @@ header .navbar.navbar-static-top {
               // long description of a package
               & > :nth-child(1) {
                 margin-top: 1em;
+
+                pre {
+                  @include terminal;
+                }
               }
 
               // how to install a package


### PR DESCRIPTION
close #737 

CC @Aleksanaa

Works on my machine
![image](https://github.com/NixOS/nixos-search/assets/23723294/7f9693ef-9461-4051-b9e4-ea4f2f178a95)
