### PR TITLE
fix(packages): directly filter `package_platforms` when querying

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -307,14 +307,9 @@ viewBuckets bucketsAsString result =
             selectedBucket.teams
         |> viewBucket
             "Platforms"
-            (result.aggregations.package_platforms.buckets |> sortBuckets |> filterPlatformsBucket)
+            (result.aggregations.package_platforms.buckets |> sortBuckets)
             (createBucketsMsg .platforms (\s v -> { s | platforms = v }))
             selectedBucket.platforms
-
-
-filterPlatformsBucket : List { a | key : String } -> List { a | key : String }
-filterPlatformsBucket =
-    List.filter (\a -> List.member a.key platforms)
 
 
 viewSuccess :
@@ -1034,11 +1029,11 @@ makeRequestBody query from size maybeBuckets sort =
         "package"
         "package_attr_name"
         [ "package_pversion" ]
-        [ "package_attr_set"
-        , "package_license_set"
-        , "package_maintainers_set"
-        , "package_teams_set"
-        , "package_platforms"
+        [ { field = "package_attr_set", size = 20, include = Nothing }
+        , { field = "package_license_set", size = 20, include = Nothing }
+        , { field = "package_maintainers_set", size = 20, include = Nothing }
+        , { field = "package_teams_set", size = 20, include = Nothing }
+        , { field = "package_platforms", size = 20, include = Just platforms }
         ]
         filterByBuckets
         "package_attr_name"

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -13,6 +13,7 @@ module Search exposing
     , ResultItem
     , SearchResult
     , Sort
+    , Terms
     , decodeAggregation
     , decodeNixOSChannels
     , decodeResolvedFlake
@@ -597,46 +598,64 @@ sortBy =
     ]
 
 
+type alias Terms =
+    { field : String
+    , size : Int
+    , include : Maybe (List String)
+    }
+
+
 toAggregations :
-    List String
+    List Terms
     -> ( String, Json.Encode.Value )
-toAggregations bucketsFields =
+toAggregations terms =
     let
-        fields =
+        aggs =
             List.map
-                (\field ->
-                    ( field
+                (\term ->
+                    ( term.field
                     , Json.Encode.object
                         [ ( "terms"
                           , Json.Encode.object
-                                [ ( "field"
-                                  , Json.Encode.string field
-                                  )
-                                , ( "size"
-                                  , Json.Encode.int 20
-                                  )
-                                ]
+                                ([ ( "field"
+                                   , Json.Encode.string term.field
+                                   )
+                                 , ( "size"
+                                   , Json.Encode.int term.size
+                                   )
+                                 ]
+                                    ++ (case term.include of
+                                            Just include ->
+                                                [ ( "include"
+                                                  , Json.Encode.list Json.Encode.string include
+                                                  )
+                                                ]
+
+                                            Nothing ->
+                                                []
+                                       )
+                                )
                           )
                         ]
                     )
                 )
-                bucketsFields
+                terms
 
-        allFields =
+        allAggs =
             [ ( "all"
               , Json.Encode.object
                     [ ( "global"
                       , Json.Encode.object []
                       )
                     , ( "aggregations"
-                      , Json.Encode.object fields
+                      , Json.Encode.object aggs
                       )
                     ]
               )
             ]
     in
     ( "aggs"
-    , Json.Encode.object <| fields ++ allFields
+    , Json.Encode.object <| aggs ++ allAggs
     )
 
 
@@ -1316,12 +1335,12 @@ makeRequestBody :
     -> String
     -> String
     -> List String
-    -> List String
+    -> List Terms
     -> List ( String, Json.Encode.Value )
     -> String
     -> List ( String, Float )
     -> Http.Body
-makeRequestBody query from sizeRaw sort type_ sortField otherSortFields bucketsFields filterByBuckets mainField fields =
+makeRequestBody query from sizeRaw sort type_ sortField otherSortFields terms filterByBuckets mainField fields =
     let
         -- you can not request more then 10000 results otherwise it will return 404
         size =
@@ -1346,7 +1365,7 @@ makeRequestBody query from sizeRaw sort type_ sortField otherSortFields bucketsF
               , Json.Encode.int size
               )
             , toSortQuery sort sortField otherSortFields
-            , toAggregations bucketsFields
+            , toAggregations terms
             , ( "query"
               , Json.Encode.object
                     [ ( "bool"


### PR DESCRIPTION
While querying packages, Elasticsearch terms aggregations are hard-capped at `size=20` returned buckets for responses. As bucket fields not in `platforms` can pollute the query response when their `doc_count` overshadows that of the allowlists' counts, this may cause platforms which would otherwise be counted when filtering the `package_platforms` aggregation with `filterPlatformsBucket` to be missed.

A possible hack is to bump `size` > 20. However, this is both stressful on the Elasticsearch instance for large values and dependant on the replacement magic being strictly less than the total possible number of platforms.

This patch introduces additional configurability for terms aggregations, allowing queries to optionally enforce an include list to filter at query time. Additionally, the `size` cap for returned buckets can now be configured per aggregation, if so desired.

Fixes #570.