### PR TITLE
fix: replace `nix profile install` with `nix profile add`

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -851,7 +851,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         , id "package-details-nixpkgs"
                                         ]
                                         [ pre [ class "code-block shell-command" ]
-                                            [ text "nix profile install nixpkgs#"
+                                            [ text "nix profile add nixpkgs#"
                                             , strong [] [ text item.source.attr_name ]
                                             ]
                                         ]


### PR DESCRIPTION
Fixed #1131

`nix profile install` is deprecated in newer versions of Nix and would give you a warning.