### PR TITLE
Add a section with all maintainer github names

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -447,6 +447,21 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                        )
                 )
 
+        linkAllMaintainers maintainers =
+            let
+                ghHandles =
+                    List.filterMap (\m -> (Maybe.map (String.append "@") m.github)) maintainers
+            in
+            optionals (List.length ghHandles > 1)
+                [ li []
+                    (
+                        [ text "Maintainer Github handles: " ]
+                        ++ [ code []
+                            [ text (String.join " " ghHandles) ]
+                        ]
+                    )
+                ]
+
         mailtoAllMaintainers maintainers =
             let
                 maintainerMails =
@@ -483,6 +498,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                             [ ul []
                                 (List.map showMaintainer item.source.maintainers
                                     ++ mailtoAllMaintainers item.source.maintainers
+                                    ++ linkAllMaintainers item.source.maintainers
                                 )
                             ]
                         )

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -793,6 +793,14 @@ header .navbar.navbar-static-top {
                 margin-top: 1em;
                 display: grid;
                 grid-template-columns: auto auto;
+
+                // make it easy to copy only the list of Github handles
+                & > :first-child > ul > :last-child {
+                  user-select: none;
+                }
+                & > :first-child > ul > :last-child > code {
+                  user-select: text;
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes #865 (there is no button but it is very easy to copy the list)

![image](https://github.com/user-attachments/assets/b16cabfa-4593-4fb0-96ea-1efa55ef0f19)
