### PR TITLE
fix(flake-info): fail group import when any member fails

### DIFF
--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -102,6 +102,9 @@ jobs:
         group:
           - "manual"
 
+    permissions:
+      issues: write
+
     env:
       RUST_LOG: debug
       FI_ES_EXISTS_STRATEGY: recreate
@@ -131,3 +134,19 @@ jobs:
           do
             curl -sS ${{ secrets.ELASTICSEARCH_URL2 }}/latest-$(nix eval --raw --file ./version.nix import)-group-${{ matrix.group }}/_search | jq -c '.took // .'
           done
+
+      - name: Create issue if failed
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        shell: sh
+        run: |
+          TITLE="Failing import for ${{ matrix.group }} group"
+
+          if [ "$(gh issue list --state open --search "in:title $TITLE" -L 1 --json id --jq length)" -eq 0 ]; then
+            gh issue create \
+              --title "$TITLE" \
+              --label "prio:blocker" \
+              --body "This issue was triggered by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -194,12 +194,18 @@ async fn main() -> Result<()> {
         "at least one of --push or --json must be specified"
     );
 
-    let (exports, ident) = run_command(args.command, args.kind, &args.extra).await?;
+    let (exports, ident, partial_error) = run_command(args.command, args.kind, &args.extra).await?;
 
     if args.elastic.enable {
         push_to_elastic(&args.elastic, exports, ident).await?;
     } else if args.elastic.json {
         println!("{}", serde_json::to_string(&exports()?)?);
+    }
+
+    // Surface partial failures (e.g. some group members failed to evaluate) as a
+    // non-zero exit so CI does not report success while data is missing.
+    if let Some(error) = partial_error {
+        return Err(error.into());
     }
     Ok(())
 }
@@ -223,7 +229,14 @@ async fn run_command(
     command: Command,
     kind: Kind,
     extra: &[String],
-) -> Result<(LazyExports, (String, String, String)), FlakeInfoError> {
+) -> Result<
+    (
+        LazyExports,
+        (String, String, String),
+        Option<FlakeInfoError>,
+    ),
+    FlakeInfoError,
+> {
     flake_info::commands::check_nix_version(env!("MIN_NIX_VERSION"))?;
 
     match command {
@@ -249,7 +262,7 @@ async fn run_command(
                 info.revision.unwrap_or("latest".into()),
             );
 
-            Ok((Box::new(|| Ok(exports)), ident))
+            Ok((Box::new(|| Ok(exports)), ident, None))
         }
         Command::Nixpkgs {
             channel,
@@ -284,6 +297,7 @@ async fn run_command(
                     .map_err(FlakeInfoError::Nixpkgs)
                 }),
                 ident,
+                None,
             ))
         }
         Command::NixpkgsArchive {
@@ -316,6 +330,7 @@ async fn run_command(
                     .map_err(FlakeInfoError::Nixpkgs)
                 }),
                 ident,
+                None,
             ))
         }
         Command::Group {
@@ -369,7 +384,7 @@ async fn run_command(
                 .map(Result::unwrap_err) // each result is_err
                 .collect::<Vec<_>>();
 
-            if !errors.is_empty() {
+            let partial_error = if !errors.is_empty() {
                 let error = FlakeInfoError::Group(name.clone(), errors);
                 if exports.is_empty() {
                     return Err(error);
@@ -383,7 +398,11 @@ async fn run_command(
                     let mut file = File::create("report.txt").await?;
                     file.write_all(format!("{}", error).as_bytes()).await?;
                 }
-            }
+
+                Some(error)
+            } else {
+                None
+            };
 
             let hash = {
                 let mut sha = sha2::Sha256::new();
@@ -395,7 +414,7 @@ async fn run_command(
 
             let ident = ("group".to_owned(), name, hash);
 
-            Ok((Box::new(|| Ok(exports)), ident))
+            Ok((Box::new(|| Ok(exports)), ident, partial_error))
         }
     }
 }


### PR DESCRIPTION
The 2-hourly flake import previously exited 0 even when individual group members failed to evaluate, leaving CI green and hiding the failure until a user reported it.

`flake-info group` now still pushes the successfully evaluated members to Elasticsearch, but propagates a non-zero exit afterwards so the workflow fails. The `import-flakes` job in the 2-hourly workflow also gains the same `Create issue if failed` step that `import-nixpkgs` already has (uses `secrets.GITHUB_TOKEN`), so a tracking issue is opened on failure (if none already existed).

Closes #1233.

Disclaimer: i used a coding agent in the creation of this patch.
