### PR TITLE
fix: Update old link in no results view

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -871,7 +871,7 @@ viewNoResults categoryName =
     div [ class "search-no-results" ]
         [ h2 [] [ text <| "No " ++ categoryName ++ " found!" ]
         , text "You might want to "
-        , Html.a [ href "https://nixos.org/manual/nixpkgs/stable/#chap-quick-start" ] [ text "add a package" ]
+        , Html.a [ href "https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package" ] [ text "add a package" ]
         , text " or "
         , a [ href "https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=0.kind%3A+packaging+request&template=packaging_request.md&title=Package+request%3A+PACKAGENAME" ] [ text "make a packaging request" ]
         , text "."


### PR DESCRIPTION
The previous link lands on a mostly-empty placeholder page pointing to a different link.

I've updated it to point directly to the final link in the chain.