### PR TITLE
Show GH handle for packages with one maintainer

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -452,7 +452,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                 ghHandles =
                     List.filterMap (\m -> (Maybe.map (String.append "@") m.github)) maintainers
             in
-            optionals (List.length ghHandles > 1)
+            optionals (not (List.isEmpty ghHandles))
                 [ li []
                     (
                         [ text "Maintainer Github handles: " ]


### PR DESCRIPTION
It seems I only tested #878 with packages that have more than one maintainer, but the section is still useful if there is only one maintainer.