### PR TITLE
fix(frontend): link Home Manager options to home-manager repo

### DIFF
--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -557,6 +557,12 @@ findSource nixosChannels channel source =
         githubUrlPrefix branch =
             "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
 
+        -- Home Manager options are imported from `github:nix-community/home-manager`
+        -- at master (see `flake-info/src/commands/nixpkgs_info.rs`), so their
+        -- `option_source` paths resolve against that repo, not nixpkgs.
+        homeManagerUrlPrefix =
+            "https://github.com/nix-community/home-manager/blob/master/"
+
         cleanPosition value =
             if String.startsWith "source/" value then
                 String.dropLeft 7 value
@@ -565,16 +571,24 @@ findSource nixosChannels channel source =
                 value
 
         asGithubLink value =
-            case List.Extra.find (\x -> x.id == channel) nixosChannels of
-                Just channelDetails ->
-                    a
-                        [ href <| githubUrlPrefix channelDetails.branch ++ (value |> String.replace ":" "#L")
-                        , target "_blank"
-                        ]
-                        [ text value ]
+            if source.docType == "home-manager-option" then
+                a
+                    [ href <| homeManagerUrlPrefix ++ (value |> String.replace ":" "#L")
+                    , target "_blank"
+                    ]
+                    [ text value ]
 
-                Nothing ->
-                    text <| cleanPosition value
+            else
+                case List.Extra.find (\x -> x.id == channel) nixosChannels of
+                    Just channelDetails ->
+                        a
+                            [ href <| githubUrlPrefix channelDetails.branch ++ (value |> String.replace ":" "#L")
+                            , target "_blank"
+                            ]
+                            [ text value ]
+
+                    Nothing ->
+                        text <| cleanPosition value
 
         asFlakeSourceLink flakeUrl_ value =
             let


### PR DESCRIPTION
The "Declared in" link on Home Manager options pointed at `github.com/NixOS/nixpkgs/blob/<channel-branch>/...`, which 404s because HM `option_source` paths (e.g. `modules/programs/chromium.nix`) live in `nix-community/home-manager`.

Disclaimer: i used a coding agent in the creation of this patch.