### PR TITLE
chore: bump package and option count

### DIFF
--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -142,7 +142,7 @@ view :
 view nixosChannels model =
     Search.view { toRoute = Route.Options, categoryName = "options" }
         [ text "Search more than "
-        , strong [] [ text "10 000 options" ]
+        , strong [] [ text "20 000 options" ]
         ]
         nixosChannels
         model

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -226,7 +226,7 @@ view :
 view nixosChannels model =
     Search.view { toRoute = Route.Packages, categoryName = "packages" }
         [ text "Search more than "
-        , strong [] [ text "100 000 packages" ]
+        , strong [] [ text "120 000 packages" ]
         ]
         nixosChannels
         model


### PR DESCRIPTION
We reached both 120k packages and 20k options some time ago:
```bash
#!/usr/bin/env nix-shell
#!nix-shell -i bash -p curl jq brotli

function parse_unstable_json() {
    local url="https://channels.nixos.org/nixos-unstable/$1.json.br"
    echo $(curl -L "$url" | brotli -d --stdout | jq "$2")
}

pkg_count=$(parse_unstable_json "packages" ".packages | length")
opt_count=$(parse_unstable_json "options" "length")

echo "{ 'packages': $pkg_count, 'options': $opt_count }" | tr "'" '"'
```
> `{ "packages": 121548, "options": 20197 }`

See:
- #701 