### PR TITLE
fix darwin for `flake-info` pkgs

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -20,7 +20,6 @@ pkgs.rustPlatform.buildRustPackage rec {
     ]
     ++ lib.optional pkgs.stdenv.isDarwin [
       libiconv
-      darwin.apple_sdk.frameworks.Security
     ];
 
   checkInputs = with pkgs; [ pandoc ];


### PR DESCRIPTION
fixes build failure for darwin systems for `flake-info`, tossing dated [apple_sdk use](https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks)