### PR TITLE
feat(frontend): show modular service options

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -39,6 +39,7 @@ import Search
         , decodeNixOSChannels
         , defaultFlakeId
         )
+import Set
 import Shortcut
 import Task
 import Url
@@ -176,7 +177,25 @@ attemptQuery (( model, _ ) as pair) =
 
         Options searchModel ->
             if Search.shouldLoad searchModel then
-                submitQuery OptionsMsg Page.Options.makeRequest { searchModel | searchType = OptionSearch }
+                Tuple.mapSecond
+                    (\cmd ->
+                        Cmd.batch
+                            [ cmd
+                            , Cmd.map OptionsMsg <|
+                                Page.Options.makeRequest
+                                    model.elasticsearch
+                                    model.nixosChannels
+                                    OptionSearch
+                                    searchModel.channel
+                                    searchModel.query
+                                    searchModel.from
+                                    searchModel.size
+                                    searchModel.buckets
+                                    searchModel.sort
+                                    searchModel.excludedOptionSources
+                            ]
+                    )
+                    pair
 
             else
                 noEffects pair
@@ -456,13 +475,13 @@ viewNavigation route =
                         args
 
                     _ ->
-                        Route.SearchArgs Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+                        Route.SearchArgs Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Set.empty
     in
     li [] [ a [ href "https://nixos.org" ] [ text "Back to nixos.org" ] ]
         :: List.map
             (viewNavigationItem route)
             [ ( Route.Packages searchArgs, text "Packages" )
-            , ( Route.Options searchArgs, text "NixOS options" )
+            , ( Route.Options searchArgs, text "Options" )
             , ( Route.Flakes searchArgs, text "3rd-party Flakes" )
             ]
         ++ [ li [] [ a [ href "https://wiki.nixos.org" ] [ text "NixOS Wiki" ] ] ]

--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -240,7 +240,7 @@ makeRequestBody : SearchType -> String -> Int -> Int -> Maybe String -> Search.S
 makeRequestBody searchType query from size maybeBuckets sort =
     case searchType of
         OptionSearch ->
-            Page.Options.makeRequestBody query from size sort
+            Page.Options.makeRequestBody [ "option" ] query from size sort
 
         PackageSearch ->
             Page.Packages.makeRequestBody query from size maybeBuckets sort

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -22,6 +22,8 @@ import Html
         , a
         , code
         , div
+        , input
+        , label
         , li
         , pre
         , span
@@ -31,26 +33,30 @@ import Html
         )
 import Html.Attributes
     exposing
-        ( class
+        ( checked
+        , class
         , classList
         , href
         , target
+        , type_
         )
 import Html.Events
     exposing
-        ( onClick
+        ( onCheck
+        , onClick
         )
 import Http exposing (Body)
 import Json.Decode
 import Json.Decode.Pipeline
 import List.Extra
-import Route exposing (SearchType)
+import Route exposing (OptionSource, SearchType)
 import Search
     exposing
         ( Details
         , NixOSChannel
         , decodeResolvedFlake
         )
+import Set exposing (Set)
 import SyntaxHighlight exposing (elm, oneDark, toBlockHtml, useTheme)
 import Utils
 
@@ -76,6 +82,11 @@ type alias ResultItemSource =
     , flakeName : Maybe String
     , flakeDescription : Maybe String
     , flakeUrl : Maybe String
+
+    -- modular service metadata (populated only for `service` docs)
+    , servicePackage : Maybe String
+    , serviceModule : Maybe String
+    , servicePackages : List String
     }
 
 
@@ -152,7 +163,38 @@ view nixosChannels model =
         viewSuccess
         viewBuckets
         SearchMsg
-        []
+        [ viewIncludeTogglesGroup model.excludedOptionSources ]
+
+
+viewIncludeTogglesGroup : Set String -> Html Msg
+viewIncludeTogglesGroup excluded =
+    li [ class "search-include-toggles" ]
+        [ ul [] <|
+            li [ class "header" ] [ text "Show" ]
+                :: List.map (viewIncludeToggle excluded) Route.allOptionSources
+        ]
+
+
+viewIncludeToggle : Set String -> OptionSource -> Html Msg
+viewIncludeToggle excluded source =
+    let
+        id =
+            Route.optionSourceId source
+
+        isChecked =
+            not (Set.member id excluded)
+    in
+    li [ class ("search-include-" ++ id ++ "-options") ]
+        [ label []
+            [ input
+                [ type_ "checkbox"
+                , checked isChecked
+                , onCheck (\b -> SearchMsg (Search.SetOptionSourceIncluded source b))
+                ]
+                []
+            , text (" " ++ Route.optionSourceLabel source)
+            ]
+        ]
 
 
 viewBuckets :
@@ -201,12 +243,31 @@ viewResultItem nixosChannels channel show item =
                         (pre [] [ code [ class "code-block" ] [ text value ] ])
                 ]
 
