### PR TITLE
frontend: add link to official NixOS Wiki

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -467,7 +467,7 @@ viewNavigation route =
             [ ( Route.Packages searchArgs, text "Packages" )
             , ( Route.Options searchArgs, text "NixOS options" )
             , ( Route.Flakes searchArgs, span [] [ text "Flakes", sup [] [ span [ class "label label-info" ] [ small [] [ text "Experimental" ] ] ] ] )
-            ]
+            ] ++ [ li [] [ a [ href "https://wiki.nixos.org" ] [ text "NixOS Wiki" ] ] ]
 
 
 viewNavigationItem :


### PR DESCRIPTION
I am often teaching people Nix, and then they bookmark search.nixos.org, as they find it really useful. Everything they need is on search.nixos.org, except for a reference to the NixOS wiki, which I inevitably have to refer them to.