### PR TITLE
fix(frontend): address Options page UI feedback

### DIFF
--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -116,6 +116,9 @@ update navKey msg model nixosChannels =
                     in
                     ( newModel, Cmd.map Page.Options.SearchMsg newCmd ) |> Tuple.mapBoth OptionModel (Cmd.map OptionsMsg)
 
+                Page.Options.CopyOptionName name ->
+                    ( OptionModel model_, Page.Options.copyToClipboard name )
+
         ( PackagesMsg msg_, PackagesModel model_ ) ->
             case msg_ of
                 Page.Packages.SearchMsg subMsg ->
@@ -186,7 +189,7 @@ view nixosChannels model =
     in
     case model of
         OptionModel model_ ->
-            Html.map OptionsMsg <| mkBody "3rd-party flake options" model_ (Page.Options.viewSuccess False) Page.Options.viewBuckets Page.Options.SearchMsg
+            Html.map OptionsMsg <| mkBody "3rd-party flake options" model_ (Page.Options.viewSuccess False model_.includedOptionSources) Page.Options.viewBuckets Page.Options.SearchMsg
 
         PackagesModel model_ ->
             Html.map PackagesMsg <| mkBody "3rd-party flake packages" model_ Page.Packages.viewSuccess Page.Packages.viewBuckets Page.Packages.SearchMsg

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -1,9 +1,10 @@
-module Page.Options exposing
+port module Page.Options exposing
     ( AggregationsAll
     , Model
     , Msg(..)
     , ResultAggregations
     , ResultItemSource
+    , copyToClipboard
     , decodeResultAggregations
     , decodeResultItemSource
     , init
@@ -20,6 +21,7 @@ import Html
     exposing
         ( Html
         , a
+        , button
         , code
         , div
         , input
@@ -38,6 +40,7 @@ import Html.Attributes
         , classList
         , href
         , target
+        , title
         , type_
         )
 import Html.Events
@@ -121,11 +124,21 @@ init searchArgs defaultNixOSChannel nixosChannels model =
 
 
 
+-- PORTS
+
+
+{-| Ask the JS side to copy the given text to the clipboard.
+-}
+port copyToClipboard : String -> Cmd msg
+
+
+
 -- UPDATE
 
 
 type Msg
     = SearchMsg (Search.Msg ResultItemSource ResultAggregations)
+    | CopyOptionName String
 
 
 update :
@@ -148,6 +161,9 @@ update navKey msg model nixosChannels =
             in
             ( newModel, Cmd.map SearchMsg newCmd )
 
+        CopyOptionName name ->
+            ( model, copyToClipboard name )
+
 
 
 -- VIEW
@@ -168,7 +184,7 @@ view nixosChannels model =
         ]
         nixosChannels
         model
-        (viewSuccess (enabledCount > 1))
+        (viewSuccess (enabledCount > 1) model.includedOptionSources)
         viewBuckets
         SearchMsg
         [ viewIncludeTogglesGroup model.includedOptionSources ]
@@ -215,16 +231,17 @@ viewBuckets _ _ =
 
 viewSuccess :
     Bool
+    -> Set String
     -> List NixOSChannel
     -> String
     -> Details
     -> Maybe String
     -> List (Search.ResultItem ResultItemSource)
     -> Html Msg
-viewSuccess showBadges nixosChannels channel _ show hits =
+viewSuccess showBadges includedSources nixosChannels channel _ show hits =
     ul []
         (List.map
-            (viewResultItem nixosChannels channel show showBadges)
+            (viewResultItem nixosChannels channel show showBadges includedSources)
             hits
         )
 
@@ -234,9 +251,10 @@ viewResultItem :
     -> String
     -> Maybe String
     -> Bool
+    -> Set String
     -> Search.ResultItem ResultItemSource
     -> Html Msg
-viewResultItem nixosChannels channel show showBadges item =
+viewResultItem nixosChannels channel show showBadges includedSources item =
     let
         asPre value =
             pre [] [ text value ]
