### PR TITLE
feat(frontend): link Functions to noogle.dev

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -484,7 +484,9 @@ viewNavigation route =
             , ( Route.Options searchArgs, text "Options" )
             , ( Route.Flakes searchArgs, text "3rd-party Flakes" )
             ]
-        ++ [ li [] [ a [ href "https://wiki.nixos.org" ] [ text "NixOS Wiki" ] ] ]
+        ++ [ li [] [ a [ href "https://noogle.dev" ] [ text "Functions" ] ]
+           , li [] [ a [ href "https://wiki.nixos.org" ] [ text "NixOS Wiki" ] ]
+           ]
 
 
 viewNavigationItem :


### PR DESCRIPTION
As a stop-gap for documenting Nix functions, add a `Functions` entry to the navigation pointing at <https://noogle.dev>, alongside the existing `NixOS Wiki` external link.

Closes #1229.