### PR TITLE
feat: support modular services (backend)

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -178,7 +178,7 @@ let
         in
         opt
         // {
-          entry_type = "option";
+          entry_type = extraAttrs.entry_type or "option";
         }
         // applyOnAttr "default" substFunction
         // applyOnAttr "example" substFunction # (_: { __type = "function"; })
@@ -199,6 +199,65 @@ let
     map (cleanUpOption extraAttrs) (
       lib.filter (x: x.visible && !x.internal && lib.head x.loc != "_module") opts
     );
+
+  # Parses the angle-bracket prefix from modular service option names to extract
+  # service_package and service_module, strips the prefix, and tags as entry_type = "service".
+  parseServiceOption =
+    opt:
+    let
+      # Match: <imports = [ pkgs.PKG.services.MODULE ]>.OPTNAME
+      # Group 1: package attrname, group 2: module name, group 3: remaining option path
+      m = builtins.match ".*imports.*pkgs\\.([^.]+)\\.services\\.([^ ]+).*>\\.(.*)" opt.name;
+    in
+    if m != null then
+      opt
+      // {
+        entry_type = "service";
+        name = builtins.elemAt m 2;
+        service_package = builtins.elemAt m 0;
+        service_module = builtins.elemAt m 1;
+      }
+    else
+      # Fallback: keep as-is but still tag as service
+      opt // { entry_type = "service"; };
+
+  # Deduplicate service options that share the same underlying module. When
+  # several packages re-export the same service module (e.g. php, php82..php85
+  # all point to the same pkgs/development/interpreters/php/service.nix), we
+  # end up with identical option entries differing only by service_package.
+  # Group by (declarations, parsed name) and keep a single entry per group,
+  # with a canonical service_package and the full list in service_packages.
+  deduplicateServices =
+    opts:
+    let
+      keyOf =
+        opt:
+        builtins.toJSON [
+          (opt.declarations or [ ])
+          (opt.name or "")
+          (opt.service_module or "")
+        ];
+      addToGroup =
+        acc: opt:
+        let
+          k = keyOf opt;
+        in
+        acc // { ${k} = (acc.${k} or [ ]) ++ [ opt ]; };
+      grouped = lib.foldl' addToGroup { } opts;
+      mergeGroup =
+        entries:
+        let
+          # Sort packages alphabetically; the shortest/unversioned name (e.g.
+          # "php") naturally sorts before versioned variants ("php82").
+          packages = lib.sort (a: b: a < b) (lib.unique (map (e: e.service_package or "") entries));
+        in
+        (builtins.head entries)
+        // {
+          service_package = builtins.head packages;
+          service_packages = packages;
+        };
+    in
+    lib.mapAttrsToList (_: mergeGroup) grouped;
 
   readFlakeOptions =
     let
@@ -373,6 +432,78 @@ let
       }
     ) { } list;
 
