### PR TITLE
fix: wording when a package has no platforms list

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -490,7 +490,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                 , div []
                     (List.append [ h4 [] [ text "Platforms" ] ]
                         (if List.isEmpty item.source.platforms then
-                            [ p [] [ text "This package is not available on any platform." ] ]
+                            [ p [] [ text "This package does not list its available platforms." ] ]
 
                          else
                             [ ul [] (List.map showPlatform (List.sort item.source.platforms)) ]


### PR DESCRIPTION
"This package is not available on any platform" is misleading and confusing, so I changed that.

Related https://github.com/NixOS/nixpkgs/issues/270206
Closes https://github.com/NixOS/nixos-search/issues/734