### PR TITLE
docs: fix README.md content link 404

### DIFF
--- a/flake-info/README.md
+++ b/flake-info/README.md
@@ -169,7 +169,7 @@ $ flake-info --push \
 
 This tool requires your system to have Nix installed!
 
-You can install nix using this installer: https://nixos.org/guides/install-nix.html
+You can install nix using this installer: https://nixos.org/download/
 Also, see https://wiki.nixos.org/wiki/Nix_Installation_Guide if your system is ✨special✨.
 
 ### Preparations (Docker)


### PR DESCRIPTION
https://nixos.org/guides/install-nix.html return:

```
Not found
The requested content at /guides/install-nix.html could not be found.
```

new url https://nixos.org/download/
