### PR TITLE
Package.elm: suggest to become a maintainer when maintainer list is e…

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -477,7 +477,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                 [ div []
                     (List.append [ h4 [] [ text "Maintainers" ] ]
                         (if List.isEmpty item.source.maintainers then
-                            [ p [] [ text "This package has no maintainers." ] ]
+                            [ p [] [ text "This package has no maintainers. If you find it useful, please consider becoming a maintainer!" ] ]
 
                          else
                             [ ul []


### PR DESCRIPTION
…mpty

> I read `maintainers = with lib.maintainers; [ ];` as a friendly open invitation, while `maintainers = [ ];` as a sad state of reality. I want people to join the project hence I very much prefer the former.

Explicit is better than implicit.