+  # nixpkgs-specific, doesn't use the flake argument
+  nixpkgsBaseModules = import <nixpkgs/nixos/modules/module-list.nix> ++ [
+    <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix>
+    { nixpkgs.hostPlatform = "x86_64-linux"; }
+  ];
+
+  # Discover modular services by introspection: any package exposing a `.services`
+  # attrset where each value is a module (not a derivation). This does not rely on
+  # nixpkgs' documentation.nixos.extraModules (which is an intermediate solution)
+  # and automatically picks up new modular services as they are added.
+  discoverServiceModules =
+    let
+      tryGetServices =
+        pkgName:
+        let
+          eval = builtins.tryEval (
+            let
+              pkg = nixpkgs.${pkgName} or null;
+            in
+            if
+              pkg != null
+              && builtins.isAttrs pkg
+              && pkg ? services
+              && builtins.isAttrs pkg.services
+              && !(lib.isDerivation pkg.services)
+            then
+              lib.filter (n: !(lib.isDerivation pkg.services.${n})) (builtins.attrNames pkg.services)
+            else
+              [ ]
+          );
+        in
+        if eval.success then
+          map (moduleName: {
+            inherit pkgName moduleName;
+            module = nixpkgs.${pkgName}.services.${moduleName};
+          }) eval.value
+        else
+          [ ];
+    in
+    lib.concatMap tryGetServices (
+      builtins.filter (n: !(lib.hasPrefix "_" n)) (builtins.attrNames nixpkgs)
+    );
+
+  # Build a synthetic module that exposes each discovered service as a submodule
+  # option with a distinguishable name prefix, mirroring nixpkgs' fakeSubmodule
+  # approach so the rest of the pipeline (name parsing, etc.) stays unchanged.
+  discoveredServicesModule = {
+    options = lib.listToAttrs (
+      map (
+        {
+          pkgName,
+          moduleName,
+          module,
+        }:
+        {
+          name = "<imports = [ pkgs.${pkgName}.services.${moduleName} ]>";
+          value = lib.mkOption {
+            type = lib.types.submoduleWith { modules = [ module ]; };
+            description = "Modular service from pkgs.${pkgName}.services.${moduleName}";
+            default = { };
+          };
+        }
+      ) discoverServiceModules
+    );
+  };
+
+  # Evaluate base + discovered service modules together (service modules depend on
+  # base option types). Then partition: options whose name starts with "<" come
+  # from modular services.
+  nixpkgsAllOpts = readNixOSOptions { module = nixpkgsBaseModules ++ [ discoveredServicesModule ]; };
+  isServiceOption = opt: lib.hasPrefix "<" opt.name;
+
 in
 
 rec {
@@ -382,11 +513,22 @@ rec {
   options = readFlakeOptions;
   all = packages ++ apps ++ options;
 
-  # nixpkgs-specific, doesn't use the flake argument
-  nixos-options = readNixOSOptions {
-    module = import <nixpkgs/nixos/modules/module-list.nix> ++ [
-      <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix>
-      { nixpkgs.hostPlatform = "x86_64-linux"; }
-    ];
-  };
+  nixos-options = builtins.filter (opt: !(isServiceOption opt)) nixpkgsAllOpts;
+
+  nixos-services =
+    let
+      parsed = map parseServiceOption (builtins.filter isServiceOption nixpkgsAllOpts);
+      # Filter out top-level submodule container entries (no service_package means regex didn't match)
+      real = builtins.filter (opt: opt ? service_package) parsed;
+    in
+    deduplicateServices real;
+
+  # Map from package attribute name to the list of modular service module
+  # names it exposes. Used by the packages importer to annotate each package
+  # with its modular services so the UI can link to them only when they exist.
+  nixos-package-services = lib.foldl' (
+    acc:
+    { pkgName, moduleName, ... }:
+    acc // { ${pkgName} = (acc.${pkgName} or [ ]) ++ [ moduleName ]; }
+  ) { } discoverServiceModules;
 }

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -5,7 +5,9 @@ mod nixpkgs_info;
 pub use nix_check_version::{NixCheckError, check_nix_version};
 pub use nix_flake_attrs::get_derivation_info;
 pub use nix_flake_info::get_flake_info;
-pub use nixpkgs_info::{get_nixpkgs_info, get_nixpkgs_options};
+pub use nixpkgs_info::{
+    get_nixpkgs_info, get_nixpkgs_options, get_nixpkgs_package_services, get_nixpkgs_services,
+};
 
 use anyhow::{Context, Result};
 use command_run::{Command, LogTo};

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -47,6 +47,8 @@ pub fn get_nixpkgs_info(nixpkgs: &Source, attribute: &Option<String>) -> Result<
         _ => Default::default(),
     };
 
+    let mut package_services = get_nixpkgs_package_services(nixpkgs).unwrap_or_default();
+
     Ok(attr_set
         .into_iter()
         .map(|(attribute, package)| {
@@ -55,13 +57,35 @@ pub fn get_nixpkgs_info(nixpkgs: &Source, attribute: &Option<String>) -> Result<
                 .unwrap_or_default()
                 .into_iter()
                 .collect();
+            let modular_services = package_services.remove(&attribute).unwrap_or_default();
             NixpkgsEntry::Derivation {
                 attribute,
                 package,
                 programs,
+                modular_services,
             }
         })
         .collect())
