### PR TITLE
feat(flake): github:felbinger/srsran.nix

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -115,6 +115,11 @@ repo = "eza"
 
 [[sources]]
 type = "github"
+owner = "felbinger"
+repo = "srsran.nix"
+
+[[sources]]
+type = "github"
 owner = "fort-nix"
 repo = "nix-bitcoin"
 


### PR DESCRIPTION
srsRAN is a open-source 4G and 5G software radio suite.

Even though the srsran package exist in nixpkgs, I'm not planning of contributing the modules their, because it's a niche module most users don't need.

If you think that the flake lacks relevance (which may be true), feel free to close this pr.