### PR TITLE
feat(flake): github:Hythera/nix-waterfox

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -136,6 +136,11 @@ repo = "hyprland"
 
 [[sources]]
 type = "github"
+owner = "Hythera"
+repo = "nix-waterfox"
+
+[[sources]]
+type = "github"
 owner = "Infinidoge"
 repo = "nix-minecraft"
 


### PR DESCRIPTION
There is a [PR](https://github.com/NixOS/nixpkgs/pull/475318) for bringing Waterfox into `nixpkgs` but I doubt that it will get merged any time soon. I currently have a working flake for both the from source and precompiled build which users would be able to use in the meantime. 