+        -- Modular-service options are stored with just the short option name
+        -- (e.g. "package") and carry `service_module` metadata. Render the
+        -- full `system.services.<name>.<module>.<option>` path so users can
+        -- see how the option is addressed in configuration.
+        isService =
+            item.source.serviceModule /= Nothing || item.source.servicePackage /= Nothing
+
+        nameSegments =
+            optionNameSegments isService item.source
+
+        displayName =
+            nameSegments |> List.map Tuple.first |> String.join "."
+
         showDetails =
             if Just item.source.name == show then
                 Just <|
                     div [ Html.Attributes.map SearchMsg Search.trapClick ] <|
+                        let
+                            pkgLink pkg =
+                                a
+                                    [ href ("/packages?channel=" ++ channel ++ "&query=" ++ pkg ++ "&show=" ++ pkg) ]
+                                    [ code [] [ text pkg ] ]
+                        in
                         [ div [] [ text "Name" ]
-                        , div [] [ viewOptionNameDetail channel item.source.name ]
+                        , div [] [ viewOptionNamePath channel nameSegments ]
                         ]
                             ++ (item.source.description
                                     |> Maybe.andThen Utils.showHtml
@@ -244,6 +305,132 @@ viewResultItem nixosChannels channel show item =
                                             ]
                                         )
                                     |> Maybe.withDefault []
+                               )
+                            ++ (if isService then
+                                    [ div [] [ text "About" ]
+                                    , div []
+                                        [ a
+                                            [ href "https://nixos.org/manual/nixos/stable/#modular-services"
+                                            , Html.Attributes.target "_blank"
+                                            ]
+                                            [ text "What are modular services?" ]
+                                        ]
+                                    ]
+
+                                else
+                                    []
+                               )
+                            ++ (if isService then
+                                    case item.source.servicePackages of
+                                        [] ->
+                                            item.source.servicePackage
+                                                |> Maybe.map
+                                                    (\pkg ->
+                                                        [ div [] [ text "Provided by package" ]
+                                                        , div [] [ pkgLink pkg ]
+                                                        ]
+                                                    )
+                                                |> Maybe.withDefault []
+
+                                        [ single ] ->
+                                            [ div [] [ text "Provided by package" ]
+                                            , div [] [ pkgLink single ]
+                                            ]
+
+                                        many ->
+                                            [ div [] [ text "Provided by packages" ]
+                                            , div []
+                                                (List.intersperse (text ", ") (List.map pkgLink many))
+                                            ]
+
+                                else
+                                    []
+                               )
+                            ++ (if isService then
+                                    case ( item.source.servicePackage, item.source.serviceModule ) of
+                                        ( Just pkg, Just mod_ ) ->
+                                            let
+                                                -- Re-indent a (possibly multi-line) value so
+                                                -- every line after the first aligns with `indent`.
+                                                indentValue indent val =
+                                                    case String.split "\n" val of
+                                                        [] ->
+                                                            val
+
+                                                        first :: rest ->
+                                                            first
+                                                                ++ String.concat
+                                                                    (List.map (\l -> "\n" ++ indent ++ l) rest)
+
+                                                -- Only use defaults that look like plain Nix
+                                                -- expressions (from `literalExpression`).
+                                                -- Rendered HTML/markdown defaults are not
+                                                -- useful in a code snippet.
+                                                isNixLiteral val =
+                                                    not (String.contains "<" val)
+
+                                                leafValue indent =
+                                                    item.source.default
+                                                        |> Maybe.andThen
+                                                            (\val ->
+                                                                if isNixLiteral val then
+                                                                    Just (indentValue indent val)
+
+                                                                else
+                                                                    Nothing
+                                                            )
+                                                        |> Maybe.withDefault "..."
+
+                                                -- Expand "php-fpm.settings" into nested:
+                                                --   php-fpm = {
+                                                --     settings = <default>;
+                                                --   };
+                                                nestOption parts indent =
+                                                    case parts of
+                                                        [] ->
+                                                            ""
+
+                                                        [ leaf ] ->
+                                                            indent ++ leaf ++ " = " ++ leafValue indent ++ ";\n"
+
+                                                        head_ :: rest ->
+                                                            indent
+                                                                ++ head_
+                                                                ++ " = {\n"
+                                                                ++ nestOption rest (indent ++ "  ")
+                                                                ++ indent
+                                                                ++ "};\n"
+
+                                                optionParts =
+                                                    String.split "." item.source.name
+
+                                                nestedOption =
+                                                    nestOption optionParts "  "
+                                            in
+                                            [ div [] [ text "Usage" ]
+                                            , div []
+                                                [ pre []
+                                                    [ code [ class "code-block" ]
+                                                        [ text
+                                                            ("system.services.<name> = {\n"
+                                                                ++ "  imports = [ pkgs."
+                                                                ++ pkg
+                                                                ++ ".services."
+                                                                ++ mod_
+                                                                ++ " ];\n"
+                                                                ++ nestedOption
+                                                                ++ "};"
+                                                            )
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+
+                                        _ ->
+                                            []
+
+                                else
+                                    []
                                )
                             ++ [ div [] [ text "Declared in" ]
                                , div [] <| findSource nixosChannels channel item.source
@@ -291,7 +478,7 @@ viewResultItem nixosChannels channel show item =
                                 [ onClick toggle
                                 , href ""
                                 ]
-                                [ text item.source.name ]
+                                [ text displayName ]
                             ]
                         ]
                     )
@@ -359,23 +546,62 @@ findSource nixosChannels channel source =
             [ span [] [ text "Not Found" ] ]
 
 
-{-| Render an option name as dot-separated segments where each non-final
-segment links to an options search filtered by that prefix. This lets users
-click-navigate into option groups (e.g. `programs.firefox`) from the
-expanded option details.
+{-| Segments making up an option's display name. Each `(text, Just q)` becomes
+a clickable link to an options search for `q`; `(text, Nothing)` is static.
+Every non-final dotted segment of the option name links to its own prefix
+(`programs` -> `programs.firefox` -> ...). For modular services the synthetic
+`system.services.<name>.` prefix is prepended as static text followed by the
+service module name, which is clickable on its own.
 -}
-viewOptionNameDetail : String -> String -> Html Msg
-viewOptionNameDetail channel name =
+optionNameSegments : Bool -> ResultItemSource -> List ( String, Maybe String )
+optionNameSegments isService source =
     let
-        parts =
-            String.split "." name
+        -- Split a dotted name into segments, attaching the dot-prefix up to
+        -- and including each segment as its search query. Every segment
+        -- becomes clickable; the leaf's query just equals the full name.
+        dottedSegments name =
+            let
+                parts =
+                    String.split "." name
+            in
+            parts
+                |> List.indexedMap
+                    (\idx part ->
+                        ( part
+                        , parts |> List.take (idx + 1) |> String.join "." |> Just
+                        )
+                    )
 
+        servicePrefix =
+            if isService then
+                [ ( "system", Nothing ), ( "services", Nothing ), ( "<name>", Nothing ) ]
+                    ++ (source.serviceModule
+                            |> Maybe.andThen
+                                (\m ->
+                                    if m == "default" then
+                                        Nothing
+
+                                    else
+                                        Just (dottedSegments m)
+                                )
+                            |> Maybe.withDefault []
+                       )
+
+            else
+                []
+    in
+    servicePrefix ++ dottedSegments source.name
+
+
+viewOptionNamePath : String -> List ( String, Maybe String ) -> Html Msg
+viewOptionNamePath channel segments =
+    let
         lastIndex =
-            List.length parts - 1
+            List.length segments - 1
 
-        groupRoute prefix =
+        groupRoute q =
             Route.Options
-                { query = Just prefix
+                { query = Just q
                 , channel = Just channel
                 , show = Nothing
                 , from = Nothing
@@ -383,14 +609,20 @@ viewOptionNameDetail channel name =
                 , buckets = Nothing
                 , sort = Nothing
                 , type_ = Nothing
+                , excludedOptionSources = Set.empty
                 }
 
-        renderSegment idx segment =
+        renderSegment idx ( segText, query ) =
             let
-                prefix =
-                    parts
-                        |> List.take (idx + 1)
-                        |> String.join "."
+                element =
+                    case query of
+                        Just q ->
+                            a
+                                [ Route.href (groupRoute q), class "option-name-group" ]
+                                [ text segText ]
+
+                        Nothing ->
+                            text segText
 
                 separator =
                     if idx < lastIndex then
@@ -399,24 +631,12 @@ viewOptionNameDetail channel name =
                     else
                         []
             in
-            if idx == lastIndex then
-                text segment :: separator
-
-            else
-                a
-                    [ Route.href (groupRoute prefix)
-                    , class "option-name-group"
-                    ]
-                    [ text segment ]
-                    :: separator
+            element :: separator
     in
     div []
         [ pre []
             [ code [ class "code-block" ]
-                (parts
-                    |> List.indexedMap renderSegment
-                    |> List.concat
-                )
+                (segments |> List.indexedMap renderSegment |> List.concat)
             ]
         ]
 
@@ -435,10 +655,20 @@ makeRequest :
     -> Int
     -> Maybe String
     -> Search.Sort
+    -> Set String
     -> Cmd Msg
-makeRequest options nixosChannels _ channel query from size _ sort =
+makeRequest options nixosChannels _ channel query from size _ sort excludedOptionSources =
+    let
+        types =
+            Route.allOptionSources
+                |> List.filter
+                    (\source ->
+                        not (Set.member (Route.optionSourceId source) excludedOptionSources)
+                    )
+                |> List.map Route.optionSourceDocType
+    in
     Search.makeRequest
-        (makeRequestBody query from size sort)
+        (makeRequestBody types query from size sort)
         nixosChannels
         channel
         decodeResultItemSource
@@ -449,14 +679,14 @@ makeRequest options nixosChannels _ channel query from size _ sort =
         |> Cmd.map SearchMsg
 
 
-makeRequestBody : String -> Int -> Int -> Search.Sort -> Body
-makeRequestBody query from size sort =
+makeRequestBody : List String -> String -> Int -> Int -> Search.Sort -> Body
+makeRequestBody types query from size sort =
     Search.makeRequestBody
         (String.trim query)
         from
         size
         sort
-        "option"
+        types
         "option_name"
         []
         []
@@ -465,6 +695,8 @@ makeRequestBody query from size sort =
         [ ( "option_name", 6.0 )
         , ( "option_description", 1.0 )
         , ( "flake_name", 0.5 )
+        , ( "service_package", 3.0 )
+        , ( "service_packages", 3.0 )
         ]
 
 
@@ -487,6 +719,9 @@ decodeResultItemSource =
         |> Json.Decode.Pipeline.optional "flake_name" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "flake_description" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "flake_resolved" (Json.Decode.map Just decodeResolvedFlake) Nothing
+        |> Json.Decode.Pipeline.optional "service_package" (Json.Decode.map Just Json.Decode.string) Nothing
+        |> Json.Decode.Pipeline.optional "service_module" (Json.Decode.map Just Json.Decode.string) Nothing
+        |> Json.Decode.Pipeline.optional "service_packages" (Json.Decode.list Json.Decode.string) []
 
 
 decodeResultAggregations : Json.Decode.Decoder ResultAggregations

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -91,6 +91,7 @@ type alias ResultItemSource =
     , flakeName : Maybe String
     , flakeDescription : Maybe String
     , flakeUrl : Maybe ( String, String )
+    , modularServices : List String
     }
 
 
@@ -853,6 +854,41 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                 ]
                     , programs
                     , maintainersTeamsAndPlatforms
+                    , if List.isEmpty item.source.modularServices then
+                        text ""
+
+                      else
+                        div []
+                            [ h4 []
+                                [ text "Modular Services"
+                                , text " "
+                                , a
+                                    [ href "https://nixos.org/manual/nixos/stable/#modular-services"
+                                    , Html.Attributes.target "_blank"
+                                    , Html.Attributes.title "What are modular services?"
+                                    ]
+                                    [ text "(?)" ]
+                                ]
+                            , ul []
+                                (List.map
+                                    (\mod_ ->
+                                        let
+                                            suffix =
+                                                if mod_ == "default" then
+                                                    ""
+
+                                                else
+                                                    "." ++ mod_
+                                        in
+                                        li []
+                                            [ a
+                                                [ href ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name ++ "&include_nixos_options=0") ]
+                                                [ code [] [ text ("pkgs." ++ item.source.attr_name ++ ".services" ++ suffix) ] ]
+                                            ]
+                                    )
+                                    item.source.modularServices
+                                )
+                            ]
                     ]
                 ]
 
