### PR TITLE
Provide VM config for local end-to-end testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ You can point your browser to `http://localhost:3000` and start developing.
 Any changes to source files (`./frontend/src`) will trigger a hot reload of an
 application.
 
+This allows testing the frontend against the 'production' package index.
+
+### End-to-end testing
+
+If you want to do a full round-trip test of importing information with
+`flake-info` and then viewing it in the frontend, you can run an ephemeral
+OpenSearch instance locally using `nixosConfigurations.opensearch-vm`. The VM
+can easily be run using `nix run .#opensearch-vm`.
+
+Then you can upload information with something like:
+
+```
+flake-info --elastic-schema-version 43 --elastic-index-name=nixos-unstable --push --elastic-exists recreate nixpkgs unstable
+```
+
+To point the frontend to the local index, `export ELASTICSEARCH_URL=http://localhost:9200` before running the frontend.
+You may need to manually edit `frontend/src/Search.elm` to use the right index.
 
 ## Deploying
 

--- a/flake.nix
+++ b/flake.nix
@@ -140,5 +140,35 @@
           devShell = warnToUpgradeNix devShells.default;
           defaultPackage = warnToUpgradeNix packages.default;
         }
-      );
+      ) // {
+        # Local testing VM configuration
+        nixosConfigurations.opensearch-vm = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            (import "${nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix")
+            ({ lib, pkgs, ... }: {
+              system.stateVersion = "25.05";
+              services.getty.autologinUser = "root";
+              virtualisation = {
+                diskImage = null; # makes VM ephemeral
+                graphics = false;
+                forwardPorts = [ { guest.port = 9200; host.port = 9200; } ]; # expose :9200 from guest to host
+                memorySize = 1024 * 8;  # 8 GB
+              };
+              environment.systemPackages = [ pkgs.opensearch-cli ];
+              networking.firewall.allowedTCPPorts = [ 9200 ];
+              services.opensearch = {
+                enable = true;
+                settings = {
+                  "network.host" = "0.0.0.0";
+                  "http.cors.enabled" = "true";
+                  "http.cors.allow-origin" = "http://localhost:3000";
+                  "http.cors.allow-credentials" = "true";
+                  "http.cors.allow-headers" = "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization";
+                };
+              };
+            })
+          ];
+        };
+      };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,12 @@
           # XXX: for backwards compatibility
           devShell = warnToUpgradeNix devShells.default;
           defaultPackage = warnToUpgradeNix packages.default;
+
+          apps.opensearch-vm = {
+            type = "app";
+            program = "${self.nixosConfigurations.opensearch-vm.config.system.build.vm}/bin/run-nixos-vm";
+            meta.description = "Run OpenSearch on port 9200 in an ephemeral VM for local testing";
+          };
         }
       ) // {
         # Local testing VM configuration

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,7 @@
               packages.frontend
             ];
             extraPackages = [
+              pkgs.opensearch-cli
               pkgs.rustfmt
               pkgs.yarn
             ];


### PR DESCRIPTION
This is an alternative to #917, using the OpenSearch config from there to build a NixOS configuration for a VM that runs an OpenSearch node exposed to the host on port 9200. The VM run script is exposed via `apps.<system>.opensearch-vm` so you can just `nix run .#opensearch-vm` and get an accessible instance that you can load information into.