### PR TITLE
Always run flake-info even if result is cached on cachix

### DIFF
--- a/.github/workflows/build-flake-info.yml
+++ b/.github/workflows/build-flake-info.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Running flake-info tests
         shell: sh
         run: |
-          nix-build ./flake-info/assets/commands/test
+          nix-build ./flake-info/assets/commands/test --option extra-substituters ""


### PR DESCRIPTION
the derivation hash for https://github.com/NixOS/nixos-search/commit/fd9323bcd9b9fb9d248f4e274e83467e540bed7e did not change and the tests didn't run in github actions, the success result was just downloaded from cachix

https://github.com/NixOS/nixos-search/actions/runs/19267069275/job/55085401126