### PR TITLE
chore: expose only a set of env variables

### DIFF
--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -22,12 +22,12 @@ module.exports = (withDebug, optimize) => {
                 template: "./src/index.html"
             }),
             new CleanWebpackPlugin(),
-            new webpack.EnvironmentPlugin([
-                "ELASTICSEARCH_MAPPING_SCHEMA_VERSION",
-                "NIXOS_CHANNELS"
-            ]),
-            new webpack.DefinePlugin({
-                'process.env': JSON.stringify(process.env)
+            new webpack.EnvironmentPlugin({
+                ELASTICSEARCH_MAPPING_SCHEMA_VERSION: "0",
+                ELASTICSEARCH_PASSWORD: 'X8gPHnzL52wFEekuxsfQ9cSh',
+                ELASTICSEARCH_URL: '/backend',
+                ELASTICSEARCH_USERNAME: 'aWVSALXpZv',
+                NIXOS_CHANNELS: "0",
             }),
         ],
         optimization: {


### PR DESCRIPTION
This is a fix to remove the use of `DefinePlugin` with `process.env` as it exposes all env variables in your bundle.
If you inspect `https://search.nixos.org/bundle.js` you will notice all CI env vars are bundled with your app.
```js
      n.Main.init({
        flags: {
          elasticsearchMappingSchemaVersion: parseInt("42"),
          elasticsearchUrl:
            {
              NODE_ENV: "production",
              SHELL:
                "/nix/store/phqa311klldrcbwid1i22dwnpfc9dnma-bash-5.1-p8/bin/bash",
              npm_config_timing: "",
              npm_config_access: "",
	      ... 
	    }.ELASTICSEARCH_URL || "/backend",
```
