### PR TITLE
frontend: Fix magnifying glass position and font

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -471,14 +471,14 @@ header .navbar.navbar-static-top {
     &:before {
       content: "\2315";
       display: inline-block;
-      font-size: 1.5em;
+      font-size: 2em;
       margin-right: 0.2em;
       -moz-transform: scale(-1, 1);
       -webkit-transform: scale(-1, 1);
       -o-transform: scale(-1, 1);
       -ms-transform: scale(-1, 1);
-      transform: scale(-1,  1);
-      vertical-align: text-bottom;
+      transform: translateY(0.15em) scaleX(-1);
+      font-family: monospace;
     }
   }
 


### PR DESCRIPTION
Used to look like this on Chrome:
![image](https://github.com/NixOS/nixos-search/assets/4971975/da6c2cb2-f9e7-4508-9edf-a993a2f6bfaa)

Used to look like this on Firefox:
![image](https://github.com/NixOS/nixos-search/assets/4971975/3ca65d68-cc7c-4e24-b576-00f7278fe96f)

---

Now looks like this on both:
![image](https://github.com/NixOS/nixos-search/assets/4971975/0ff9e0e5-5f8a-4c75-a1de-b5200f4781f1)
