### PR TITLE
frontend: Suggest nix profile install for flakes installation

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -718,7 +718,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                                     ]
                                                 ]
                                                 [ pre [ class "code-block shell-command" ]
-                                                    [ text "nix build "
+                                                    [ text "nix profile install "
                                                     , strong [] [ text url ]
                                                     , text "#"
                                                     , em [] [ text item.source.attr_name ]


### PR DESCRIPTION
This makes more sense than having nix build, which doesn't really install things
