### PR TITLE
flake-list: add chaotic nyx flake

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -114,3 +114,8 @@ repo = "nix-vscode-extensions"
 type = "github"
 owner = "hyprwm"
 repo = "hyprland"
+
+[[sources]]
+type = "github"
+owner = "chaotic-cx"
+repo = "nyx"


### PR DESCRIPTION
Nix flake for bleeding-edge and unreleased packages (e.g., mesa_git, telegram_git)
Additonally it provides cachyos linux kernel.

@dasJ @Mic92 friendly ping