@@ -1026,7 +1062,7 @@ makeRequestBody query from size maybeBuckets sort =
         from
         size
         sort
-        "package"
+        [ "package" ]
         "package_attr_name"
         [ "package_pversion" ]
         [ { field = "package_attr_set", size = 20, include = Nothing }
@@ -1094,6 +1130,7 @@ decodeResultItemSource =
         |> Json.Decode.Pipeline.optional "flake_name" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "flake_description" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "flake_resolved" (Json.Decode.map Just decodeResolvedFlake) Nothing
+        |> Json.Decode.Pipeline.optional "package_modular_services" (Json.Decode.list Json.Decode.string) []
 
 
 type alias ResolvedFlake =

--- a/frontend/src/Route.elm
+++ b/frontend/src/Route.elm
@@ -1,11 +1,16 @@
 module Route exposing
-    ( Route(..)
+    ( OptionSource(..)
+    , Route(..)
     , SearchArgs
     , SearchRoute
     , SearchType(..)
+    , allOptionSources
     , allTypes
     , fromUrl
     , href
+    , optionSourceDocType
+    , optionSourceId
+    , optionSourceLabel
     , routeToString
     , searchTypeToTitle
     )
@@ -15,6 +20,7 @@ import Dict
 import Html
 import Html.Attributes
 import Maybe.Extra
+import Set exposing (Set)
 import Url
 
 
@@ -31,7 +37,63 @@ type alias SearchArgs =
     , buckets : Maybe String
     , sort : Maybe String
     , type_ : Maybe SearchType
+    , excludedOptionSources : Set String
     }
+
+
+{-| Kinds of options that can be shown on the Options page. Each source maps
+to an Elasticsearch document `type` and has its own checkbox in the UI.
+Add a new variant here (plus its cases below) to expose it to the page.
+-}
+type OptionSource
+    = NixosOptions
+    | ModularServiceOptions
+
+
+allOptionSources : List OptionSource
+allOptionSources =
+    [ NixosOptions, ModularServiceOptions ]
+
+
+{-| Stable identifier used in URL parameter names and the excluded-sources set.
+-}
+optionSourceId : OptionSource -> String
+optionSourceId source =
+    case source of
+        NixosOptions ->
+            "nixos"
+
+        ModularServiceOptions ->
+            "modular_service"
+
+
+{-| Elasticsearch document `type` field value.
+-}
+optionSourceDocType : OptionSource -> String
+optionSourceDocType source =
+    case source of
+        NixosOptions ->
+            "option"
+
+        ModularServiceOptions ->
+            "service"
+
+
+{-| Human-readable checkbox label.
+-}
+optionSourceLabel : OptionSource -> String
+optionSourceLabel source =
+    case source of
+        NixosOptions ->
+            "NixOS"
+
+        ModularServiceOptions ->
+            "Modular services"
+
+
+optionSourceUrlParam : OptionSource -> String
+optionSourceUrlParam source =
+    "include_" ++ optionSourceId source ++ "_options"
 
 
 type SearchType
@@ -41,6 +103,7 @@ type SearchType
 
 
 -- | FlakeSearch
+-- Sub-navigation inside the 3rd-party Flakes page.
 
 
 allTypes : List SearchType
@@ -126,6 +189,18 @@ searchQueryParser appUrl =
     , buckets = string "buckets"
     , sort = string "sort"
     , type_ = Maybe.andThen searchTypeFromString (string "type")
+    , excludedOptionSources =
+        -- Each source defaults to included; URL explicitly says "0" to exclude.
+        allOptionSources
+            |> List.filterMap
+                (\source ->
+                    if string (optionSourceUrlParam source) == Just "0" then
+                        Just (optionSourceId source)
+
+                    else
+                        Nothing
+                )
+            |> Set.fromList
     }
 
 
