### PR TITLE
feat(flake-info): handle compound licenses from nixpkgs

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -48,11 +48,111 @@ impl From<import::License> for License {
                 fullName,
                 shortName,
                 url,
+                ..
             } => License {
                 url,
                 fullName: fullName.unwrap_or(shortName.unwrap_or("custom".into())),
             },
+            // Compound variants should be flattened before reaching this point;
+            // if one slips through, use its SPDX expression as the display name.
+            other => License {
+                url: None,
+                fullName: other.spdx_expression(),
+            },
         }
+    }
+}
+
+/// A tree representation of a compound license expression, preserving the
+/// structural AND/OR/WITH/PLUS operators so the frontend can distinguish
+/// licenses that are jointly required from licenses the user may choose
+/// between.  Leaves carry the displayable fullName and (optional) URL so they
+/// can still render as links.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum LicenseExpression {
+    Leaf {
+        #[serde(rename = "fullName")]
+        full_name: String,
+        url: Option<String>,
+    },
+    And {
+        licenses: Vec<LicenseExpression>,
+    },
+    Or {
+        licenses: Vec<LicenseExpression>,
+    },
+    With {
+        license: Box<LicenseExpression>,
+        exception: Box<LicenseExpression>,
+    },
+    Plus {
+        license: Box<LicenseExpression>,
+    },
+}
+
+impl From<import::License> for LicenseExpression {
+    fn from(license: import::License) -> Self {
+        match license {
+            import::License::None { .. } => LicenseExpression::Leaf {
+                full_name: "no license specified".to_string(),
+                url: None,
+            },
+            import::License::Simple { license } => LicenseExpression::Leaf {
+                full_name: license,
+                url: None,
+            },
+            import::License::Full {
+                fullName,
+                shortName,
+                url,
+                ..
+            } => LicenseExpression::Leaf {
+                full_name: fullName
+                    .or(shortName)
+                    .unwrap_or_else(|| "custom".to_string()),
+                url,
+            },
+            import::License::Compound {
+                operator, licenses, ..
+            } => {
+                let children: Vec<LicenseExpression> =
+                    licenses.into_iter().map(|l| l.0.into()).collect();
+                if operator == "OR" {
+                    LicenseExpression::Or { licenses: children }
+                } else {
+                    LicenseExpression::And { licenses: children }
+                }
+            }
+            import::License::Exception {
+                license, exception, ..
+            } => LicenseExpression::With {
+                license: Box::new((*license).0.into()),
+                exception: Box::new((*exception).0.into()),
+            },
+            import::License::Plus { license, .. } => LicenseExpression::Plus {
+                license: Box::new((*license).0.into()),
+            },
+        }
+    }
+}
+
+/// Build an optional license-expression tree from a list of top-level licenses.
+/// Returns `None` if no license in the list uses compound operators (the flat
+/// `package_license` list is sufficient in that case).  Multiple top-level
+/// licenses are implicitly joined with AND, matching the historical nixpkgs
+/// convention that a list of licenses means "all of them apply".
+fn build_license_expression(
+    licenses: &[import::StringOrStruct<import::License>],
+) -> Option<LicenseExpression> {
+    if !licenses.iter().any(|l| l.0.is_compound()) {
+        return None;
+    }
+    let items: Vec<LicenseExpression> = licenses.iter().map(|l| l.0.clone().into()).collect();
+    if items.len() == 1 {
+        items.into_iter().next()
+    } else {
+        Some(LicenseExpression::And { licenses: items })
     }
 }
 
@@ -75,6 +175,7 @@ pub enum Derivation {
         package_mainProgram: Option<String>,
         package_license: Vec<License>,
         package_license_set: Vec<String>,
+        package_license_expression: Option<LicenseExpression>,
         package_maintainers: Vec<Maintainer>,
         package_maintainers_set: Vec<String>,
         package_teams: Vec<Team>,
@@ -164,15 +265,17 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
 
                 let long_description = long_description.map(|s| s.render_markdown()).transpose()?;
 
-                let package_license: Vec<License> = license
-                    .map(OneOrMany::into_list)
-                    .unwrap_or_default()
+                let license_list = license.map(OneOrMany::into_list).unwrap_or_default();
+
+                let package_license_expression = build_license_expression(&license_list);
+
+                let package_license: Vec<License> = license_list
                     .into_iter()
-                    .map(|sos| sos.0.into())
+                    .flat_map(|sos| sos.0.flatten())
+                    .map(|l| l.into())
                     .collect();
                 let package_license_set: Vec<String> = package_license
                     .iter()
-                    .clone()
                     .map(|l| l.fullName.to_owned())
                     .collect();
 
@@ -190,6 +293,7 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                     package_mainProgram: None,
                     package_license,
                     package_license_set,
+                    package_license_expression,
                     package_description: description.clone(),
                     package_maintainers: vec![maintainer.clone()],
                     package_maintainers_set: maintainer.name.map_or(vec![], |n| vec![n]),
@@ -238,12 +342,17 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 })
                 .into();
 
-                let package_license: Vec<License> = package
+                let license_list = package
                     .meta
                     .license
-                    .map_or(Default::default(), OneOrMany::into_list)
+                    .map_or(Default::default(), OneOrMany::into_list);
+
+                let package_license_expression = build_license_expression(&license_list);
+
+                let package_license: Vec<License> = license_list
                     .into_iter()
-                    .map(|sos| sos.0.into())
+                    .flat_map(|sos| sos.0.flatten())
+                    .map(|l| l.into())
                     .collect();
 
                 let package_license_set = package_license
@@ -312,6 +421,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     package_mainProgram: package.meta.mainProgram,
                     package_license,
                     package_license_set,
+                    package_license_expression,
                     package_maintainers,
                     package_maintainers_set,
                     package_teams,

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -324,7 +324,21 @@ impl Platforms {
     }
 }
 
