### PR TITLE
Add nixpkgs-ruby flake

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -171,3 +171,9 @@ repo = "telescope"
 type = "github"
 owner = "nix-community"
 repo = "autofirma-nix"
+
+[[sources]]
+type = "github"
+owner = "bobvanderlinden"
+repo = "nixpkgs-ruby"
+


### PR DESCRIPTION
This adds the nixpkgs-ruby flake, which aims to package all ruby versions.
See https://github.com/bobvanderlinden/nixpkgs-ruby