### PR TITLE
Add github:CertainLach/fleet to flake sources

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -171,3 +171,8 @@ repo = "telescope"
 type = "github"
 owner = "nilp0inter"
 repo = "autofirma-nix"
+
+[[sources]]
+type = "github"
+owner = "CertainLach"
+repo = "fleet"


### PR DESCRIPTION
This adds [CertainLach/fleet] to flake sources.

Quote from the repo:

> An NixOS cluster deployment tool.

[CertainLach/fleet]: https://github.com/CertainLach/fleet