### PR TITLE
fix: code block style in `Description` field

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -414,7 +414,7 @@ body {
   }
 }
 
-.code-block {
+.code-block,.sourceCode {
   display: block;
   cursor: text;
 }


### PR DESCRIPTION
For example, in result of `boot.kernelPatches`

before & after:
![image](https://github.com/user-attachments/assets/4ba95cde-8388-4ec1-b1ba-d4ff128890c7)
