### PR TITLE
flakes: drop github:ngi-nix/pixelfed

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -11,11 +11,6 @@ repo = "offen"
 [[sources]]
 type = "github"
 owner = "ngi-nix"
-repo = "pixelfed"
-
-[[sources]]
-type = "github"
-owner = "ngi-nix"
 repo = "lightmeter"
 
 [[sources]]


### PR DESCRIPTION
https://github.com/ngi-nix/pixelfed has been archived in 2023, since the service is upstreamed.