### PR TITLE
elasticsearch bulk upload in smaller chunks

### DIFF
--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -276,7 +276,7 @@ impl Elasticsearch {
     ) -> Result<(), ElasticsearchError> {
         // let exports: Result<Vec<Value>, serde_json::Error> = exports.iter().map(serde_json::to_value).collect();
         // let exports = exports?;
-        let bodies = exports.chunks(10_000).map(|chunk| {
+        let bodies = exports.chunks(7_000).map(|chunk| {
             chunk
                 .iter()
                 .map(|e| BulkOperation::from(BulkOperation::index(e)))


### PR DESCRIPTION
since #1189 it seems the unstable crossed some threshold and is causing gateway timeouts while performing bulk upload calls. If that problem persists then let's see if splitting the upload in smaller chunks helps.

Seen twice now - I just started a third attempt, let's see if that times out as well, if so try with this change.

Towards #1197 