### PR TITLE
fix: remove filter on header logo

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -273,10 +273,6 @@
   // Very navbar to boost specificity
   .navbar.navbar.navbar.navbar.navbar.navbar {
     &>.navbar-inner {
-      .brand img {
-        filter: brightness(0) invert(1);
-      }
-
       background: var(--headerbar-background-color);
       border-bottom: none;
 


### PR DESCRIPTION
| Before | After |
| - | - |
| ![Screenshot 2024-04-27 at 18 02 43 (Arc)](https://github.com/NixOS/nixos-search/assets/47499684/cc877d5c-7a6a-4ed1-86d1-794e6e52a238) | ![Screenshot 2024-04-27 at 18 03 01 (Arc)](https://github.com/NixOS/nixos-search/assets/47499684/2dccffe1-843b-40b8-b16f-1ed847f6196a) |

I think the contrast of the logo looks just fine and more recognizable without the filter/invert.