+}
+
+pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {
+    let mut command = Command::with_args("nix", &["eval", "--json"]);
+    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
+    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_arg("nixos-package-services");
+
+    command.enable_capture();
+    command.log_to = LogTo::Log;
+    command.log_output_on_error = true;
+
+    let cow = command
+        .run()
+        .with_context(|| "Failed to gather modular service mapping for packages")?;
+
+    let output = &*cow.stdout_string_lossy();
+    let map: HashMap<String, Vec<String>> =
+        serde_json::from_str(output).with_context(|| "Could not parse package-services map")?;
+    Ok(map)
 }
 
 pub fn get_nixpkgs_programs(nixpkgs: &Nixpkgs) -> Result<HashMap<String, HashSet<String>>> {
@@ -123,4 +147,26 @@ pub fn get_nixpkgs_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
         serde_path_to_error::deserialize(de).with_context(|| "Could not parse options")?;
 
     Ok(attr_set.into_iter().map(NixpkgsEntry::Option).collect())
+}
+
+pub fn get_nixpkgs_services(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
+    let mut command = Command::with_args("nix", &["eval", "--json"]);
+    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
+    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_arg("nixos-services");
+
+    command.enable_capture();
+    command.log_to = LogTo::Log;
+    command.log_output_on_error = true;
+
+    let cow = command
+        .run()
+        .with_context(|| "Failed to gather information about nixpkgs modular services")?;
+
+    let output = &*cow.stdout_string_lossy();
+    let de = &mut Deserializer::from_str(output);
+    let attr_set: Vec<NixOption> =
+        serde_path_to_error::deserialize(de).with_context(|| "Could not parse services")?;
+
+    Ok(attr_set.into_iter().map(NixpkgsEntry::Service).collect())
 }

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -85,6 +85,7 @@ pub enum Derivation {
         package_system: String,
         package_homepage: Vec<String>,
         package_position: Option<String>,
+        package_modular_services: Vec<String>,
     },
     #[serde(rename = "app")]
     App {
@@ -109,6 +110,19 @@ pub enum Derivation {
         option_example: Option<DocValue>,
 
         option_flake: Option<ModulePath>,
+    },
+    #[serde(rename = "service")]
+    Service {
+        option_source: Option<String>,
+        option_name: String,
+        option_description: Option<DocString>,
+        option_type: Option<String>,
+        option_default: Option<DocValue>,
+        option_example: Option<DocValue>,
+        option_flake: Option<ModulePath>,
+        service_package: Option<String>,
+        service_module: Option<String>,
+        service_packages: Vec<String>,
     },
 }
 
@@ -176,6 +190,7 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                     package_system: String::new(),
                     package_homepage: Vec::new(),
                     package_position: None,
+                    package_modular_services: Vec::new(),
                 }
             }
             import::FlakeEntry::App {
@@ -203,6 +218,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 attribute,
                 package,
                 programs,
+                modular_services,
             } => {
                 let package_attr_set: Vec<_> = attribute.split(".").collect();
                 let package_attr_set: String = (if package_attr_set.len() > 1 {
@@ -299,9 +315,36 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                         .homepage
                         .map_or(Default::default(), OneOrMany::into_list),
                     package_position: position,
+                    package_modular_services: modular_services,
                 }
             }
             import::NixpkgsEntry::Option(option) => option.try_into()?,
+            import::NixpkgsEntry::Service(option) => {
+                let NixOption {
+                    declarations,
+                    description,
+                    name,
+                    option_type,
+                    default,
+                    example,
+                    flake,
+                    service_package,
+                    service_module,
+                    service_packages,
+                } = option;
+                Derivation::Service {
+                    option_source: declarations.get(0).map(Clone::clone),
+                    option_name: name,
+                    option_description: description,
+                    option_default: default,
+                    option_example: example,
+                    option_flake: flake,
+                    option_type,
+                    service_package,
+                    service_module,
+                    service_packages,
+                }
+            }
         })
     }
 }
