### PR TITLE
for home-manager, filter displayed options by branches deemed to match the selected nixpkgs one

### DIFF
--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -181,15 +181,25 @@ pub fn get_nixpkgs_services(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
     Ok(attr_set.into_iter().map(NixpkgsEntry::Service).collect())
 }
 
-/// Home-manager flake reference used to evaluate HM options alongside
-/// each nixpkgs channel import.
-const HOME_MANAGER_FLAKE_REF: &str = "github:nix-community/home-manager";
+/// Home-manager flake reference matching a given nixpkgs channel. Stable
+/// nixpkgs channels (`nixos-XX.YY`) get the corresponding `release-XX.YY`
+/// branch in `nix-community/home-manager`; `nixos-unstable` gets `master`.
+fn home_manager_flake_ref(nixpkgs: &Source) -> String {
+    let base = "github:nix-community/home-manager";
+    match nixpkgs {
+        Source::Nixpkgs(Nixpkgs { channel, .. }) if channel != "unstable" => {
+            format!("{base}/release-{channel}")
+        }
+        _ => base.to_string(),
+    }
+}
 
 pub fn get_home_manager_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
+    let hm_flake_ref = home_manager_flake_ref(nixpkgs);
     let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
     command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
-    command.add_args(["--override-flake", "input-flake", HOME_MANAGER_FLAKE_REF].iter());
+    command.add_args(["--override-flake", "input-flake", &hm_flake_ref].iter());
     command.add_arg("home-manager-options");
 
     command.enable_capture();

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -575,11 +575,20 @@ findSource nixosChannels channel source =
         githubUrlPrefix branch =
             "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
 
-        -- Home Manager options are imported from `github:nix-community/home-manager`
-        -- at master (see `flake-info/src/commands/nixpkgs_info.rs`), so their
-        -- `option_source` paths resolve against that repo, not nixpkgs.
-        homeManagerUrlPrefix =
-            "https://github.com/nix-community/home-manager/blob/master/"
+        -- Home Manager options are imported from the `release-XX.YY` branch of
+        -- `nix-community/home-manager` matching the nixpkgs channel
+        -- (see `flake-info/src/commands/nixpkgs_info.rs`), or `master` for
+        -- `nixos-unstable`. Their `option_source` paths resolve against that
+        -- repo, not nixpkgs.
+        homeManagerBranch nixpkgsBranch =
+            if nixpkgsBranch == "nixos-unstable" then
+                "master"
+
+            else
+                "release-" ++ String.dropLeft (String.length "nixos-") nixpkgsBranch
+
+        homeManagerUrlPrefix branch =
+            "https://github.com/nix-community/home-manager/blob/" ++ branch ++ "/"
 
         cleanPosition value =
             if String.startsWith "source/" value then
@@ -589,24 +598,24 @@ findSource nixosChannels channel source =
                 value
 
         asGithubLink value =
-            if source.docType == "home-manager-option" then
-                a
-                    [ href <| homeManagerUrlPrefix ++ (value |> String.replace ":" "#L")
-                    , target "_blank"
-                    ]
-                    [ text value ]
+            case List.Extra.find (\x -> x.id == channel) nixosChannels of
+                Just channelDetails ->
+                    let
+                        prefix =
+                            if source.docType == "home-manager-option" then
+                                homeManagerUrlPrefix (homeManagerBranch channelDetails.branch)
 
-            else
-                case List.Extra.find (\x -> x.id == channel) nixosChannels of
-                    Just channelDetails ->
-                        a
-                            [ href <| githubUrlPrefix channelDetails.branch ++ (value |> String.replace ":" "#L")
-                            , target "_blank"
-                            ]
-                            [ text value ]
+                            else
+                                githubUrlPrefix channelDetails.branch
+                    in
+                    a
+                        [ href <| prefix ++ (value |> String.replace ":" "#L")
+                        , target "_blank"
+                        ]
+                        [ text value ]
 
-                    Nothing ->
-                        text <| cleanPosition value
+                Nothing ->
+                    text <| cleanPosition value
 
         asFlakeSourceLink flakeUrl_ value =
             let


### PR DESCRIPTION
to translate the spirit of the UI without further complicating it for the time being, implicitly maps nixpkgs branch `nixos-unstable` to HM branch `master,` and stable branches to corresponding stable branches.

Closes #1242.

Disclaimer: I used a coding agent in the creation of this patch.
