### PR TITLE
fix(flake-info): improve error handling in NixOS options evaluation

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -151,16 +151,24 @@ let
   cleanUpOption =
     extraAttrs: opt:
     let
-      applyOnAttr = n: f: lib.optionalAttrs (builtins.hasAttr n opt) { ${n} = f opt.${n}; };
+      safeApplyOnAttr =
+        n: f:
+        let
+          valueResult = builtins.tryEval opt.${n};
+        in
+        if builtins.hasAttr n opt && valueResult.success then
+          lib.optionalAttrs (valueResult.value != null) { ${n} = f valueResult.value; }
+        else
+          { };
     in
     opt
     // {
       entry_type = extraAttrs.entry_type or "option";
     }
-    // applyOnAttr "default" substFunction
-    // applyOnAttr "example" substFunction
-    // applyOnAttr "type" substFunction
-    // applyOnAttr "declarations" (map mkDeclaration)
+    // safeApplyOnAttr "default" substFunction
+    // safeApplyOnAttr "example" substFunction
+    // safeApplyOnAttr "type" substFunction
+    // safeApplyOnAttr "declarations" (map mkDeclaration)
     // extraAttrs;
 
   # Filter for user-visible, non-internal options
@@ -172,9 +180,11 @@ let
       modulePath ? null,
     }:
     let
-      declarations =
+      flakePackages = resolved.packages or resolved.legacyPackages or { };
+      modules = (if lib.isList module then module else [ module ]);
+      evalResult = builtins.tryEval (
         (lib.evalModules {
-          modules = (if lib.isList module then module else [ module ]) ++ [
+          modules = modules ++ [
             (
               { ... }:
               {
@@ -192,15 +202,27 @@ let
             # Provide commonly-used arguments so module evaluation that expects them
             # (e.g. `pkgs` or `config`) does not fail during CI evaluation.
             pkgs = nixpkgs;
+            flakePackages = flakePackages;
           };
-        }).options;
+        })
+      );
 
-      opts = lib.optionAttrSetToDocList declarations;
+      rawOpts =
+        if evalResult.success then
+          let
+            docOpts = builtins.tryEval (lib.optionAttrSetToDocList evalResult.value.options);
+          in
+          if docOpts.success then docOpts.value else [ ]
+        else
+          [ ];
+
+      opts = filterOptions rawOpts;
       extraAttrs = lib.optionalAttrs (modulePath != null) {
         flake = modulePath;
       };
+      cleanupResult = builtins.tryEval (map (cleanUpOption extraAttrs) opts);
     in
-    map (cleanUpOption extraAttrs) (filterOptions opts);
+    if cleanupResult.success then cleanupResult.value else [ ];
 
   # Parses the angle-bracket prefix from modular service option names to extract
   # service_package and service_module, strips the prefix, and tags as entry_type = "service".
@@ -295,8 +317,10 @@ let
           addOnce = acc: opt: if acc ? ${opt.name} then acc else acc // { ${opt.name} = opt; };
         in
         lib.attrValues (lib.foldl' addOnce { } opts);
+
+      dedupResult = builtins.tryEval (dedup raw);
     in
-    dedup raw;
+    if dedupResult.success then dedupResult.value else [ ];
 
   # Extract options from home-manager's module system.
   # Only produces output when `resolved` points to a home-manager flake


### PR DESCRIPTION
## Summary

Improve robustness of NixOS options evaluation in `flake_info.nix`:

1. **Use `safeApplyOnAttr`** which wraps option attribute access in `tryEval` to prevent errors in one option from failing the entire evaluation. This helps handle flakes with problematic options more gracefully.

2. **Add `flakePackages` to `specialArgs`** in `readNixOSOptions` to provide packages to flakes that need them in their module system.

3. **Add additional `tryEval` wrappers** around option processing to gracefully handle evaluation errors and return empty lists instead of failing entirely.

## Testing

- `nix-build ./flake-info/assets/commands/test` passes all tests
- `github:Hythera/nix-waterfox` now works correctly
- `github:NixOS/hydra` still fails due to `flakePackages` not being properly provided through `lib.evalModules` specialArgs (see issue #1175)

## Note

`github:NixOS/hydra` still requires `flakePackages` which cannot be properly provided through `lib.evalModules` specialArgs. It may need to be disabled in `flakes/manual.toml` until a proper fix is implemented (as suggested in PR #1190).

Fixes #1175 (partially - addresses waterfox, hydra still needs to be disabled)