### PR TITLE
fix: Remove link to "make a packaging request"

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -872,8 +872,6 @@ viewNoResults categoryName =
         [ h2 [] [ text <| "No " ++ categoryName ++ " found!" ]
         , text "You might want to "
         , Html.a [ href "https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package" ] [ text "add a package" ]
-        , text " or "
-        , a [ href "https://github.com/NixOS/nixpkgs/issues/new?template=05_package_request.yml" ] [ text "make a packaging request" ]
         , text "."
         ]
 


### PR DESCRIPTION
packaging_request.md template has been removed from nixpkgs github(https://github.com/NixOS/nixpkgs/tree/master/.github/ISSUE_TEMPLATE) after this PR: https://github.com/NixOS/nixpkgs/pull/391926

Following discussion here: https://github.com/NixOS/nixos-search/pull/881, this removes the now broken link to it from search.nixos.org

CC: @raboof 