### PR TITLE
fix: revert frontend schema version to 44

### DIFF
--- a/version.nix
+++ b/version.nix
@@ -8,5 +8,5 @@
     Frontend index version used by the UI when querying Elasticsearch
     Keep this at the old version while 'import' populates a new index, then update to switch traffic
   */
-  frontend = "45";
+  frontend = "44";
 }


### PR DESCRIPTION
PR 1189 bumped both `import` and `frontend` versions to 45, but the frontend should have stayed at 44 until the v45 indices were fully populated. This broke the unstable options listing.

Fixes https://github.com/NixOS/nixos-search/pull/1189#issuecomment-4232732541.