### PR TITLE
fix(flake-info): tighten home-manager flake detection

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -518,9 +518,17 @@ rec {
   options = readFlakeOptions;
   home-manager-options =
     let
-      hasHmModules = builtins.tryEval (builtins.pathExists "${resolved}/modules/modules.nix");
+      # Require both `modules/modules.nix` and `modules/lib/stdlib-extended.nix`
+      # to avoid false positives. Other flakes (e.g. `nix-bitcoin`) ship a
+      # `modules/modules.nix` that is unrelated to home-manager; only
+      # home-manager itself also provides the `stdlib-extended.nix` helper
+      # that `readHomeManagerOptions` imports.
+      isHomeManager = builtins.tryEval (
+        builtins.pathExists "${resolved}/modules/modules.nix"
+        && builtins.pathExists "${resolved}/modules/lib/stdlib-extended.nix"
+      );
     in
-    if hasHmModules.success && hasHmModules.value then readHomeManagerOptions else [ ];
+    if isHomeManager.success && isHomeManager.value then readHomeManagerOptions else [ ];
   all = packages ++ apps ++ options ++ home-manager-options;
 
   nixos-options = builtins.filter (opt: !(isServiceOption opt)) nixpkgsAllOpts;


### PR DESCRIPTION
Detecting home-manager flakes by `modules/modules.nix` alone produced false positives for unrelated flakes that happen to ship a similarly named file (e.g. `nix-bitcoin`). Once a non-HM flake matched, the subsequent `import` of `modules/lib/stdlib-extended.nix` aborted the whole evaluation, so packages and options for those flakes also failed to index.

Also require `modules/lib/stdlib-extended.nix` to be present, which is specific to home-manager and is the helper `readHomeManagerOptions` already imports.

Closes #1234.

Disclaimer: i used a coding agent in the creation of this patch.