@@ -318,6 +361,7 @@ impl TryFrom<import::NixOption> for Derivation {
             default,
             example,
             flake,
+            ..
         }: import::NixOption,
     ) -> Result<Self, Self::Error> {
         Ok(Derivation::Option {

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -71,6 +71,19 @@ pub struct NixOption {
 
     /// If defined in a flake, contains defining flake and optionally a module
     pub flake: Option<ModulePath>,
+
+    /// For modular service options: the canonical package attrname providing this service
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_package: Option<String>,
+
+    /// For modular service options: the module name (e.g. "default")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_module: Option<String>,
+
+    /// For modular service options: all packages that expose this same service
+    /// module (e.g. ["php", "php82", "php83", "php84", "php85"]).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_packages: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -184,8 +197,10 @@ pub enum NixpkgsEntry {
         attribute: String,
         package: Package,
         programs: Vec<String>,
+        modular_services: Vec<String>,
     },
     Option(NixOption),
+    Service(NixOption),
 }
 
 /// Most information about packages in nixpkgs is contained in the meta key
@@ -238,6 +253,7 @@ arg_enum! {
         App,
         Package,
         Option,
+        ModularService,
         All,
     }
 }
@@ -248,6 +264,7 @@ impl AsRef<str> for Kind {
             Kind::App => "apps",
             Kind::Package => "packages",
             Kind::Option => "options",
+            Kind::ModularService => "services",
             Kind::All => "all",
         }
     }
@@ -459,6 +476,7 @@ mod tests {
                 attribute,
                 package,
                 programs: Vec::new(),
+                modular_services: Vec::new(),
             })
             .collect();
     }

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -144,6 +144,9 @@ lazy_static! {
                 "package_homepage": {
                     "type": "keyword"
                 },
+                "package_modular_services": {
+                    "type": "keyword"
+                },
                 // Options fields
                 "option_name": {
                     "type": "keyword",
@@ -162,6 +165,20 @@ lazy_static! {
                 "option_default": {"type": "text"},
                 "option_example": {"type": "text"},
                 "option_source": {"type": "keyword"},
+                // Modular service fields
+                "service_package": {
+                    "type": "keyword",
+                    "fields": {
+                        "edge": {"type": "text", "analyzer": "edge"}
+                    },
+                },
+                "service_module": {"type": "keyword"},
+                "service_packages": {
+                    "type": "keyword",
+                    "fields": {
+                        "edge": {"type": "text", "analyzer": "edge"}
+                    },
+                },
             }
         },
         "settings": {

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -62,8 +62,15 @@ pub fn process_nixpkgs(
         Vec::new()
     };
 
+    let mut services = if matches!(kind, Kind::All | Kind::ModularService) {
+        commands::get_nixpkgs_services(nixpkgs)?
+    } else {
+        Vec::new()
+    };
+
     let mut all = drvs;
     all.append(&mut options);
+    all.append(&mut services);
 
     let exports = all
         .into_iter()

--- a/version.nix
+++ b/version.nix
@@ -2,7 +2,7 @@
   /**
     Backend index version used by import jobs when writing data to Elasticsearch
   */
-  import = "44";
+  import = "45";
 
   /**
     Frontend index version used by the UI when querying Elasticsearch


### PR DESCRIPTION
Adds modular-service discovery to flake-info: each package's nixpkgs service modules are introspected into standalone option docs tagged with `type=service` plus service_package/service_module metadata, and package docs gain a package_modular_services list of provided modules.

Bump backend index schema to 45 so ingest writes the new docs to fresh indices. The frontend schema version stays at 44 and continues to read the existing latest-44-* indices until a follow-up PR switches it over.

split out from #1186.

first part of #1167.
