### PR TITLE
feat(flake-info): add backend support for home-manager options

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -126,10 +126,53 @@ let
       )
     ) apps;
 
+  # Replace functions by the string <function>
+  substFunction =
+    x:
+    if builtins.isAttrs x then
+      lib.mapAttrs (_: substFunction) x
+    else if builtins.isList x then
+      map substFunction x
+    else if lib.isFunction x then
+      "function"
+    else
+      x;
+
+  # Strip store-path prefix from a declaration path
+  mkDeclaration =
+    decl:
+    let
+      discard = lib.concatStringsSep "/" (lib.take 4 (lib.splitString "/" decl)) + "/";
+      path = if lib.hasPrefix builtins.storeDir decl then lib.removePrefix discard decl else decl;
+    in
+    path;
+
+  # Clean up a raw option attrset for indexing
+  cleanUpOption =
+    extraAttrs: opt:
+    let
+      applyOnAttr = n: f: lib.optionalAttrs (builtins.hasAttr n opt) { ${n} = f opt.${n}; };
+    in
+    opt
+    // {
+      entry_type = extraAttrs.entry_type or "option";
+    }
+    // applyOnAttr "default" substFunction
+    // applyOnAttr "example" substFunction
+    // applyOnAttr "type" substFunction
+    // applyOnAttr "declarations" (map mkDeclaration)
+    // extraAttrs;
+
+  # Filter for user-visible, non-internal options
+  filterOptions = opts: lib.filter (x: x.visible && !x.internal && lib.head x.loc != "_module") opts;
+
   readNixOSOptions =
+    {
+      module,
+      modulePath ? null,
+    }:
     let
       declarations =
-        module:
         (lib.evalModules {
           modules = (if lib.isList module then module else [ module ]) ++ [
             (
@@ -152,53 +195,12 @@ let
           };
         }).options;
 
-      cleanUpOption =
-        extraAttrs: opt:
-        let
-          applyOnAttr = n: f: lib.optionalAttrs (builtins.hasAttr n opt) { ${n} = f opt.${n}; };
-          mkDeclaration =
-            decl:
-            let
-              discard = lib.concatStringsSep "/" (lib.take 4 (lib.splitString "/" decl)) + "/";
-              path = if lib.hasPrefix builtins.storeDir decl then lib.removePrefix discard decl else decl;
-            in
-            path;
-
-          # Replace functions by the string <function>
-          substFunction =
-            x:
-            if builtins.isAttrs x then
-              lib.mapAttrs (_: substFunction) x
-            else if builtins.isList x then
-              map substFunction x
-            else if lib.isFunction x then
-              "function"
-            else
-              x;
-        in
-        opt
-        // {
-          entry_type = extraAttrs.entry_type or "option";
-        }
-        // applyOnAttr "default" substFunction
-        // applyOnAttr "example" substFunction # (_: { __type = "function"; })
-        // applyOnAttr "type" substFunction
-        // applyOnAttr "declarations" (map mkDeclaration)
-        // extraAttrs;
-    in
-    {
-      module,
-      modulePath ? null,
-    }:
-    let
-      opts = lib.optionAttrSetToDocList (declarations module);
+      opts = lib.optionAttrSetToDocList declarations;
       extraAttrs = lib.optionalAttrs (modulePath != null) {
         flake = modulePath;
       };
     in
-    map (cleanUpOption extraAttrs) (
-      lib.filter (x: x.visible && !x.internal && lib.head x.loc != "_module") opts
-    );
+    map (cleanUpOption extraAttrs) (filterOptions opts);
 
   # Parses the angle-bracket prefix from modular service option names to extract
   # service_package and service_module, strips the prefix, and tags as entry_type = "service".
@@ -278,10 +280,64 @@ let
         module = resolved.nixosModule;
         modulePath = [ flake ];
       });
