### PR TITLE
Change import interval to every two hours

### DIFF
--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -1,9 +1,9 @@
-name: "Hourly import to Elasticsearch"
+name: "2-hourly import to Elasticsearch"
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */2 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
To reduce confusion as the import now takes 1.5h.

(this is _probably_ not a problem since the actual upload happens at the end of the run, but simpler is better)