### PR TITLE
add flake.nix example to how to install tabs

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -597,6 +597,20 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         ]
                                     , li
                                         [ classList
+                                            [ ( "active", showInstallDetails == Search.ViaFlakeNix )
+                                            , ( "pull-right", True )
+                                            ]
+                                        ]
+                                        [ a
+                                            [ href "#"
+                                            , Search.onClickStop <|
+                                                SearchMsg <|
+                                                    Search.ShowInstallDetails Search.ViaFlakeNix
+                                            ]
+                                            [ text "flake.nix" ]
+                                        ]
+                                    , li
+                                        [ classList
                                             [ ( "active", showInstallDetails == Search.ViaNixOS )
                                             , ( "pull-right", True )
                                             ]
@@ -713,6 +727,50 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                             , strong [] [ text item.source.attr_name ]
                                             , text "\n# with flakes:\nnix profile install nixpkgs#"
                                             , strong [] [ text item.source.attr_name ]
+                                            ]
+                                        ]
+                                    , div
+                                        [ classList
+                                            [ ( "tab-pane", True )
+                                            , ( "active", showInstallDetails == Search.ViaFlakeNix )
+                                            ]
+                                        ]
+                                        [ p []
+                                            [ text "Add the following to your "
+                                            , strong [] [ text "flake.nix" ]
+                                            , text ":"
+                                            ]
+                                        ]
+                                    , div
+                                        [ classList
+                                            [ ( "active", showInstallDetails == Search.ViaFlakeNix )
+                                            ]
+                                        , class "tab-pane"
+                                        , id "package-details-flake"
+                                        ]
+                                        [ pre [ class "code-block" ]
+                                            [ text <| "{\n  inputs.nixpkgs.url = \"github:NixOS/nixpkgs/nixos-" ++ channel ++ "\";\n  outputs = { nixpkgs, ... }: {\n    packages.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux."
+                                            , strong [] [ text item.source.attr_name ]
+                                            , text <| ";\n    devShells.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux.mkShell {\n      packages = [ nixpkgs.legacyPackages.x86_64-linux."
+                                            , strong [] [ text item.source.attr_name ]
+                                            , text <| " ];\n    };\n  };\n}"
+                                            ]
+                                        ]
+                                    , div [] [ p [] [] ]
+                                    , div
+                                        [ classList
+                                            [ ( "active", showInstallDetails == Search.ViaFlakeNix )
+                                            ]
+                                        , class "tab-pane"
+                                        ]
+                                        [ p []
+                                            [ text "Then run "
+                                            , code [] [ text "nix build" ]
+                                            , text " to build the package, "
+                                            , code [] [ text "nix run" ]
+                                            , text " to run it directly, or "
+                                            , code [] [ text "nix develop" ]
+                                            , text " to enter a shell with the package available."
                                             ]
                                         ]
                                     , div

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -388,6 +388,7 @@ type Msg a b
 
 type Details
     = ViaNixShell
+    | ViaFlakeNix
     | ViaNixOS
     | ViaNixEnv
     | FromFlake


### PR DESCRIPTION
See screenshot for a new "flake.nix" tab in the "Host to install <package>?" section:
![image](https://github.com/user-attachments/assets/873c9271-0e9b-4691-b0af-70d5817b316d)

It works with their currently selected channel (example 24.11 selected): 
![image](https://github.com/user-attachments/assets/a72325db-ae0b-4e67-861d-f75ffd574472)
