### PR TITLE
Add github:nilp0inter/autofirma-nix to flake index

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -166,3 +166,8 @@ repo = "numen-nix"
 type = "github"
 owner = "StardustXR"
 repo = "telescope"
+
+[[sources]]
+type = "github"
+owner = "nilp0inter"
+repo = "autofirma-nix"


### PR DESCRIPTION
A flake for installing AutoFirma¹ and related packages, the Spanish goverment official software for implementing digital signatures, an essential element for interacting with the Spanish Public Administration.

¹: https://firmaelectronica.gob.es/Home/Descargas.html