### PR TITLE
Packages.elm: add missing newline to 'nix-env' tab

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -654,7 +654,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         [ pre [ class "code-block shell-command" ]
                                             [ text "# without flakes:\nnix-env -iA nixpkgs."
                                             , strong [] [ text item.source.attr_name ]
-                                            , text "# with flakes:\nnix profile install nixpkgs#"
+                                            , text "\n# with flakes:\nnix profile install nixpkgs#"
                                             , strong [] [ text item.source.attr_name ]
                                             ]
                                         ]


### PR DESCRIPTION
This is wrong
![image](https://github.com/NixOS/nixos-search/assets/140964/7236c081-114b-4cdc-939b-4e8e995c8de4)