@@ -149,6 +224,19 @@ searchArgsToUrl args =
     , string "type" <| Maybe.map searchTypeToString args.type_
     , string "query" args.query
     ]
+        ++ List.map
+            (\source ->
+                let
+                    value =
+                        if Set.member (optionSourceId source) args.excludedOptionSources then
+                            "0"
+
+                        else
+                            "1"
+                in
+                string (optionSourceUrlParam source) (Just value)
+            )
+            allOptionSources
         |> Maybe.Extra.values
         |> Dict.fromList
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -84,10 +84,12 @@ import List.Extra
 import RemoteData
 import Route
     exposing
-        ( SearchType
+        ( OptionSource
+        , SearchType
         , allTypes
         , searchTypeToTitle
         )
+import Set exposing (Set)
 import Task
 
 
@@ -105,6 +107,7 @@ type alias Model a b =
     , showInstallDetails : Details
     , searchType : Route.SearchType
     , redirectedChannel : Maybe String
+    , excludedOptionSources : Set String
     }
 
 
@@ -342,6 +345,7 @@ init args defaultNixOSChannel nixosChannels maybeModel =
       , searchType =
             args.type_
                 |> Maybe.withDefault defaultSearchArgs.searchType
+      , excludedOptionSources = args.excludedOptionSources
       }
         |> ensureLoading nixosChannels
     , Browser.Dom.focus "search-query-input" |> Task.attempt (\_ -> NoOp)
