### PR TITLE
Show compound licenses in the front-end

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -81,6 +81,7 @@ type alias ResultItemSource =
     , description : Maybe String
     , longDescription : Maybe String
     , licenses : List ResultPackageLicense
+    , licenseExpression : Maybe LicenseExpression
     , maintainers : List ResultPackageMaintainer
     , teams : List ResultPackageTeam
     , platforms : List String
@@ -99,6 +100,19 @@ type alias ResultPackageLicense =
     { fullName : Maybe String
     , url : Maybe String
     }
+
+
+{-| Structured license expression tree mirroring the compound-license
+operators introduced in NixOS/nixpkgs#468378. AND licenses must all be
+satisfied; OR licenses offer a choice; WITH applies an exception; PLUS is
+"or any later version".
+-}
+type LicenseExpression
+    = LicenseLeaf { fullName : String, url : Maybe String }
+    | LicenseAnd (List LicenseExpression)
+    | LicenseOr (List LicenseExpression)
+    | LicenseWith LicenseExpression LicenseExpression
+    | LicensePlus LicenseExpression
 
 
 type alias ResultPackageMaintainer =
@@ -405,35 +419,38 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     |> Maybe.withDefault []
                                )
                             ++ renderSource item nixosChannels channel trapClick createShortDetailsItem createGithubUrl
-                            ++ (let
-                                    licenses =
-                                        item.source.licenses
-                                            |> List.filterMap
-                                                (\license ->
-                                                    case license.url of
-                                                        Nothing ->
-                                                            Maybe.map text license.fullName
-
-                                                        Just url ->
-                                                            Just
-                                                                (createShortDetailsItem
-                                                                    (Maybe.withDefault "Unknown" license.fullName)
-                                                                    url
-                                                                )
-                                                )
-                                in
-                                optionals (not (List.isEmpty licenses))
-                                    [ li []
-                                        (text
-                                            (if List.length licenses == 1 then
-                                                "License: "
-
-                                             else
-                                                "Licenses: "
+                            ++ (case item.source.licenseExpression of
+                                    Just expression ->
+                                        [ li []
+                                            (text "License: "
+                                                :: renderLicenseExpression createShortDetailsItem expression
                                             )
-                                            :: List.intersperse (text " ▪ ") licenses
-                                        )
-                                    ]
+                                        ]
+
+                                    Nothing ->
+                                        let
+                                            licenses =
+                                                item.source.licenses
+                                                    |> List.filterMap
+                                                        (\license ->
+                                                            case license.url of
+                                                                Nothing ->
+                                                                    Maybe.map text license.fullName
+
+                                                                Just url ->
+                                                                    Just
+                                                                        (createShortDetailsItem
+                                                                            (Maybe.withDefault "Unknown" license.fullName)
+                                                                            url
+                                                                        )
+                                                        )
+                                        in
+                                        optionals (not (List.isEmpty licenses))
+                                            [ li []
+                                                (text "License: "
+                                                    :: List.intersperse (text " ▪ ") licenses
+                                                )
+                                            ]
                                )
                        )
                 )
@@ -936,6 +953,74 @@ viewResultItem nixosChannels channel showInstallDetails show item =
         )
 
 
+renderLicenseExpression :
+    (String -> String -> Html Msg)
+    -> LicenseExpression
+    -> List (Html Msg)
+renderLicenseExpression mkLink expr =
+    case expr of
+        LicenseLeaf { fullName, url } ->
+            case url of
+                Just u ->
+                    [ mkLink fullName u ]
+
+                Nothing ->
+                    [ text fullName ]
+
+        LicenseAnd children ->
+            renderJoined mkLink "AND" children
+
+        LicenseOr children ->
+            renderJoined mkLink "OR" children
+
+        LicenseWith license exception ->
+            renderChild mkLink license
+                ++ [ text " ", span [ class "license-operator" ] [ text "WITH" ], text " " ]
+                ++ renderChild mkLink exception
+
+        LicensePlus license ->
+            renderChild mkLink license ++ [ text "+" ]
+
+
+renderJoined :
+    (String -> String -> Html Msg)
+    -> String
+    -> List LicenseExpression
+    -> List (Html Msg)
+renderJoined mkLink op children =
+    let
+        separator =
+            [ text " ", span [ class "license-operator" ] [ text op ], text " " ]
+    in
+    children
+        |> List.map (renderChild mkLink)
+        |> List.intersperse separator
+        |> List.concat
+
+
+{-| Render a sub-expression, parenthesising compound children so the
+precedence is unambiguous.
+-}
+renderChild :
+    (String -> String -> Html Msg)
+    -> LicenseExpression
+    -> List (Html Msg)
+renderChild mkLink expr =
+    let
+        inner =
+            renderLicenseExpression mkLink expr
+    in
+    case expr of
+        LicenseLeaf _ ->
+            inner
+
+        LicensePlus _ ->
+            inner
+
+        _ ->
+            text "(" :: inner ++ [ text ")" ]
+
+
 renderSource :
     Search.ResultItem ResultItemSource
     -> List NixOSChannel