+
+      raw =
+        # We assume that `nixosModules` includes `nixosModule` when there
+        # are multiple modules
+        if nixosModulesOpts != [ ] then nixosModulesOpts else nixosModuleOpts;
+
+      # When a flake re-exports the same module under multiple names
+      # (e.g. `default` and `home-manager`), deduplicate by option name,
+      # keeping the first occurrence.
+      dedup =
+        opts:
+        let
+          addOnce = acc: opt: if acc ? ${opt.name} then acc else acc // { ${opt.name} = opt; };
+        in
+        lib.attrValues (lib.foldl' addOnce { } opts);
     in
-    # We assume that `nixosModules` includes `nixosModule` when there
-    # are multiple modules
-    if nixosModulesOpts != [ ] then nixosModulesOpts else nixosModuleOpts;
+    dedup raw;
+
+  # Extract options from home-manager's module system.
+  # Only produces output when `resolved` points to a home-manager flake
+  # (detected by the presence of `modules/modules.nix`).
+  readHomeManagerOptions =
+    let
+      # Home-manager modules use `lib.hm.*` helpers; extend nixpkgs' lib with
+      # HM's custom library so module evaluation does not fail.
+      hmLib = import "${resolved}/modules/lib/stdlib-extended.nix" lib;
+
+      hmModulesPath = "${resolved}/modules/modules.nix";
+      hmModuleList =
+        let
+          fn = import hmModulesPath;
+        in
+        if builtins.isFunction fn then
+          fn {
+            lib = hmLib;
+            pkgs = nixpkgs;
+          }
+        else
+          fn;
+
+      declarations =
+        (hmLib.evalModules {
+          modules = hmModuleList ++ [
+            (
+              { lib, ... }:
+              {
+                _module.check = lib.mkForce false;
+              }
+            )
+          ];
+          specialArgs = {
+            pkgs = nixpkgs;
+          };
+        }).options;
+
+      opts = hmLib.optionAttrSetToDocList declarations;
+    in
+    map (cleanUpOption { entry_type = "home-manager-option"; }) (filterOptions opts);
 
   read = reader: set: lib.flatten (lib.attrValues (withSystem reader set));
 
@@ -460,7 +516,12 @@ rec {
   packages = lib.attrValues (collectSystems allPackageSets.packages packages');
   apps = lib.attrValues (collectSystems { } apps'); # apps don't need fallback evaluation
   options = readFlakeOptions;
-  all = packages ++ apps ++ options;
+  home-manager-options =
+    let
+      hasHmModules = builtins.tryEval (builtins.pathExists "${resolved}/modules/modules.nix");
+    in
+    if hasHmModules.success && hasHmModules.value then readHomeManagerOptions else [ ];
+  all = packages ++ apps ++ options ++ home-manager-options;
 
   nixos-options = builtins.filter (opt: !(isServiceOption opt)) nixpkgsAllOpts;
 

--- a/flake-info/assets/commands/test/expected-outputs/agenix.json
+++ b/flake-info/assets/commands/test/expected-outputs/agenix.json
@@ -83,7 +83,10 @@
   },
   {
     "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "{ }" },
+    "default": {
+      "_type": "literalExpression",
+      "text": "{ }"
+    },
     "description": "Attrset of secrets.\n",
     "entry_type": "option",
     "flake": [
@@ -133,7 +136,10 @@
   },
   {
     "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"0400\"" },
+    "default": {
+      "_type": "literalExpression",
+      "text": "\"0400\""
+    },
     "description": "Permissions mode of the decrypted secret in a format understood by chmod.\n",
     "entry_type": "option",
     "flake": [
@@ -168,7 +174,10 @@
   },
   {
     "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"0\"" },
+    "default": {
+      "_type": "literalExpression",
+      "text": "\"0\""
+    },
     "description": "User of the decrypted secret.\n",
     "entry_type": "option",
     "flake": [
@@ -203,10 +212,16 @@
   },
   {
     "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "true" },
+    "default": {
+      "_type": "literalExpression",
+      "text": "true"
+    },
     "description": "Whether to enable symlinking secrets to their destination.",
     "entry_type": "option",
-    "example": { "_type": "literalExpression", "text": "true" },
+    "example": {
+      "_type": "literalExpression",
+      "text": "true"
+    },
     "flake": [
       "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
       "age"
@@ -220,7 +235,10 @@
   },
   {
     "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"/run/agenix\"" },
+    "default": {
+      "_type": "literalExpression",
+      "text": "\"/run/agenix\""
+    },
     "description": "Folder where secrets are symlinked to\n",
     "entry_type": "option",
     "flake": [
@@ -236,219 +254,15 @@
   },
   {
     "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"/run/agenix.d\"" },
+    "default": {
+      "_type": "literalExpression",
+      "text": "\"/run/agenix.d\""
+    },
     "description": "Where secrets are created before they are symlinked to {option}`age.secretsDir`\n",
     "entry_type": "option",
     "flake": [
       "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
       "age"
-    ],
-    "internal": false,
-    "loc": ["age", "secretsMountPoint"],
-    "name": "age.secretsMountPoint",
-    "readOnly": false,
-    "type": "string (with check: non-empty without trailing slash)",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": {
-      "_type": "literalExpression",
-      "text": "\"${pkgs.age}/bin/age\"\n"
-    },
-    "description": "The age executable to use.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "ageBin"],
-    "name": "age.ageBin",
-    "readOnly": false,
-    "type": "string",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": {
-      "_type": "literalExpression",
-      "text": "if isDarwin\nthen [\n  \"/etc/ssh/ssh_host_ed25519_key\"\n  \"/etc/ssh/ssh_host_rsa_key\"\n]\nelse if (config.services.openssh.enable or false)\nthen map (e: e.path) (lib.filter (e: e.type == \"rsa\" || e.type == \"ed25519\") config.services.openssh.hostKeys)\nelse [];\n"
-    },
-    "description": "Path to SSH keys to be used as identities in age decryption.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "identityPaths"],
-    "name": "age.identityPaths",
-    "readOnly": false,
-    "type": "list of absolute path",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "{ }" },
-    "description": "Attrset of secrets.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets"],
-    "name": "age.secrets",
-    "readOnly": false,
-    "type": "attribute set of (submodule)",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "description": "Age file the secret is loaded from.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "file"],
-    "name": "age.secrets.<name>.file",
-    "readOnly": false,
-    "type": "absolute path",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": {
-      "_type": "literalExpression",
-      "text": "users.${config.owner}.group or \"0\"\n"
-    },
-    "description": "Group of the decrypted secret.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "group"],
-    "name": "age.secrets.<name>.group",
-    "readOnly": false,
-    "type": "string",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"0400\"" },
-    "description": "Permissions mode of the decrypted secret in a format understood by chmod.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "mode"],
-    "name": "age.secrets.<name>.mode",
-    "readOnly": false,
-    "type": "string",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": {
-      "_type": "literalExpression",
-      "text": "config._module.args.name"
-    },
-    "description": "Name of the file used in {option}`age.secretsDir`\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "name"],
-    "name": "age.secrets.<name>.name",
-    "readOnly": false,
-    "type": "string",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"0\"" },
-    "description": "User of the decrypted secret.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "owner"],
-    "name": "age.secrets.<name>.owner",
-    "readOnly": false,
-    "type": "string",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": {
-      "_type": "literalExpression",
-      "text": "\"${cfg.secretsDir}/${config.name}\"\n"
-    },
-    "description": "Path where the decrypted secret is installed.\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "path"],
-    "name": "age.secrets.<name>.path",
-    "readOnly": false,
-    "type": "string",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "true" },
-    "description": "Whether to enable symlinking secrets to their destination.",
-    "entry_type": "option",
-    "example": { "_type": "literalExpression", "text": "true" },
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secrets", "<name>", "symlink"],
-    "name": "age.secrets.<name>.symlink",
-    "readOnly": false,
-    "type": "boolean",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"/run/agenix\"" },
-    "description": "Folder where secrets are symlinked to\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
-    ],
-    "internal": false,
-    "loc": ["age", "secretsDir"],
-    "name": "age.secretsDir",
-    "readOnly": false,
-    "type": "absolute path",
-    "visible": true
-  },
-  {
-    "declarations": ["modules/age.nix"],
-    "default": { "_type": "literalExpression", "text": "\"/run/agenix.d\"" },
-    "description": "Where secrets are created before they are symlinked to {option}`age.secretsDir`\n",
-    "entry_type": "option",
-    "flake": [
-      "github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6",
-      "default"
     ],
     "internal": false,
     "loc": ["age", "secretsMountPoint"],

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -124,6 +124,16 @@ pub enum Derivation {
         service_module: Option<String>,
         service_packages: Vec<String>,
     },
+    #[serde(rename = "home-manager-option")]
+    HomeManagerOption {
+        option_source: Option<String>,
+        option_name: String,
+        option_description: Option<DocString>,
+        option_type: Option<String>,
+        option_default: Option<DocValue>,
+        option_example: Option<DocValue>,
+        option_flake: Option<ModulePath>,
+    },
 }
 
 // ----- Conversions
