### PR TITLE
Rename `nix profile install` to `nix profile add`

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -648,7 +648,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                             ]
                                         ]
                                         [ pre [ class "code-block shell-command" ]
-                                            [ text "nix profile install "
+                                            [ text "nix profile add "
                                             , strong [] [ text flakeUrl ]
                                             , text "#"
                                             , em [] [ text item.source.attr_name ]
@@ -773,7 +773,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         [ pre [ class "code-block shell-command" ]
                                             [ text "# without flakes:\nnix-env -iA nixpkgs."
                                             , strong [] [ text item.source.attr_name ]
-                                            , text "\n# with flakes:\nnix profile install nixpkgs#"
+                                            , text "\n# with flakes:\nnix profile add nixpkgs#"
                                             , strong [] [ text item.source.attr_name ]
                                             ]
                                         ]


### PR DESCRIPTION
In `nix (Nix) 2.32.1` using `nix profile install` gives the following message:

```console
$ nix profile install nixpkgs#direnv
warning: 'install' is a deprecated alias for 'add'
```