### PR TITLE
fix: using nixfmt instead of deprecated nixpkgs-fmt

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import <nixpkgs> { }
+{
+  pkgs ? import <nixpkgs> { },
 }:
 pkgs.rustPlatform.buildRustPackage rec {
   name = "flake-info";
@@ -11,11 +12,13 @@ pkgs.rustPlatform.buildRustPackage rec {
   };
   nativeBuildInputs = with pkgs; [ pkg-config ];
   buildInputs =
-    with pkgs; [
+    with pkgs;
+    [
       openssl
       openssl.dev
       makeWrapper
-    ] ++ lib.optional pkgs.stdenv.isDarwin [
+    ]
+    ++ lib.optional pkgs.stdenv.isDarwin [
       libiconv
       darwin.apple_sdk.frameworks.Security
     ];

--- a/flake-info/src/data/link-manpages.nix
+++ b/flake-info/src/data/link-manpages.nix
@@ -9,8 +9,9 @@ pkgs.writeText "link-manpages.lua" ''
   ]]
 
   local manpage_urls = {
-  ${lib.concatStringsSep "\n" (lib.mapAttrsToList (man: url:
-    "  [${builtins.toJSON man}] = ${builtins.toJSON url},") manpageURLs)}
+  ${lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (man: url: "  [${builtins.toJSON man}] = ${builtins.toJSON url},") manpageURLs
+  )}
   }
 
   traverse = 'topdown'

--- a/frontend/default.nix
+++ b/frontend/default.nix
@@ -1,6 +1,7 @@
-{ pkgs ? import <nixpkgs> { }
-, nixosChannels
-, version
+{
+  pkgs ? import <nixpkgs> { },
+  nixosChannels,
+  version,
 }:
 pkgs.npmlock2nix.v1.build {
   src = ./.;
@@ -23,8 +24,8 @@ pkgs.npmlock2nix.v1.build {
     (with pkgs; [
       nodejs
       elm2nix
-    ]) ++
-    (with pkgs.elmPackages; [
+    ])
+    ++ (with pkgs.elmPackages; [
       elm
       elm-format
       elm-language-server
@@ -32,14 +33,16 @@ pkgs.npmlock2nix.v1.build {
     ]);
   node_modules_attrs = {
     sourceOverrides = {
-      elm = sourceIngo: drv: drv.overrideAttrs (old: {
-        postPatch = ''
-          sed -i -e "s|download(|//download(|" install.js
-          sed -i -e "s|request(|//request(|" download.js
-          sed -i -e "s|var version|return; var version|" download.js
-          cp ${pkgs.elmPackages.elm}/bin/elm bin/elm
-        '';
-      });
+      elm =
+        sourceIngo: drv:
+        drv.overrideAttrs (old: {
+          postPatch = ''
+            sed -i -e "s|download(|//download(|" install.js
+            sed -i -e "s|request(|//request(|" download.js
+            sed -i -e "s|var version|return; var version|" download.js
+            cp ${pkgs.elmPackages.elm}/bin/elm bin/elm
+          '';
+        });
     };
   };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,5 +1,4 @@
-final: prev:
-{
+final: prev: {
   nixos-search = {
     frontend = import ./frontend { pkgs = prev; };
     flake-info = import ./flake-info { pkgs = prev; };

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -3,7 +3,7 @@
   projectRootFile = "flake.nix";
 
   programs = {
-    nixpkgs-fmt.enable = true;
+    nixfmt.enable = true;
     rustfmt.enable = true;
     elm-format.enable = true;
 


### PR DESCRIPTION
I missed this detail when creating the config file

[nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt) was archived in favor of [nixfmt](https://github.com/NixOS/nixfmt/)