### PR TITLE
Sort provided programs for packages

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -505,7 +505,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                     p [] [ text "This package provides no programs." ]
 
                   else
-                    p [] (List.intersperse (text " ") (List.map (\p -> code [] [ text p ]) item.source.programs))
+                    p [] (List.intersperse (text " ") (List.map (\p -> code [] [ text p ]) (List.sort item.source.programs)))
                 ]
 
         longerPackageDetails =


### PR DESCRIPTION
The provided programs with a package were not sorted, making it hard to figure out which programs were included in programs with 20+ programs in random order.

For example:
![image](https://github.com/user-attachments/assets/658d0d08-0b23-4455-9106-50c110f965c7)
