### PR TITLE
flakes: drop problematic sources

### DIFF
--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -37,7 +37,7 @@ jobs:
         do
           echo "::group::Group \"$(basename $flake_group .toml)\""
 
-         nix run --accept-flake-config .#flake-info -- group "$flake_group" "$(basename "$flake_group" .toml)" --report
+         nix run --accept-flake-config .#flake-info -- --json group "$flake_group" "$(basename "$flake_group" .toml)" --report
 
           if [[ -f "./report.txt" ]]
           then

--- a/flake-info/README.md
+++ b/flake-info/README.md
@@ -127,7 +127,7 @@ An example `targets.json` file can look like the following
 ```
 
 ```
-$ flake-info group ./targets.json small-group
+$ flake-info --json group ./targets.json small-group
 ```
 
 ### Elasticsearch

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -45,11 +45,6 @@ repo = "neuropil"
 
 [[sources]]
 type = "github"
-owner = "pinpox"
-repo = "nixos"
-
-[[sources]]
-type = "github"
 owner = "Mic92"
 repo = "sops-nix"
 

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -78,11 +78,6 @@ owner = "PrismLauncher"
 repo = "PrismLauncher"
 
 [[sources]]
-type = "gitlab"
-owner = "simple-nixos-mailserver"
-repo = "nixos-mailserver"
-
-[[sources]]
 type = "git"
 url = "git+https://codeberg.org/wolfangaukang/stream-alert-bot?ref=main"
 

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -92,11 +92,6 @@ repo = "nix-security"
 
 [[sources]]
 type = "github"
-owner = "astro"
-repo = "microvm.nix"
-
-[[sources]]
-type = "github"
 owner = "lnbits"
 repo = "lnbits-legend"
 

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -45,11 +45,6 @@ repo = "neuropil"
 
 [[sources]]
 type = "github"
-owner = "tweag"
-repo = "nickel"
-
-[[sources]]
-type = "github"
 owner = "pinpox"
 repo = "nixos"
 

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -69,11 +69,6 @@ owner = "yusdacra"
 repo = "rust-nix-templater"
 
 [[sources]]
-type = "github"
-owner = "srid"
-repo = "emanote"
-
-[[sources]]
 type = "git"
 url = "git+https://git.sr.ht/~kerstin/sway-timetracker?ref=main"
 

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -79,10 +79,6 @@ repo = "PrismLauncher"
 
 [[sources]]
 type = "git"
-url = "git+https://codeberg.org/wolfangaukang/stream-alert-bot?ref=main"
-
-[[sources]]
-type = "git"
 url = "git+https://codeberg.org/wolfangaukang/python-trovo?ref=main"
 
 [[sources]]


### PR DESCRIPTION
These public flakes are not indexed on https://search.nixos.org/flakes due to various errors, and can therefore be safely dropped.