@@ -410,6 +414,7 @@ type Msg a b
     | ShowDetails String
     | ChangePage Int
     | ShowInstallDetails Details
+    | SetOptionSourceIncluded OptionSource Bool
 
 
 type Details
@@ -540,6 +545,26 @@ update toRoute navKey msg model nixosChannels =
             { model | showInstallDetails = details }
                 |> pushUrl toRoute navKey
 
+        SetOptionSourceIncluded source included ->
+            let
+                id =
+                    Route.optionSourceId source
+
+                excluded =
+                    if included then
+                        Set.remove id model.excludedOptionSources
+
+                    else
+                        Set.insert id model.excludedOptionSources
+            in
+            { model
+                | excludedOptionSources = excluded
+                , show = Nothing
+                , from = 0
+            }
+                |> ensureLoading nixosChannels
+                |> pushUrl toRoute navKey
+
 
 pushUrl :
     Route.SearchRoute
@@ -578,6 +603,7 @@ createUrl toRoute model =
                 justIfNotDefault model.sort defaultSearchArgs.sort
                     |> Maybe.map toSortId
             , type_ = justIfNotDefault model.searchType defaultSearchArgs.searchType
+            , excludedOptionSources = model.excludedOptionSources
             }
 
 
@@ -684,11 +710,15 @@ toSortQuery sort field fields =
                 ]
 
         Relevance ->
+            -- When scores tie, fall back to ascending alphabetical order on the
+            -- main field (and any secondary fields). Using asc gives a natural
+            -- reading order, e.g. `php-fpm.package` before `php-fpm.settings`,
+            -- instead of the reverse order you get with desc.
             Json.Encode.list Json.Encode.object
                 [ ( "_score", Json.Encode.string "desc" )
-                    :: ( field, Json.Encode.string "desc" )
+                    :: ( field, Json.Encode.string "asc" )
                     :: List.map
-                        (\x -> ( x, Json.Encode.string "desc" ))
+                        (\x -> ( x, Json.Encode.string "asc" ))
                         fields
                 ]
     )
