### PR TITLE
Suggest to search on nixpkgs issues when nothing is found

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -819,7 +819,7 @@ viewResult nixosChannels outMsg toRoute categoryName model viewSuccess viewBucke
             if result.hits.total.value == 0 && List.length buckets == 0 then
                 div [ class "search-results" ]
                     [ ul [ class "search-sidebar" ] searchBuckets
-                    , viewNoResults categoryName
+                    , viewNoResults categoryName (Maybe.withDefault "" model.query)
                     ]
 
             else if List.length buckets > 0 then
@@ -866,12 +866,15 @@ viewResult nixosChannels outMsg toRoute categoryName model viewSuccess viewBucke
 
 viewNoResults :
     String
+    -> String
     -> Html c
-viewNoResults categoryName =
+viewNoResults categoryName query =
     div [ class "search-no-results" ]
         [ h2 [] [ text <| "No " ++ categoryName ++ " found!" ]
         , text "You might want to "
         , Html.a [ href "https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package" ] [ text "add a package" ]
+        , text " or "
+        , Html.a [ href ("https://github.com/NixOS/nixpkgs/issues?q=" ++ query) ] [ text "search nixpkgs issues" ]
         , text "."
         ]
 


### PR DESCRIPTION
When an user searches for a package not already merged it won't be found.

For example:
> https://search.nixos.org/packages?channel=unstable&query=nibbler

Right now it won't find the package, because it hass just been requested.
But it might be useful to the user to quickly check for the status on nixpkgs.

Therefore I Added a link to `nixpkgs/issues?q=PACKAGENAME` in `viewNoResults`.