### PR TITLE
Add https://github.com/vorburger/bazel-nix flake

### DIFF
--- a/flakes/github-ntoz.toml
+++ b/flakes/github-ntoz.toml
@@ -120,6 +120,11 @@ repo = "niri"
 
 [[sources]]
 type = "github"
+owner = "vorburger"
+repo = "bazel-nix"
+
+[[sources]]
+type = "github"
 owner = "yusdacra"
 repo = "nix-cargo-integration"
 


### PR DESCRIPTION
I'm [very new to Nix](https://github.com/vorburger/vorburger.ch-Notes/blob/develop/conferences/NixCon-2025.md)...

... is this OK? Wanted? As in, do you want contribs with PRs to one's Nix flakes, like this?

This would add https://github.com/vorburger/bazel-nix to https://search.nixos.org/flakes?channel=25.05&query=bazel

https://github.com/enola-dev/enola/pull/1879 demonstrates that this Flake actually works.

If you would rather not, just send me away! 🤣 I'm just trying to learn the ecosystem.