-/// Different representations of the licence attribute
+/// Different representations of the licence attribute.
+///
+/// Variant ordering matters for `#[serde(untagged)]`: serde tries each variant
+/// top-to-bottom and picks the first one whose required fields are all present.
+///
+///  - `None` / `Simple` match degenerate cases (null, bare string via
+///    `StringOrStruct`).
+///  - `Compound` needs `licenses` (a Vec) -- unique among variants.
+///  - `Exception` needs both `license` **and** `exception` -- must come before
+///    `Plus` whose fields are a subset.
+///  - `Plus` needs `license` + `operator` (but not `exception`).
+///  - `Full` has only `Option` fields, so it acts as the catch-all for any
+///    license object.
+///
+/// See NixOS/nixpkgs#468378 for the upstream compound-license proposal.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum License {
@@ -335,12 +349,127 @@ pub enum License {
     Simple {
         license: String,
     },
+    /// `lib.licenses.AND [...]` / `lib.licenses.OR [...]`
+    #[allow(non_snake_case)]
+    Compound {
+        licenseType: String,
+        operator: String,
+        licenses: Vec<StringOrStruct<License>>,
+    },
+    /// `lib.licenses.WITH license exception`
+    #[allow(non_snake_case)]
+    Exception {
+        licenseType: String,
+        operator: String,
+        license: Box<StringOrStruct<License>>,
+        exception: Box<StringOrStruct<License>>,
+    },
+    /// `lib.licenses.PLUS license`
+    #[allow(non_snake_case)]
+    Plus {
+        licenseType: String,
+        operator: String,
+        license: Box<StringOrStruct<License>>,
+    },
     #[allow(non_snake_case)]
     Full {
         fullName: Option<String>,
         shortName: Option<String>,
+        spdxId: Option<String>,
         url: Option<String>,
     },
+}
+
+impl License {
+    /// Whether this license is a compound expression (AND, OR, WITH, PLUS)
+    /// rather than a simple/full leaf license.
+    pub fn is_compound(&self) -> bool {
+        matches!(
+            self,
+            License::Compound { .. } | License::Exception { .. } | License::Plus { .. }
+        )
+    }
+
+    /// Recursively collect all leaf (simple/full) licenses from a compound
+    /// expression.  A leaf license returns itself.
+    pub fn flatten(self) -> Vec<License> {
+        match self {
+            License::Compound { licenses, .. } => {
+                licenses.into_iter().flat_map(|l| l.0.flatten()).collect()
+            }
+            License::Exception {
+                license, exception, ..
+            } => {
+                let mut out = license.0.flatten();
+                out.extend(exception.0.flatten());
+                out
+            }
+            License::Plus { license, .. } => license.0.flatten(),
+            other => vec![other],
+        }
+    }
+
+    /// Short display name suitable for use in SPDX-style expressions.
+    fn display_name(&self) -> String {
+        match self {
+            License::Full {
+                spdxId,
+                shortName,
+                fullName,
+                ..
+            } => spdxId
+                .clone()
+                .or_else(|| shortName.clone())
+                .or_else(|| fullName.clone())
+                .unwrap_or_else(|| "custom".into()),
+            License::Simple { license } => license.clone(),
+            License::None { .. } => String::new(),
+            // Compound variants delegate to spdx_expression()
+            _ => self.spdx_expression(),
+        }
+    }
+
+    /// Build an SPDX-style expression string (e.g. "MIT AND (Apache-2.0 WITH
+    /// LLVM-exception)").
+    pub fn spdx_expression(&self) -> String {
+        match self {
+            License::Compound {
+                operator, licenses, ..
+            } => {
+                let parts: Vec<String> = licenses
+                    .iter()
+                    .map(|l| {
+                        if l.0.is_compound() {
+                            format!("({})", l.0.spdx_expression())
+                        } else {
+                            l.0.display_name()
+                        }
+                    })
+                    .collect();
+                parts.join(&format!(" {} ", operator))
+            }
+            License::Exception {
+                license, exception, ..
+            } => {
+                let lic = if license.0.is_compound() {
+                    format!("({})", license.0.spdx_expression())
+                } else {
+                    license.0.display_name()
+                };
+                let exc = exception.0.display_name();
+                format!("{} WITH {}", lic, exc)
+            }
+            License::Plus { license, .. } => {
+                let lic = if license.0.is_compound() {
+                    format!("({})", license.0.spdx_expression())
+                } else {
+                    license.0.display_name()
+                };
+                format!("{}+", lic)
+            }
+            other => other.display_name(),
+        }
+    }
 }
 
 impl Default for License {

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -117,6 +117,7 @@ lazy_static! {
                         "url": {"type": "text"}},
                 },
                 "package_license_set": {"type": "keyword"},
+                "package_license_expression": {"type": "object", "enabled": false},
                 "package_maintainers": {
                     "type": "nested",
                     "properties": {

--- a/version.nix
+++ b/version.nix
@@ -2,7 +2,7 @@
   /**
     Backend index version used by import jobs when writing data to Elasticsearch
   */
-  import = "47";
+  import = "48";
 
   /**
     Frontend index version used by the UI when querying Elasticsearch


### PR DESCRIPTION
This extends the `License` enum to deserialize the new `licenseType`-tagged structures, recursively flattens them into leaf licenses for the search index, and exposes a `package_license_expression` field carrying the SPDX-style [expression string](https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/) (AND, OR, WITH, PLUS) when compound licenses are present (see NixOS/nixpkgs#468378).

Bump import index version to 47 for the new field.

Note that a potential follow-up would be to compound-proof our license filter, which under this PR just matches on any package containing a license in its expression.

Disclaimer: i used a coding agent in the creation of this patch.