@@ -278,7 +296,7 @@ viewResultItem nixosChannels channel show showBadges item =
                 Just <|
                     div [ Html.Attributes.map SearchMsg Search.trapClick ] <|
                         [ div [] [ text "Name" ]
-                        , div [] [ viewOptionNamePath channel nameSegments ]
+                        , div [] [ viewOptionNamePath channel includedSources item.source.name nameSegments ]
                         ]
                             ++ (item.source.description
                                     |> Maybe.andThen Utils.showHtml
@@ -632,7 +650,7 @@ findSource nixosChannels channel source =
 
 {-| Segments making up an option's display name. Each `(text, Just q)` becomes
 a clickable link to an options search for `q`; `(text, Nothing)` is static.
-Every non-final dotted segment of the option name links to its own prefix
+Every dotted segment of the option name links to its own prefix
 (`programs` -> `programs.firefox` -> ...).
 -}
 optionNameSegments : ResultItemSource -> List ( String, Maybe String )
@@ -650,8 +668,8 @@ optionNameSegments source =
             )
 
 
-viewOptionNamePath : String -> List ( String, Maybe String ) -> Html Msg
-viewOptionNamePath channel segments =
+viewOptionNamePath : String -> Set String -> String -> List ( String, Maybe String ) -> Html Msg
+viewOptionNamePath channel includedSources optionName segments =
     let
         lastIndex =
             List.length segments - 1
@@ -666,7 +684,7 @@ viewOptionNamePath channel segments =
                 , buckets = Nothing
                 , sort = Nothing
                 , type_ = Nothing
-                , includedOptionSources = Set.fromList (List.map Route.optionSourceId Route.allOptionSources)
+                , includedOptionSources = includedSources
                 }
 
         renderSegment idx ( segText, query ) =
@@ -690,11 +708,18 @@ viewOptionNamePath channel segments =
             in
             element :: separator
     in
-    div []
+    div [ class "option-name-path" ]
         [ pre []
             [ code [ class "code-block" ]
                 (segments |> List.indexedMap renderSegment |> List.concat)
             ]
+        , button
+            [ type_ "button"
+            , class "option-copy-button"
+            , title "Copy option name"
+            , onClick (CopyOptionName optionName)
+            ]
+            [ text "Copy" ]
         ]
 
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -484,14 +484,18 @@ update toRoute navKey msg model nixosChannels =
                 |> pushUrl toRoute navKey
 
         ChannelChange channel ->
