### PR TITLE
fix(flake-info): use nixpkgs hand-maintained service list

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -438,70 +438,19 @@ let
     { nixpkgs.hostPlatform = "x86_64-linux"; }
   ];
 
-  # Discover modular services by introspection: any package exposing a `.services`
-  # attrset where each value is a module (not a derivation). This does not rely on
-  # nixpkgs' documentation.nixos.extraModules (which is an intermediate solution)
-  # and automatically picks up new modular services as they are added.
-  discoverServiceModules =
-    let
-      tryGetServices =
-        pkgName:
-        let
-          eval = builtins.tryEval (
-            let
-              pkg = nixpkgs.${pkgName} or null;
-            in
-            if
-              pkg != null
-              && builtins.isAttrs pkg
-              && pkg ? services
-              && builtins.isAttrs pkg.services
-              && !(lib.isDerivation pkg.services)
-            then
-              lib.filter (n: !(lib.isDerivation pkg.services.${n})) (builtins.attrNames pkg.services)
-            else
-              [ ]
-          );
-        in
-        if eval.success then
-          map (moduleName: {
-            inherit pkgName moduleName;
-            module = nixpkgs.${pkgName}.services.${moduleName};
-          }) eval.value
-        else
-          [ ];
-    in
-    lib.concatMap tryGetServices (
-      builtins.filter (n: !(lib.hasPrefix "_" n)) (builtins.attrNames nixpkgs)
-    );
+  # Use nixpkgs' hand-maintained modular services list rather than walking all
+  # `pkgs` attributes (which would force shallow evaluation of every package
+  # and is too expensive -- see NixOS/nixpkgs#509117).
+  serviceDocModules =
+    (import <nixpkgs/nixos/modules/misc/documentation/modular-services.nix> {
+      inherit lib;
+      pkgs = nixpkgs;
+    }).documentation.nixos.extraModules;
 
-  # Build a synthetic module that exposes each discovered service as a submodule
-  # option with a distinguishable name prefix, mirroring nixpkgs' fakeSubmodule
-  # approach so the rest of the pipeline (name parsing, etc.) stays unchanged.
-  discoveredServicesModule = {
-    options = lib.listToAttrs (
-      map (
-        {
-          pkgName,
-          moduleName,
-          module,
-        }:
-        {
-          name = "<imports = [ pkgs.${pkgName}.services.${moduleName} ]>";
-          value = lib.mkOption {
-            type = lib.types.submoduleWith { modules = [ module ]; };
-            description = "Modular service from pkgs.${pkgName}.services.${moduleName}";
-            default = { };
-          };
-        }
-      ) discoverServiceModules
-    );
-  };
-
-  # Evaluate base + discovered service modules together (service modules depend on
-  # base option types). Then partition: options whose name starts with "<" come
-  # from modular services.
-  nixpkgsAllOpts = readNixOSOptions { module = nixpkgsBaseModules ++ [ discoveredServicesModule ]; };
+  # Evaluate base + service documentation modules together (service modules
+  # depend on base option types). Then partition: options whose name starts
+  # with "<" come from modular services.
+  nixpkgsAllOpts = readNixOSOptions { module = nixpkgsBaseModules ++ serviceDocModules; };
   isServiceOption = opt: lib.hasPrefix "<" opt.name;
 
 in
@@ -524,11 +473,18 @@ rec {
     deduplicateServices real;
 
   # Map from package attribute name to the list of modular service module
-  # names it exposes. Used by the packages importer to annotate each package
-  # with its modular services so the UI can link to them only when they exist.
-  nixos-package-services = lib.foldl' (
-    acc:
-    { pkgName, moduleName, ... }:
-    acc // { ${pkgName} = (acc.${pkgName} or [ ]) ++ [ moduleName ]; }
-  ) { } discoverServiceModules;
+  # names it exposes. Derived from the parsed service options above so it
+  # stays in sync with nixpkgs' hand-maintained list.
+  nixos-package-services =
+    let
+      parsed = map parseServiceOption (builtins.filter isServiceOption nixpkgsAllOpts);
+      real = builtins.filter (opt: opt ? service_package) parsed;
+    in
+    lib.foldl' (
+      acc: opt:
+      acc
+      // {
+        ${opt.service_package} = lib.unique ((acc.${opt.service_package} or [ ]) ++ [ opt.service_module ]);
+      }
+    ) { } real;
 }


### PR DESCRIPTION
following https://github.com/NixOS/nixos-search/pull/1189#issuecomment-4231105147:

- Replace `discoverServiceModules` introspection (which walked all of `pkgs` via `builtins.attrNames` and forced shallow evaluation of every package attribute) with a direct import of nixpkgs' `modular-services.nix` hand-maintained list.
- Derive `nixos-package-services` from the evaluated service options instead of from the removed introspection walker.

The introspection approach caused 3-5x slowdowns in Nix evaluation (see NixOS/nixpkgs#509117 review for benchmarks). Since there is no way to lazily discover which packages expose `.services`, we fall back to the list nixpkgs already maintains in `documentation.nixos.extraModules`.

disclaimer i used a coding agent in the creation of this patch.

## Test plan

- [x] Verify `flake-info` still produces service entries for `ghostunnel` and `php` (the two currently listed modular services)
- [x] Confirm no evaluation-time regression vs. pre-modular-services  `main`

### Performance benchmark by hyperfine

| Variant | Mean | vs baseline |
|:---|---:|---:|
| pre-modular-services baseline (`30cb145`) | 2.77s | 1.00x |
| this branch (hand-maintained list) | 2.96s | 1.07x |
| introspection (`dae57bd`) | 15.36s | 5.55x |
