### PR TITLE
flakes: split sources

### DIFF
--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Checking out the repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup
       uses: ./.github/actions/common-setup
@@ -33,11 +35,13 @@ jobs:
 
         had_error=0
 
-        for flake_group in flakes/**/*.toml
-        do
-          echo "::group::Group \"$(basename $flake_group .toml)\""
+        for folder in flakes/*/; do
+          flake_group=$(basename "$folder")
+          echo "::group::Group \""$flake_group"\""
 
-         nix run --accept-flake-config .#flake-info -- --json group "$flake_group" "$(basename "$flake_group" .toml)" --report
+          flake_toml=flakes/"$flake_group".toml
+          cat $(git diff --name-only HEAD~1 -- "$folder"/*.toml) > "$flake_toml"
+          nix run --accept-flake-config .#flake-info -- --json group "$flake_toml" "$flake_group" --report
 
           if [[ -f "./report.txt" ]]
           then
@@ -50,7 +54,7 @@ jobs:
             report="${report//$'\n'/'%0A'}"
             report="${report//$'\r'/'%0D'}"
 
-            echo "::error file=$flake_group::$report"
+            echo "::error file=$flake_toml::$report"
           fi
 
           echo ::endgroup::

--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -110,6 +110,7 @@ jobs:
 
     - name: Import ${{ matrix.group }} group
       run: |
+        cat $(find ./flakes/${{ matrix.group }}/ -type f -name '*.toml') > ./flakes/${{ matrix.group }}.toml
         nix run --accept-flake-config .#flake-info -- --push --elastic-schema-version=$(< ./VERSION) group ./flakes/${{ matrix.group }}.toml ${{ matrix.group }}
       if: github.repository_owner == 'NixOS'
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ application.
 
 ## Adding flakes
 
-To add your own flakes to the search index edit [./flakes/manual.toml](./flakes/manual.toml).
+To add your own flakes to the search index, add a file under `./flakes/manual`.
 
 Possible types are `github`, `gitlab`, `sourcehut`, and `git` (which is the fallback for any kind of git repository but requires to set a revision key manually as of now).
 

--- a/flakes/manual/ngi-nix.toml
+++ b/flakes/manual/ngi-nix.toml
@@ -1,0 +1,19 @@
+[[sources]]
+type = "github"
+owner = "ngi-nix"
+repo = "offen"
+
+[[sources]]
+type = "github"
+owner = "ngi-nix"
+repo = "lightmeter"
+
+[[sources]]
+type = "github"
+owner = "ngi-nix"
+repo = "openpgp-ca"
+
+[[sources]]
+type = "github"
+owner = "ngi-nix"
+repo = "weblate"

--- a/flakes/manual/nix-community.toml
+++ b/flakes/manual/nix-community.toml
@@ -1,0 +1,9 @@
+[[sources]]
+type = "github"
+owner = "nix-community"
+repo = "fenix"
+
+[[sources]]
+type = "github"
+owner = "nix-community"
+repo = "nix-vscode-extensions"

--- a/flakes/manual/nixos.toml
+++ b/flakes/manual/nixos.toml
@@ -1,0 +1,4 @@
+[[sources]]
+type = "github"
+owner = "NixOS"
+repo = "hydra"

--- a/flakes/manual/uncategorized.toml
+++ b/flakes/manual/uncategorized.toml
@@ -1,35 +1,5 @@
 [[sources]]
 type = "github"
-owner = "NixOS"
-repo = "hydra"
-
-[[sources]]
-type = "github"
-owner = "ngi-nix"
-repo = "offen"
-
-[[sources]]
-type = "github"
-owner = "ngi-nix"
-repo = "lightmeter"
-
-[[sources]]
-type = "github"
-owner = "ngi-nix"
-repo = "openpgp-ca"
-
-[[sources]]
-type = "github"
-owner = "ngi-nix"
-repo = "weblate"
-
-[[sources]]
-type = "github"
-owner = "nix-community"
-repo = "fenix"
-
-[[sources]]
-type = "github"
 owner = "fort-nix"
 repo = "nix-bitcoin"
 
@@ -119,11 +89,6 @@ repo = "nix-software-center"
 type = "github"
 owner = "snowfallorg"
 repo = "nixos-conf-editor"
-
-[[sources]]
-type = "github"
-owner = "nix-community"
-repo = "nix-vscode-extensions"
 
 [[sources]]
 type = "github"

--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -172,7 +172,7 @@ view nixosChannels model =
             [ text "Search packages and options of "
             , strong []
                 [ a
-                    [ href "https://github.com/NixOS/nixos-search/blob/main/flakes/manual.toml" ]
+                    [ href "https://github.com/NixOS/nixos-search/tree/main/flakes/manual" ]
                     [ text "public flakes" ]
                 ]
             ]


### PR DESCRIPTION
This PR splits `flakes/manual.toml` into multiple files under `flakes/manual/`, and modifies `.github/workflows/check-flake-files.yml` so that it only runs on the modified files.