### PR TITLE
flake-info: support importing a single nixpkgs attribute via --attr

### DIFF
--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -58,7 +58,8 @@ enum Command {
         channel: String,
 
         #[structopt(
-            help = "Restrict to importing a single attribute",
+            long = "attr",
+            help = "Restrict to importing a single attribute. Implies --kind package",
         )]
         attribute: Option<String>,
     },
@@ -236,6 +237,8 @@ async fn run_command(
                 nixpkgs.channel.to_owned(),
                 nixpkgs.git_ref.to_owned(),
             );
+            // Force --kind package if an attribute was specified
+            let kind = if attribute.is_some() { Kind::Package } else { kind };
 
             Ok((
                 Box::new(move || {
@@ -251,6 +254,8 @@ async fn run_command(
                 channel.to_owned(),
                 "latest".to_string(),
             );
+            // Force --kind package if an attribute was specified
+            let kind = if attribute.is_some() { Kind::Package } else { kind };
 
             Ok((
                 Box::new(move || {

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -237,8 +237,14 @@ async fn run_command(
                 nixpkgs.channel.to_owned(),
                 nixpkgs.git_ref.to_owned(),
             );
-            // Force --kind package if an attribute was specified
-            let kind = if attribute.is_some() { Kind::Package } else { kind };
+            let kind = if attribute.is_some() {
+                if !matches!(kind, Kind::All | Kind::Package) {
+                    warn!("Forcing --kind package because --attr was specified");
+                }
+                Kind::Package
+            } else {
+                kind
+            };
 
             Ok((
                 Box::new(move || {
@@ -254,8 +260,14 @@ async fn run_command(
                 channel.to_owned(),
                 "latest".to_string(),
             );
-            // Force --kind package if an attribute was specified
-            let kind = if attribute.is_some() { Kind::Package } else { kind };
+            let kind = if attribute.is_some() {
+                if !matches!(kind, Kind::All | Kind::Package) {
+                    warn!("Forcing --kind package because --attr was specified");
+                }
+                Kind::Package
+            } else {
+                kind
+            };
 
             Ok((
                 Box::new(move || {

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -8,7 +8,7 @@ use crate::data::import::{NixOption, NixpkgsEntry, Package};
 use crate::data::Nixpkgs;
 use crate::Source;
 
-pub fn get_nixpkgs_info(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
+pub fn get_nixpkgs_info(nixpkgs: &Source, attribute: &Option<String>) -> Result<Vec<NixpkgsEntry>> {
     let mut command = Command::new("nix-env");
     command.add_args(&[
         "--json",
@@ -20,8 +20,12 @@ pub fn get_nixpkgs_info(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
         "config",
         "import <nixpkgs/pkgs/top-level/packages-config.nix>",
         "-qa",
-        "--meta",
     ]);
+    match attribute {
+        Some(attr) => { command.add_arg(attr); },
+        None => {},
+    }
+    command.add_arg("--meta");
 
     command.enable_capture();
     command.log_to = LogTo::Log;

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -39,9 +39,9 @@ pub fn process_flake(
     Ok((info, exports))
 }
 
-pub fn process_nixpkgs(nixpkgs: &Source, kind: &Kind) -> Result<Vec<Export>, anyhow::Error> {
+pub fn process_nixpkgs(nixpkgs: &Source, kind: &Kind, attribute: &Option<String>) -> Result<Vec<Export>, anyhow::Error> {
     let drvs = if matches!(kind, Kind::All | Kind::Package) {
-        commands::get_nixpkgs_info(nixpkgs)?
+        commands::get_nixpkgs_info(nixpkgs, attribute)?
     } else {
         Vec::new()
     };


### PR DESCRIPTION
Alternative to #916, with the additions that:

* When an attribute is provided to `nixpkgs` and `nixpkgs-archive`, `--kind package` is forced.
* The attribute is provided as `--attr <name>` instead of a positional argument. This is to make it easier to add something like `--option` in the future.