@@ -205,6 +215,24 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                 app_type,
             },
             import::FlakeEntry::Option(option) => option.try_into()?,
+            import::FlakeEntry::HomeManagerOption(NixOption {
+                declarations,
+                description,
+                name,
+                option_type,
+                default,
+                example,
+                flake,
+                ..
+            }) => Derivation::HomeManagerOption {
+                option_source: declarations.get(0).map(Clone::clone),
+                option_name: name,
+                option_description: description,
+                option_default: default,
+                option_example: example,
+                option_flake: flake,
+                option_type,
+            },
         })
     }
 }

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -47,6 +47,9 @@ pub enum FlakeEntry {
     },
     /// an option defined in a module of a flake
     Option(NixOption),
+    /// a home-manager option extracted from a flake's module system
+    #[serde(rename = "home-manager-option")]
+    HomeManagerOption(NixOption),
 }
 
 /// The representation of an option that is part of some module and can be used
@@ -253,6 +256,7 @@ arg_enum! {
         App,
         Package,
         Option,
+        HomeManagerOption,
         ModularService,
         All,
     }
@@ -264,6 +268,7 @@ impl AsRef<str> for Kind {
             Kind::App => "apps",
             Kind::Package => "packages",
             Kind::Option => "options",
+            Kind::HomeManagerOption => "home-manager-options",
             Kind::ModularService => "services",
             Kind::All => "all",
         }


### PR DESCRIPTION
Add `home-manager-option` as a new indexed document type. The Nix extraction script detects flakes whose store path contains `modules/modules.nix` (home-manager's layout) and evaluates their module system to produce option declarations.

Changes:

- Factor `cleanUpOption`/`substFunction`/`mkDeclaration` out of `readNixOSOptions` for reuse by `readHomeManagerOptions`
- Import home-manager's `lib/stdlib-extended.nix` so `lib.hm.*` helpers are available during module evaluation
- Use `lib.mkForce false` for `_module.check` to override home-manager's own `true` default without conflict
- Add `HomeManagerOption` variant to `FlakeEntry`, `Kind`, and `Derivation` enums with serde tag `home-manager-option`
- Include `home-manager-options` in the `all` extraction output so the Group command picks them up automatically
- Bump import schema version to 46

Disclaimer: i used a coding agent in the creation of this patch.