@@ -909,8 +939,7 @@ viewResult nixosChannels outMsg categoryName model viewSuccess viewBuckets searc
             in
             div []
                 [ div [ class "alert alert-error" ]
-                    [ ul [ class "search-sidebar" ] searchBuckets
-                    , h4 [] [ text errorTitle ]
+                    [ h4 [] [ text errorTitle ]
                     , text errorMessage
                     ]
                 ]
@@ -922,13 +951,23 @@ viewNoResults :
     -> Html c
 viewNoResults categoryName query =
     div [ class "search-no-results" ]
-        [ h2 [] [ text <| "No " ++ categoryName ++ " found!" ]
-        , text "You might want to "
-        , Html.a [ href "https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package" ] [ text "add a package" ]
-        , text " or "
-        , Html.a [ href ("https://github.com/NixOS/nixpkgs/issues?q=" ++ query) ] [ text "search nixpkgs issues" ]
-        , text "."
-        ]
+        ([ h2 [] [ text <| "No " ++ categoryName ++ " found!" ]
+         ]
+            ++ (if categoryName == "modular services" then
+                    [ text "Not all packages provide modular services. You might want to "
+                    , Html.a [ href ("https://github.com/NixOS/nixpkgs/issues?q=" ++ query) ] [ text "search nixpkgs issues" ]
+                    , text "."
+                    ]
+
+                else
+                    [ text "You might want to "
+                    , Html.a [ href "https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package" ] [ text "add a package" ]
+                    , text " or "
+                    , Html.a [ href ("https://github.com/NixOS/nixpkgs/issues?q=" ++ query) ] [ text "search nixpkgs issues" ]
+                    , text "."
+                    ]
+               )
+        )
 
 
 closeButton : Html a
@@ -1270,20 +1309,31 @@ type alias Options =
 
 
 filterByType :
-    String
+    List String
     -> List ( String, Json.Encode.Value )
-filterByType type_ =
-    [ ( "term"
-      , Json.Encode.object
-            [ ( "type"
+filterByType types =
+    case types of
+        [ type_ ] ->
+            [ ( "term"
               , Json.Encode.object
-                    [ ( "value", Json.Encode.string type_ )
-                    , ( "_name", Json.Encode.string <| "filter_" ++ type_ ++ "s" )
+                    [ ( "type"
+                      , Json.Encode.object
+                            [ ( "value", Json.Encode.string type_ )
+                            , ( "_name", Json.Encode.string <| "filter_" ++ type_ ++ "s" )
+                            ]
+                      )
                     ]
               )
             ]
-      )
-    ]
+
+        _ ->
+            [ ( "terms"
+              , Json.Encode.object
+                    [ ( "type", Json.Encode.list Json.Encode.string types )
+                    , ( "_name", Json.Encode.string <| "filter_" ++ String.join "_" types )
+                    ]
+              )
+            ]
 
 
 searchFields :
@@ -1332,7 +1382,7 @@ makeRequestBody :
     -> Int
     -> Int
     -> Sort
-    -> String
+    -> List String
     -> String
     -> List String
     -> List Terms
@@ -1340,7 +1390,7 @@ makeRequestBody :
     -> String
     -> List ( String, Float )
     -> Http.Body
-makeRequestBody query from sizeRaw sort type_ sortField otherSortFields terms filterByBuckets mainField fields =
+makeRequestBody query from sizeRaw sort types sortField otherSortFields terms filterByBuckets mainField fields =
     let
         -- you can not request more then 10000 results otherwise it will return 404
         size =
@@ -1373,7 +1423,7 @@ makeRequestBody query from sizeRaw sort type_ sortField otherSortFields terms fi
                             [ ( "filter"
                               , Json.Encode.list Json.Encode.object
                                     (List.append
-                                        [ filterByType type_ ]
+                                        [ filterByType types ]
                                         (if List.isEmpty filterByBuckets then
                                             []
 

--- a/version.nix
+++ b/version.nix
@@ -8,5 +8,5 @@
     Frontend index version used by the UI when querying Elasticsearch
     Keep this at the old version while 'import' populates a new index, then update to switch traffic
   */
-  frontend = "44";
+  frontend = "45";
 }


### PR DESCRIPTION
Add modular service options to the existing Options page. Use checkboxes to filter between the two option categories, which introduces query parameters `?include_{nixos,modular_service}_options}=0|1` (default 1).

Unifies handling of breadcrumbs (#1188) across these categories .

split out from (and supersedes) #1186.
follow-up of #1189.
closes #1167.
