### PR TITLE
Switch back to index version 45

### DIFF
--- a/version.nix
+++ b/version.nix
@@ -8,5 +8,5 @@
     Frontend index version used by the UI when querying Elasticsearch
     Keep this at the old version while 'import' populates a new index, then update to switch traffic
   */
-  frontend = "44";
+  frontend = "45";
 }


### PR DESCRIPTION
So that modular services (and other new data) are visible again.

Towards #1197

This is possible since the unstable 45 index has now been populated (in https://github.com/NixOS/nixos-search/actions/runs/24331699615)

Can be tested with https://69dbd995fc172424a176bd40--nixos-search.netlify.app (from #1192)