@@ -1120,6 +1205,9 @@ decodeResultItemSource =
         |> Json.Decode.Pipeline.required "package_description" (Json.Decode.nullable Json.Decode.string)
         |> Json.Decode.Pipeline.required "package_longDescription" (Json.Decode.nullable Json.Decode.string)
         |> Json.Decode.Pipeline.required "package_license" (Json.Decode.list decodeResultPackageLicense)
+        |> Json.Decode.Pipeline.optional "package_license_expression"
+            (Json.Decode.nullable decodeLicenseExpression)
+            Nothing
         |> Json.Decode.Pipeline.required "package_maintainers" (Json.Decode.list decodeResultPackageMaintainer)
         |> Json.Decode.Pipeline.required "package_teams" (Json.Decode.list decodeResultPackageTeam)
         |> Json.Decode.Pipeline.required "package_platforms" (Json.Decode.map filterPlatforms (Json.Decode.list Json.Decode.string))
@@ -1223,6 +1311,44 @@ decodeResultPackageLicense =
     Json.Decode.map2 ResultPackageLicense
         (Json.Decode.field "fullName" (Json.Decode.nullable Json.Decode.string))
         (Json.Decode.field "url" (Json.Decode.nullable Json.Decode.string))
+
+
+decodeLicenseExpression : Json.Decode.Decoder LicenseExpression
+decodeLicenseExpression =
+    let
+        recurse =
+            Json.Decode.lazy (\_ -> decodeLicenseExpression)
+    in
+    Json.Decode.field "kind" Json.Decode.string
+        |> Json.Decode.andThen
+            (\kind ->
+                case kind of
+                    "leaf" ->
+                        Json.Decode.map2
+                            (\n u -> LicenseLeaf { fullName = n, url = u })
+                            (Json.Decode.field "fullName" Json.Decode.string)
+                            (Json.Decode.field "url" (Json.Decode.nullable Json.Decode.string))
+
+                    "and" ->
+                        Json.Decode.map LicenseAnd
+                            (Json.Decode.field "licenses" (Json.Decode.list recurse))
+
+                    "or" ->
+                        Json.Decode.map LicenseOr
+                            (Json.Decode.field "licenses" (Json.Decode.list recurse))
+
+                    "with" ->
+                        Json.Decode.map2 LicenseWith
+                            (Json.Decode.field "license" recurse)
+                            (Json.Decode.field "exception" recurse)
+
+                    "plus" ->
+                        Json.Decode.map LicensePlus
+                            (Json.Decode.field "license" recurse)
+
+                    other ->
+                        Json.Decode.fail ("Unknown license expression kind: " ++ other)
+            )
 
 
 decodeResultPackageMaintainer : Json.Decode.Decoder ResultPackageMaintainer

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1098,3 +1098,11 @@ a:focus-visible {
     }
   }
 }
+
+// SPDX operators in compound license expressions -- bold weight to
+// distinguish AND / OR / WITH from license names.
+.license-operator {
+  font-weight: bold;
+  font-size: 0.85em;
+  opacity: 0.75;
+}

--- a/version.nix
+++ b/version.nix
@@ -8,5 +8,5 @@
     Frontend index version used by the UI when querying Elasticsearch
     Keep this at the old version while 'import' populates a new index, then update to switch traffic
   */
-  frontend = "47";
+  frontend = "48";
 }


### PR DESCRIPTION
Builds upon the back-end change (#1227) to show compound licenses in the front-end.

How this looks in action:

<img width="1506" height="916" alt="image" src="https://github.com/user-attachments/assets/a9c1bfa6-20e8-4eeb-9e66-c0d4adbb6c62" />

Note that traditional license lists are shown as before to distinguish when we have vs lack such data -- we do expect explicit migration of licenses to ensure semantics are reflected as intended.

Disclaimer: i used a coding agent in the creation of this patch.