### PR TITLE
flake-info: drop channels for flake commands

### DIFF
--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -22,7 +22,7 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
 ) -> Result<Vec<FlakeEntry>> {
     let mut command = Command::with_args("nix", ARGS.iter());
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_arg_pair("-I", "nixpkgs=channel:nixpkgs-unstable");
+    command.add_arg_pair("-I", "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz");
     command.add_args(["--override-flake", "input-flake", flake_ref.as_ref()].iter());
     command.add_args(["--argstr", "flake", flake_ref.as_ref()].iter());
     command.add_arg(kind.as_ref());


### PR DESCRIPTION
Same workaround as in nix-community/nur-packages-template#95 and https://github.com/wegank/nur-packages/commit/631ea9f525ec2ecfb3daf4365cab213b19baa0cf, should hopefully fix the hourly import.