-            { model
-                | channel = channel
-                , redirectedChannel = Nothing
-                , show = Nothing
-                , from = 0
-            }
-                |> ensureLoading nixosChannels
-                |> pushUrl toRoute navKey
+            if channel == model.channel then
+                ( model, Cmd.none )
+
+            else
+                { model
+                    | channel = channel
+                    , redirectedChannel = Nothing
+                    , show = Nothing
+                    , from = 0
+                }
+                    |> ensureLoading nixosChannels
+                    |> pushUrl toRoute navKey
 
         SubjectChange subject ->
             { model
@@ -1143,7 +1147,8 @@ viewResults nixosChannels model result viewSuccess outMsg categoryName =
                     ]
                     (if result.hits.total.value == 10000 then
                         [ text "more than 10000."
-                        , p [] [ text "Please provide more precise search terms." ]
+                        , p [ class "search-refine-hint" ]
+                            [ text "Please provide more precise search terms." ]
                         ]
 
                      else

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,7 +5,7 @@ require("elm-keyboard-shortcut");
 
 const { Elm } = require("./Main");
 
-Elm.Main.init({
+const app = Elm.Main.init({
     flags: {
         elasticsearchMappingSchemaVersion: parseInt(
             process.env.ELASTICSEARCH_MAPPING_SCHEMA_VERSION,
@@ -18,6 +18,13 @@ Elm.Main.init({
         nixosChannels: JSON.parse(process.env.NIXOS_CHANNELS),
     },
 });
+
+if (app.ports && app.ports.copyToClipboard) {
+    app.ports.copyToClipboard.subscribe((text) => {
+        if (!text || !navigator.clipboard) return;
+        navigator.clipboard.writeText(text).catch(() => {});
+    });
+}
 
 document.addEventListener("DOMContentLoaded", function () {
     const shortcutEl = document.getElementById("shortcut-list-el");

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -536,15 +536,18 @@ header .navbar.navbar-static-top {
     padding: 0;
 
     & > li {
-      display: inline-block;
-
-      &:first-child:not(:last-child):after {
-        content: "→";
-        margin: 0 0.2em;
-      }
-
       & > a:hover {
         text-decoration: underline;
+      }
+
+      // Badge column keeps its fixed width; the name column takes the rest
+      // and lets long unbreakable identifiers wrap instead of pushing onto
+      // the next line beneath the badge. (Display:flex is set on the parent
+      // by the more-specific `:nth-child(1).search-result-button` rule.)
+      &:last-child {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow-wrap: anywhere;
       }
     }
   }
@@ -708,6 +711,16 @@ header .navbar.navbar-static-top {
             display: block;
             a {
               color: inherit !important;
+            }
+
+            // For options, the title row is a flex layout so a long option
+            // name wraps inside its own column instead of dropping below the
+            // category badge. Without this override the surrounding
+            // `:nth-child(1)` rule forces `display: block`.
+            &.search-result-button {
+              display: flex;
+              align-items: baseline;
+              gap: 0.5em;
             }
           }
 
@@ -965,6 +978,72 @@ a:focus-visible {
   vertical-align: baseline;
 }
 
+// Align checkboxes vertically with their labels and stop them inheriting
+// stray bootstrap margins that produce a jagged column.
+.search-include-toggles {
+  ul > li > label {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  ul > li > label > input[type="checkbox"] {
+    margin: 0;
+    flex: 0 0 auto;
+  }
+}
+
+// The Name code block in the expanded option view hosts a floating copy
+// button at its right edge. Keep the block as the positioning context so
+// the button overlays the code without jostling its layout.
+.option-name-path {
+  position: relative;
+
+  & > pre {
+    margin: 0;
+  }
+
+  // Reserve space at the right edge of the code block so segment links
+  // never end up underneath the floating button.
+  & > pre > code.code-block {
+    padding-right: 4em;
+  }
+}
+
+.option-copy-button {
+  position: absolute;
+  top: 50%;
+  right: 0.4em;
+  transform: translateY(-50%);
+  padding: 0.3em 0.7em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  line-height: 1.3;
+  cursor: pointer;
+  user-select: none;
+  color: var(--search-result-short-details-color, #666);
+  border: 1px solid var(--search-sidebar-container-border-color, #ccc);
+  background: var(--background-color, #fff);
+
+  &:hover {
+    color: var(--text-color);
+    background: var(--hover-background, rgba(0, 0, 0, 0.05));
+  }
+}
+
+// Make the "Please provide more precise search terms." hint stand out so
+// users notice when their query has been truncated to 10000 results.
+.search-refine-hint {
+  margin-top: 0.3em;
+  padding: 0.4em 0.6em;
+  border-left: 3px solid var(--info-label-background);
+  background: var(--hover-background, rgba(0, 0, 0, 0.05));
+  font-size: 0.7em;
+  font-weight: bold;
+}
+
 .option-badge {
   display: inline-block;
   padding: 0.1em 0.4em;
@@ -978,10 +1057,4 @@ a:focus-visible {
   &.badge-service { background-color: #6e56a0; }
   &.badge-home-manager { background-color: #e07020; }
   &.badge-other { background-color: #888; }
-}
-
-// When a badge column is the first child in search-result-button,
-// suppress the arrow separator that normally follows the first li.
-.search-result-button > li:has(.option-badge-column):first-child:not(:last-child):after {
-  content: none;
 }


### PR DESCRIPTION
Addresses several front-end issues raised largely in #1210:

- Skip channel reload when clicking the already-selected channel button.
- Preserve the active source filters when clicking a parent segment of an option name; previously every category was forcibly re-enabled.
- Add a `Copy` button floating at the right edge of the expanded option's Name code block. Clicking it copies the full dotted name via a `copyToClipboard` port and `navigator.clipboard.writeText`, so the per-segment refine links can stay clickable.
- Drop the `arrow` separator between the category badge and the option name in the result header.
- Style the "Please provide more precise search terms." hint as a callout so it is noticeable when a query is truncated at 10000 hits.
- Align the source-filter checkboxes with their labels in the sidebar.
- [Wrap long option names](https://github.com/NixOS/nixos-search/issues/1210#issuecomment-4338716561)

Disclaimer: i used a coding agent in the creation of this patch.
