### PR TITLE
fix: center magnifying glass / search icon

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -482,6 +482,7 @@ header .navbar.navbar-static-top {
       -o-transform: scale(-1, 1);
       -ms-transform: scale(-1, 1);
       transform: scale(-1,  1);
+      vertical-align: text-bottom;
     }
   }
 


### PR DESCRIPTION
| Before | After |
| - | - |
| ![Screenshot 2024-04-27 at 17 58 50 (Arc)](https://github.com/NixOS/nixos-search/assets/47499684/7d6ca084-c8dc-4931-86cc-6e87f7f62e44) | ![Screenshot 2024-04-27 at 17 59 05 (Arc)](https://github.com/NixOS/nixos-search/assets/47499684/867cce62-edd0-44d3-866c-48540b6397be) |

Notice how the search / magnifying glass icon is now vertically centered to match the text :)