### PR TITLE
HM: handle back-end symmetrically to nixpkgs options and modular services

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -299,8 +299,9 @@ let
     dedup raw;
 
   # Extract options from home-manager's module system.
-  # Only produces output when `resolved` points to a home-manager flake
-  # (detected by the presence of `modules/modules.nix`).
+  # Evaluated separately during the nixpkgs channel import (via
+  # `--override-flake input-flake github:nix-community/home-manager`) so that
+  # home-manager options land in the channel index alongside NixOS options.
   readHomeManagerOptions =
     let
       # Home-manager modules use `lib.hm.*` helpers; extend nixpkgs' lib with
@@ -521,7 +522,7 @@ rec {
       hasHmModules = builtins.tryEval (builtins.pathExists "${resolved}/modules/modules.nix");
     in
     if hasHmModules.success && hasHmModules.value then readHomeManagerOptions else [ ];
-  all = packages ++ apps ++ options ++ home-manager-options;
+  all = packages ++ apps ++ options;
 
   nixos-options = builtins.filter (opt: !(isServiceOption opt)) nixpkgsAllOpts;
 

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -6,7 +6,8 @@ pub use nix_check_version::{NixCheckError, check_nix_version};
 pub use nix_flake_attrs::get_derivation_info;
 pub use nix_flake_info::get_flake_info;
 pub use nixpkgs_info::{
-    get_nixpkgs_info, get_nixpkgs_options, get_nixpkgs_package_services, get_nixpkgs_services,
+    get_home_manager_options, get_nixpkgs_info, get_nixpkgs_options, get_nixpkgs_package_services,
+    get_nixpkgs_services,
 };
 
 use anyhow::{Context, Result};

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -170,3 +170,33 @@ pub fn get_nixpkgs_services(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
 
     Ok(attr_set.into_iter().map(NixpkgsEntry::Service).collect())
 }
+
+/// Home-manager flake reference used to evaluate HM options alongside
+/// each nixpkgs channel import.
+const HOME_MANAGER_FLAKE_REF: &str = "github:nix-community/home-manager";
+
+pub fn get_home_manager_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
+    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
+    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
+    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_args(["--override-flake", "input-flake", HOME_MANAGER_FLAKE_REF].iter());
+    command.add_arg("home-manager-options");
+
+    command.enable_capture();
+    command.log_to = LogTo::Log;
+    command.log_output_on_error = true;
+
+    let cow = command
+        .run()
+        .with_context(|| "Failed to gather information about home-manager options")?;
+
+    let output = &*cow.stdout_string_lossy();
+    let de = &mut Deserializer::from_str(output);
+    let attr_set: Vec<NixOption> = serde_path_to_error::deserialize(de)
+        .with_context(|| "Could not parse home-manager options")?;
+
+    Ok(attr_set
+        .into_iter()
+        .map(NixpkgsEntry::HomeManagerOption)
+        .collect())
+}

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -215,24 +215,6 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                 app_type,
             },
             import::FlakeEntry::Option(option) => option.try_into()?,
-            import::FlakeEntry::HomeManagerOption(NixOption {
-                declarations,
-                description,
-                name,
-                option_type,
-                default,
-                example,
-                flake,
-                ..
-            }) => Derivation::HomeManagerOption {
-                option_source: declarations.get(0).map(Clone::clone),
-                option_name: name,
-                option_description: description,
-                option_default: default,
-                option_example: example,
-                option_flake: flake,
-                option_type,
-            },
         })
     }
 }
@@ -373,6 +355,24 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     service_packages,
                 }
             }
+            import::NixpkgsEntry::HomeManagerOption(NixOption {
+                declarations,
+                description,
+                name,
+                option_type,
+                default,
+                example,
+                flake,
+                ..
+            }) => Derivation::HomeManagerOption {
+                option_source: declarations.get(0).map(Clone::clone),
+                option_name: name,
+                option_description: description,
+                option_default: default,
+                option_example: example,
+                option_flake: flake,
+                option_type,
+            },
         })
     }
 }

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -47,9 +47,6 @@ pub enum FlakeEntry {
     },
     /// an option defined in a module of a flake
     Option(NixOption),
-    /// a home-manager option extracted from a flake's module system
-    #[serde(rename = "home-manager-option")]
-    HomeManagerOption(NixOption),
 }
 
 /// The representation of an option that is part of some module and can be used
@@ -204,6 +201,7 @@ pub enum NixpkgsEntry {
     },
     Option(NixOption),
     Service(NixOption),
+    HomeManagerOption(NixOption),
 }
 
 /// Most information about packages in nixpkgs is contained in the meta key

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -68,9 +68,16 @@ pub fn process_nixpkgs(
         Vec::new()
     };
 
+    let mut hm_options = if matches!(kind, Kind::All | Kind::HomeManagerOption) {
+        commands::get_home_manager_options(nixpkgs)?
+    } else {
+        Vec::new()
+    };
+
     let mut all = drvs;
     all.append(&mut options);
     all.append(&mut services);
+    all.append(&mut hm_options);
 
     let exports = all
         .into_iter()

--- a/version.nix
+++ b/version.nix
@@ -2,7 +2,7 @@
   /**
     Backend index version used by import jobs when writing data to Elasticsearch
   */
-  import = "46";
+  import = "47";
 
   /**
     Frontend index version used by the UI when querying Elasticsearch


### PR DESCRIPTION
should make #1202 work, which is now rebased on this for the demo preview.