### PR TITLE
feat(frontend): tab Options page sources, opt into ES request_cache

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -3,6 +3,7 @@ module Main exposing (Flags, Model, Msg, Page, main)
 import Browser
 import Browser.Dom
 import Browser.Navigation
+import Dict
 import Html
     exposing
         ( Html
@@ -39,7 +40,6 @@ import Search
         , decodeNixOSChannels
         , defaultFlakeId
         )
-import Set
 import Shortcut
 import Task
 import Url
@@ -192,7 +192,7 @@ attemptQuery (( model, _ ) as pair) =
                                     searchModel.size
                                     searchModel.buckets
                                     searchModel.sort
-                                    searchModel.includedOptionSources
+                                    searchModel.activeOptionSource
                             ]
                     )
                     pair
@@ -225,17 +225,20 @@ pageMatch m1 m2 =
             True
 
         ( Packages model_a, Packages model_b ) ->
-            { model_a | show = Nothing, showInstallDetails = Search.Unset, result = NotAsked }
-                == { model_b | show = Nothing, showInstallDetails = Search.Unset, result = NotAsked }
+            { model_a | show = Nothing, showInstallDetails = Search.Unset, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
+                == { model_b | show = Nothing, showInstallDetails = Search.Unset, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
 
         ( Options model_a, Options model_b ) ->
-            { model_a | show = Nothing, result = NotAsked } == { model_b | show = Nothing, result = NotAsked }
+            { model_a | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
+                == { model_b | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
 
         ( Flakes (OptionModel model_a), Flakes (OptionModel model_b) ) ->
-            { model_a | show = Nothing, result = NotAsked } == { model_b | show = Nothing, result = NotAsked }
+            { model_a | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
+                == { model_b | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
 
         ( Flakes (PackagesModel model_a), Flakes (PackagesModel model_b) ) ->
-            { model_a | show = Nothing, result = NotAsked } == { model_b | show = Nothing, result = NotAsked }
+            { model_a | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
+                == { model_b | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
 
         _ ->
             False
@@ -475,7 +478,7 @@ viewNavigation route =
                         args
 
                     _ ->
-                        Route.SearchArgs Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing (Set.fromList (List.map Route.optionSourceId Route.allOptionSources))
+                        Route.SearchArgs Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Route.defaultOptionSource
     in
     li [] [ a [ href "https://nixos.org" ] [ text "Back to nixos.org" ] ]
         :: List.map

--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -189,7 +189,7 @@ view nixosChannels model =
     in
     case model of
         OptionModel model_ ->
-            Html.map OptionsMsg <| mkBody "3rd-party flake options" model_ (Page.Options.viewSuccess False model_.includedOptionSources) Page.Options.viewBuckets Page.Options.SearchMsg
+            Html.map OptionsMsg <| mkBody "3rd-party flake options" model_ (Page.Options.viewSuccess model_.activeOptionSource) Page.Options.viewBuckets Page.Options.SearchMsg
 
         PackagesModel model_ ->
             Html.map PackagesMsg <| mkBody "3rd-party flake packages" model_ Page.Packages.viewSuccess Page.Packages.viewBuckets Page.Packages.SearchMsg

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -17,6 +17,7 @@ port module Page.Options exposing
     )
 
 import Browser.Navigation
+import Dict exposing (Dict)
 import Html
     exposing
         ( Html
@@ -52,6 +53,7 @@ import Http exposing (Body)
 import Json.Decode
 import Json.Decode.Pipeline
 import List.Extra
+import RemoteData
 import Route exposing (OptionSource, SearchType)
 import Search
     exposing
@@ -59,8 +61,8 @@ import Search
         , NixOSChannel
         , decodeResolvedFlake
         )
-import Set exposing (Set)
 import SyntaxHighlight exposing (elm, oneDark, toBlockHtml, useTheme)
+import Task
 import Utils
 
 
@@ -174,51 +176,86 @@ view :
     -> Model
     -> Html Msg
 view nixosChannels model =
-    let
-        enabledCount =
-            Set.size model.includedOptionSources
-    in
     Search.view { categoryName = "options" }
         [ text "Search more than "
         , strong [] [ text "20 000 options" ]
         ]
         nixosChannels
         model
-        (viewSuccess (enabledCount > 1) model.includedOptionSources)
+        (viewSuccess model.activeOptionSource)
         viewBuckets
         SearchMsg
-        [ viewIncludeTogglesGroup model.includedOptionSources ]
+        [ viewSourceTabs model.activeOptionSource model.sourceCounts ]
 
 
-viewIncludeTogglesGroup : Set String -> Html Msg
-viewIncludeTogglesGroup included =
-    li [ class "search-include-toggles" ]
+{-| Tab strip: one tab per option source. Each tab pulls its count from
+the shared `sourceCounts` dict (the active tab's count is mirrored
+there on `QueryResponse`, inactive ones come from `size: 0` queries
+fired alongside the main one). Pulling counts uniformly from one place
+means the badges survive a tab switch unchanged — the previous tab's
+count stays visible until a fresh count for the new tab arrives.
+-}
+viewSourceTabs : OptionSource -> Dict String Int -> Html Msg
+viewSourceTabs activeSource sourceCounts =
+    li [ class "search-source-tabs" ]
         [ ul [] <|
-            li [ class "header" ] [ text "Show" ]
-                :: List.map (viewIncludeToggle included) Route.allOptionSources
+            li [ class "header" ] [ text "Source" ]
+                :: List.map
+                    (\source ->
+                        viewSourceTab
+                            activeSource
+                            (Dict.get (Route.optionSourceId source) sourceCounts)
+                            source
+                    )
+                    Route.allOptionSources
         ]
 
 
-viewIncludeToggle : Set String -> OptionSource -> Html Msg
-viewIncludeToggle included source =
+viewSourceTab : OptionSource -> Maybe Int -> OptionSource -> Html Msg
+viewSourceTab activeSource count source =
     let
+        isActive =
+            source == activeSource
+
         id =
             Route.optionSourceId source
 
-        isChecked =
-            Set.member id included
+        badge =
+            case count of
+                Just n ->
+                    [ span [ class "badge" ] [ text (formatCount n) ] ]
+
+                Nothing ->
+                    []
     in
-    li [ class ("search-include-" ++ id ++ "-options") ]
-        [ label []
-            [ input
-                [ type_ "checkbox"
-                , checked isChecked
-                , onCheck (\b -> SearchMsg (Search.SetOptionSourceIncluded source b))
-                ]
-                []
-            , text (" " ++ Route.optionSourceLabel source)
+    li
+        [ class ("search-source-" ++ id) ]
+        [ a
+            -- The sidebar's existing `&.selected` styling targets `a`,
+            -- not `li`, so the active-tab highlight class lives on the
+            -- anchor.
+            [ classList [ ( "selected", isActive ) ]
+            , href "#"
+            , Html.Events.onClick (SearchMsg (Search.SetActiveOptionSource source))
             ]
+            (span [] [ text (Route.optionSourceLabel source) ] :: badge)
         ]
+
+
+{-| Compact rendering of a hit count for the tab badge: 1.2k, 23k, etc.
+ES returns counts up to 10 000 as exact and beyond that as a >=10000
+sentinel; render the latter as "10k+" so we don't lie about precision.
+-}
+formatCount : Int -> String
+formatCount n =
+    if n >= 10000 then
+        "10k+"
+
+    else if n >= 1000 then
+        String.fromInt (n // 1000) ++ "." ++ String.fromInt (modBy 10 (n // 100)) ++ "k"
+
+    else
+        String.fromInt n
 
 
 viewBuckets :
@@ -230,18 +267,17 @@ viewBuckets _ _ =
 
 
 viewSuccess :
-    Bool
-    -> Set String
+    OptionSource
     -> List NixOSChannel
     -> String
     -> Details
     -> Maybe String
     -> List (Search.ResultItem ResultItemSource)
     -> Html Msg
-viewSuccess showBadges includedSources nixosChannels channel _ show hits =
+viewSuccess activeSource nixosChannels channel _ show hits =
     ul []
         (List.map
-            (viewResultItem nixosChannels channel show showBadges includedSources)
+            (viewResultItem nixosChannels channel show activeSource)
             hits
         )
 
@@ -250,11 +286,10 @@ viewResultItem :
     List NixOSChannel
     -> String
     -> Maybe String
-    -> Bool
-    -> Set String
+    -> OptionSource
     -> Search.ResultItem ResultItemSource
     -> Html Msg
-viewResultItem nixosChannels channel show showBadges includedSources item =
+viewResultItem nixosChannels channel show activeSource item =
     let
         asPre value =
             pre [] [ text value ]
@@ -296,7 +331,7 @@ viewResultItem nixosChannels channel show showBadges includedSources item =
                 Just <|
                     div [ Html.Attributes.map SearchMsg Search.trapClick ] <|
                         [ div [] [ text "Name" ]
-                        , div [] [ viewOptionNamePath channel includedSources item.source.name nameSegments ]
+                        , div [] [ viewOptionNamePath channel activeSource item.source.name nameSegments ]
                         ]
                             ++ (item.source.description
                                     |> Maybe.andThen Utils.showHtml
@@ -388,34 +423,6 @@ viewResultItem nixosChannels channel show showBadges includedSources item =
 
         isOpen =
             Just itemId == show
-
-        categoryBadge =
-            if showBadges then
-                let
-                    ( badgeText, badgeClass ) =
-                        case item.source.docType of
-                            "option" ->
-                                ( "NixOS", "badge-nixos" )
-
-                            "service" ->
-                                ( "Service", "badge-service" )
-
-                            "home-manager-option" ->
-                                ( "HM", "badge-home-manager" )
-
-                            _ ->
-                                ( "Other", "badge-other" )
-                in
-                [ li []
-                    [ span [ class "option-badge-column" ]
-                        [ span [ class ("option-badge " ++ badgeClass) ]
-                            [ text badgeText ]
-                        ]
-                    ]
-                ]
-
-            else
-                []
     in
     li
         [ class "option"
@@ -426,16 +433,14 @@ viewResultItem nixosChannels channel show showBadges includedSources item =
         List.filterMap identity
             [ Just <|
                 ul [ class "search-result-button" ]
-                    (categoryBadge
-                        ++ [ li []
-                                [ a
-                                    [ onClick toggle
-                                    , href ""
-                                    ]
-                                    [ text displayName ]
-                                ]
-                           ]
-                    )
+                    [ li []
+                        [ a
+                            [ onClick toggle
+                            , href ""
+                            ]
+                            [ text displayName ]
+                        ]
+                    ]
             , showDetails
             ]
 
@@ -682,8 +687,8 @@ optionNameSegments source =
             )
 
 
-viewOptionNamePath : String -> Set String -> String -> List ( String, Maybe String ) -> Html Msg
-viewOptionNamePath channel includedSources optionName segments =
+viewOptionNamePath : String -> OptionSource -> String -> List ( String, Maybe String ) -> Html Msg
+viewOptionNamePath channel activeSource optionName segments =
     let
         lastIndex =
             List.length segments - 1
@@ -698,7 +703,7 @@ viewOptionNamePath channel includedSources optionName segments =
                 , buckets = Nothing
                 , sort = Nothing
                 , type_ = Nothing
-                , includedOptionSources = includedSources
+                , activeOptionSource = activeSource
                 }
 
         renderSegment idx ( segText, query ) =
@@ -741,6 +746,13 @@ viewOptionNamePath channel includedSources optionName segments =
 -- API
 
 
+{-| Issue a single ES query restricted to the active tab's source plus
+one tiny `size: 0` count query per inactive source so the tabs can
+display hit-count badges. Active-tab body and count bodies are all
+byte-stable across users on identical input, so `request_cache` hits
+amortize the cost; size:0 in particular is the workload that cache
+was designed for.
+-}
 makeRequest :
     Search.Options
     -> List NixOSChannel
@@ -751,27 +763,63 @@ makeRequest :
     -> Int
     -> Maybe String
     -> Search.Sort
-    -> Set String
+    -> OptionSource
     -> Cmd Msg
-makeRequest options nixosChannels _ channel query from size _ sort includedSources =
+makeRequest options nixosChannels _ channel query from size _ sort activeSource =
     let
-        types =
-            Route.allOptionSources
-                |> List.filter
-                    (\source ->
-                        Set.member (Route.optionSourceId source) includedSources
+        activeQuery : Cmd (Search.Msg ResultItemSource ResultAggregations)
+        activeQuery =
+            Search.makeRequestTask
+                (makeRequestBody
+                    [ Route.optionSourceDocType activeSource ]
+                    query
+                    from
+                    size
+                    sort
+                )
+                nixosChannels
+                channel
+                decodeResultItemSource
+                decodeResultAggregations
+                options
+                |> Task.attempt (RemoteData.fromResult >> Search.QueryResponse)
+
+        countQuery : OptionSource -> Cmd (Search.Msg ResultItemSource ResultAggregations)
+        countQuery source =
+            Search.makeRequestTask
+                (makeRequestBody
+                    [ Route.optionSourceDocType source ]
+                    query
+                    0
+                    0
+                    sort
+                )
+                nixosChannels
+                channel
+                decodeResultItemSource
+                decodeResultAggregations
+                options
+                |> Task.attempt
+                    (\result ->
+                        case result of
+                            Ok r ->
+                                Search.SourceCount
+                                    (Route.optionSourceId source)
+                                    r.hits.total.value
+
+                            Err _ ->
+                                -- Swallow the error; the badge just won't
+                                -- appear for that tab. The active tab's
+                                -- own failure mode is handled by `result`.
+                                Search.NoOp
                     )
-                |> List.map Route.optionSourceDocType
+
+        inactiveSources =
+            Route.allOptionSources
+                |> List.filter (\s -> s /= activeSource)
     in
-    Search.makeRequest
-        (makeRequestBody types query from size sort)
-        nixosChannels
-        channel
-        decodeResultItemSource
-        decodeResultAggregations
-        options
-        Search.QueryResponse
-        (Just "query-options")
+    (activeQuery :: List.map countQuery inactiveSources)
+        |> Cmd.batch
         |> Cmd.map SearchMsg
 
 

--- a/frontend/src/Route.elm
+++ b/frontend/src/Route.elm
@@ -6,9 +6,11 @@ module Route exposing
     , SearchType(..)
     , allOptionSources
     , allTypes
+    , defaultOptionSource
     , fromUrl
     , href
     , optionSourceDocType
+    , optionSourceFromId
     , optionSourceId
     , optionSourceLabel
     , routeToString
@@ -20,7 +22,6 @@ import Dict
 import Html
 import Html.Attributes
 import Maybe.Extra
-import Set exposing (Set)
 import Url
 
 
@@ -37,7 +38,7 @@ type alias SearchArgs =
     , buckets : Maybe String
     , sort : Maybe String
     , type_ : Maybe SearchType
-    , includedOptionSources : Set String
+    , activeOptionSource : OptionSource
     }
 
 
@@ -56,7 +57,14 @@ allOptionSources =
     [ NixosOptions, ModularServiceOptions, HomeManagerOptionSource ]
 
 
-{-| Stable identifier used in URL parameter names and the excluded-sources set.
+{-| Default tab when no source is specified in the URL.
+-}
+defaultOptionSource : OptionSource
+defaultOptionSource =
+    NixosOptions
+
+
+{-| Stable identifier used in the `source=` URL parameter.
 -}
 optionSourceId : OptionSource -> String
 optionSourceId source =
@@ -69,6 +77,16 @@ optionSourceId source =
 
         HomeManagerOptionSource ->
             "home_manager"
+
+
+{-| Inverse of `optionSourceId`. Returns `Nothing` for unknown identifiers
+so URL parsing can fall back to the default tab.
+-}
+optionSourceFromId : String -> Maybe OptionSource
+optionSourceFromId id =
+    allOptionSources
+        |> List.filter (\s -> optionSourceId s == id)
+        |> List.head
 
 
 {-| Elasticsearch document `type` field value.
@@ -99,11 +117,6 @@ optionSourceLabel source =
 
         HomeManagerOptionSource ->
             "Home Manager"
-
-
-optionSourceUrlParam : OptionSource -> String
-optionSourceUrlParam source =
-    "include_" ++ optionSourceId source ++ "_options"
 
 
 type SearchType
@@ -199,18 +212,10 @@ searchQueryParser appUrl =
     , buckets = string "buckets"
     , sort = string "sort"
     , type_ = Maybe.andThen searchTypeFromString (string "type")
-    , includedOptionSources =
-        -- Each source defaults to included; URL says "0" to exclude.
-        allOptionSources
-            |> List.filterMap
-                (\source ->
-                    if string (optionSourceUrlParam source) == Just "0" then
-                        Nothing
-
-                    else
-                        Just (optionSourceId source)
-                )
-            |> Set.fromList
+    , activeOptionSource =
+        string "source"
+            |> Maybe.andThen optionSourceFromId
+            |> Maybe.withDefault defaultOptionSource
     }
 
 
@@ -233,20 +238,15 @@ searchArgsToUrl args =
     , string "sort" args.sort
     , string "type" <| Maybe.map searchTypeToString args.type_
     , string "query" args.query
-    ]
-        ++ List.map
-            (\source ->
-                let
-                    value =
-                        if Set.member (optionSourceId source) args.includedOptionSources then
-                            "1"
+    , string "source"
+        (if args.activeOptionSource == defaultOptionSource then
+            -- Keep the default tab off the URL for clean bookmarks.
+            Nothing
 
-                        else
-                            "0"
-                in
-                string (optionSourceUrlParam source) (Just value)
-            )
-            allOptionSources
+         else
+            Just (optionSourceId args.activeOptionSource)
+        )
+    ]
         |> Maybe.Extra.values
         |> Dict.fromList
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -22,6 +22,7 @@ module Search exposing
     , init
     , makeRequest
     , makeRequestBody
+    , makeRequestTask
     , onClickStop
     , shouldLoad
     , showMoreButton
@@ -38,6 +39,7 @@ import Array
 import Base64
 import Browser.Dom
 import Browser.Navigation
+import Dict exposing (Dict)
 import Html
     exposing
         ( Html
@@ -89,7 +91,6 @@ import Route
         , allTypes
         , searchTypeToTitle
         )
-import Set exposing (Set)
 import Task
 
 
@@ -107,7 +108,19 @@ type alias Model a b =
     , showInstallDetails : Details
     , searchType : Route.SearchType
     , redirectedChannel : Maybe String
-    , includedOptionSources : Set String
+    , activeOptionSource : Route.OptionSource
+
+    -- Hit counts per option source, keyed by `Route.optionSourceId`.
+    -- The active source's count is written here on `QueryResponse`,
+    -- inactive sources' counts arrive via `SourceCount`. Surviving
+    -- across tab switches keeps the badges visible while the new
+    -- tab's full query is in flight.
+    , sourceCounts : Dict String Int
+
+    -- Last successful result, retained while a new query is in flight
+    -- so the UI can keep showing it (with a spinner) instead of
+    -- flashing the full loader. Cleared once the new response lands.
+    , previousResult : Maybe (SearchResult a b)
     }
 
 
@@ -345,7 +358,9 @@ init args defaultNixOSChannel nixosChannels maybeModel =
       , searchType =
             args.type_
                 |> Maybe.withDefault defaultSearchArgs.searchType
-      , includedOptionSources = args.includedOptionSources
+      , activeOptionSource = args.activeOptionSource
+      , sourceCounts = Dict.empty
+      , previousResult = Nothing
       }
         |> ensureLoading nixosChannels
     , Browser.Dom.focus "search-query-input" |> Task.attempt (\_ -> NoOp)
@@ -384,7 +399,21 @@ ensureLoading nixosChannels model =
         not (String.isEmpty model.query)
             && List.any (\channel -> channel.id == model.channel) nixosChannels
     then
-        { model | result = RemoteData.Loading }
+        -- Save the current Success result so views can keep showing it
+        -- (with a spinner overlay) while the new response is in flight,
+        -- rather than flashing the full loader. Source counts are left
+        -- alone: they get overwritten as new responses arrive, which
+        -- avoids tab badges blanking on every tab switch.
+        { model
+            | result = RemoteData.Loading
+            , previousResult =
+                case model.result of
+                    RemoteData.Success r ->
+                        Just r
+
+                    _ ->
+                        model.previousResult
+        }
 
     else
         model
@@ -414,7 +443,8 @@ type Msg a b
     | ShowDetails String
     | ChangePage Int
     | ShowInstallDetails Details
-    | SetOptionSourceIncluded OptionSource Bool
+    | SetActiveOptionSource OptionSource
+    | SourceCount String Int
 
 
 type Details
@@ -521,8 +551,41 @@ update toRoute navKey msg model nixosChannels =
                 |> pushUrl toRoute navKey
 
         QueryResponse result ->
+            let
+                activeSourceId =
+                    Route.optionSourceId model.activeOptionSource
+
+                -- Mirror the active tab's count into the per-source dict
+                -- so tabs read uniformly from one place. Pages that don't
+                -- use option-source tabs (Packages, Flakes) just write
+                -- into a dict no one reads.
+                updatedCounts =
+                    case result of
+                        RemoteData.Success r ->
+                            Dict.insert
+                                activeSourceId
+                                r.hits.total.value
+                                model.sourceCounts
+
+                        _ ->
+                            model.sourceCounts
+
+                -- A fresh Success replaces the stale-while-loading copy.
+                -- Failure keeps the previous result available so the user
+                -- sees the prior data alongside an error rather than a
+                -- blank page.
+                clearedPrevious =
+                    case result of
+                        RemoteData.Success _ ->
+                            Nothing
+
+                        _ ->
+                            model.previousResult
+            in
             ( { model
                 | result = result
+                , sourceCounts = updatedCounts
+                , previousResult = clearedPrevious
               }
             , scrollToEntry model.show
             )
@@ -547,20 +610,17 @@ update toRoute navKey msg model nixosChannels =
             { model | showInstallDetails = details }
                 |> pushUrl toRoute navKey
 
-        SetOptionSourceIncluded source included ->
-            let
-                id =
-                    Route.optionSourceId source
+        SourceCount sourceId count ->
+            ( { model
+                | sourceCounts =
+                    Dict.insert sourceId count model.sourceCounts
+              }
+            , Cmd.none
+            )
 
-                newIncluded =
-                    if included then
-                        Set.insert id model.includedOptionSources
-
-                    else
-                        Set.remove id model.includedOptionSources
-            in
+        SetActiveOptionSource source ->
             { model
-                | includedOptionSources = newIncluded
+                | activeOptionSource = source
                 , show = Nothing
                 , from = 0
             }
@@ -605,7 +665,7 @@ createUrl toRoute model =
                 justIfNotDefault model.sort defaultSearchArgs.sort
                     |> Maybe.map toSortId
             , type_ = justIfNotDefault model.searchType defaultSearchArgs.searchType
-            , includedOptionSources = model.includedOptionSources
+            , activeOptionSource = model.activeOptionSource
             }
 
 
@@ -895,11 +955,28 @@ viewResult nixosChannels outMsg categoryName model viewSuccess viewBuckets searc
                     ]
 
         RemoteData.Loading ->
-            div [ class "loader-wrapper" ]
-                [ ul [ class "search-sidebar" ] searchBuckets
-                , div [ class "loader" ] [ text "Loading..." ]
-                , h2 [] [ text "Searching..." ]
-                ]
+            case model.previousResult of
+                Just prev ->
+                    -- Stale-while-revalidating: keep the previous result
+                    -- on screen and overlay a small spinner so the page
+                    -- doesn't blank out on every re-fetch (e.g. tab
+                    -- switch). The view path is the same as Success.
+                    let
+                        buckets =
+                            viewBuckets model.buckets prev
+                    in
+                    div [ class "search-results", class "loading-overlay" ]
+                        [ ul [ class "search-sidebar" ] (searchBuckets ++ buckets)
+                        , div []
+                            (viewResults nixosChannels model prev viewSuccess outMsg categoryName)
+                        ]
+
+                Nothing ->
+                    div [ class "loader-wrapper" ]
+                        [ ul [ class "search-sidebar" ] searchBuckets
+                        , div [ class "loader" ] [ text "Loading..." ]
+                        , h2 [] [ text "Searching..." ]
+                        ]
 
         RemoteData.Success result ->
             let
@@ -1532,6 +1609,70 @@ makeRequest body nixosChannels channel decodeResultItemSource decodeResultAggreg
                 (decodeResult decodeResultItemSource decodeResultAggregations)
         , timeout = Nothing
         , tracker = tracker
+        }
+
+
+{-| Task-returning variant of `makeRequest` so callers can combine several
+HTTP requests into a single Cmd via `Task.sequence` / `Task.map`. Used by
+the Options page to fan out one ES request per included source and merge
+the responses into a single `SearchResult` before delivering it to the
+search update flow.
+-}
+makeRequestTask :
+    Http.Body
+    -> List NixOSChannel
+    -> String
+    -> Json.Decode.Decoder a
+    -> Json.Decode.Decoder b
+    -> Options
+    -> Task.Task Http.Error (SearchResult a b)
+makeRequestTask body nixosChannels channel decodeResultItemSource decodeResultAggregations options =
+    let
+        branch : String
+        branch =
+            nixosChannels
+                |> List.filter (\x -> x.id == channel)
+                |> List.head
+                |> Maybe.map (\x -> x.branch)
+                |> Maybe.withDefault channel
+
+        index =
+            "latest-" ++ String.fromInt options.mappingSchemaVersion ++ "-" ++ branch
+    in
+    -- `request_cache=true` opts these federated per-source queries into ES's
+    -- shard request cache. The cache is normally only used for `size:0`
+    -- aggregations; opting in is safe here because each query body is
+    -- byte-stable across users (only the user query varies), making cache
+    -- hits real and useful. Index refreshes invalidate automatically.
+    Http.riskyTask
+        { method = "POST"
+        , headers =
+            [ Http.header "Authorization" ("Basic " ++ Base64.encode (options.username ++ ":" ++ options.password))
+            ]
+        , url = options.url ++ "/" ++ index ++ "/_search?request_cache=true"
+        , body = body
+        , resolver =
+            Http.stringResolver <|
+                \response ->
+                    case response of
+                        Http.GoodStatus_ _ s ->
+                            Json.Decode.decodeString
+                                (decodeResult decodeResultItemSource decodeResultAggregations)
+                                s
+                                |> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+
+                        Http.BadStatus_ meta _ ->
+                            Err (Http.BadStatus meta.statusCode)
+
+                        Http.NetworkError_ ->
+                            Err Http.NetworkError
+
+                        Http.Timeout_ ->
+                            Err Http.Timeout
+
+                        Http.BadUrl_ url ->
+                            Err (Http.BadUrl url)
+        , timeout = Nothing
         }
 
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -969,29 +969,68 @@ a:focus-visible {
   background-color: var(--badge-background)
 }
 
-// Fixed-width column for category badges so option names align.
-// The width accommodates the longest label ("Service") plus padding.
-.option-badge-column {
+// Stale-while-loading indicator. When a fresh query is in flight but a
+// previous result is still being shown (e.g. during a tab switch), the
+// `.search-results` container also gets `.loading-overlay`. A small
+// spinner appears next to the result-count header without blanking the
+// page.
+.search-results.loading-overlay h2::after {
+  content: "";
   display: inline-block;
-  width: 4.5em;
-  text-align: center;
-  vertical-align: baseline;
+  width: 0.9em;
+  height: 0.9em;
+  margin-left: 0.5em;
+  vertical-align: -0.1em;
+  border: 2px solid var(--text-color-light, currentColor);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin-overlay 0.8s linear infinite;
 }
 
-// Align checkboxes vertically with their labels and stop them inheriting
-// stray bootstrap margins that produce a jagged column.
-.search-include-toggles {
-  ul > li > label {
-    display: flex;
-    align-items: center;
-    gap: 0.4em;
-    margin: 0;
-    cursor: pointer;
+@keyframes spin-overlay {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// Tab strip in the Options sidebar — one tab per option source. Active
+// tab inherits the `.selected` background/foreground from the sidebar's
+// generic styling; the rules below diverge from the bucket-style sidebar
+// in two ways:
+//
+// 1. The bucket layout uses `display: grid` + `:last-child { text-align:
+//    right }`, which right-aligns the lone label whenever a tab's count
+//    badge is missing (e.g. while a fresh query is loading). Flex with
+//    `margin-left: auto` on the badge keeps the label left-aligned
+//    regardless of whether a badge is present.
+// 2. The bucket pattern hides the *last child* of `.selected` because
+//    the count is duplicated above the result list — that rule hides
+//    both the badge (when present) and the lone label (when not),
+//    which means the active tab disappears entirely while loading.
+//    We re-show last-child for tabs.
+//
+// Nested inside `.search-page` to match the specificity of the rule
+// being overridden (which is also `.search-page`-prefixed via outer
+// nesting), so the override actually wins the cascade.
+.search-page ul.search-sidebar > li.search-source-tabs > ul > li > a {
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+  text-decoration: none;
+
+  & > span {
+    text-align: left;
   }
 
-  ul > li > label > input[type="checkbox"] {
-    margin: 0;
-    flex: 0 0 auto;
+  & > .badge {
+    margin-left: auto;
+  }
+
+  // Counter the bucket-pattern `&.selected > span:last-child {
+  // display: none }` rule — applies to both the badge (when present)
+  // and the lone label (when counts are still loading).
+  &.selected > span:last-child {
+    display: inline-block;
   }
 }
 
@@ -1044,17 +1083,3 @@ a:focus-visible {
   font-weight: bold;
 }
 
-.option-badge {
-  display: inline-block;
-  padding: 0.1em 0.4em;
-  border-radius: 999px;
-  font-size: 0.7em;
-  font-weight: 600;
-  line-height: 1.4;
-  color: #fff;
-
-  &.badge-nixos { background-color: #5277c3; }
-  &.badge-service { background-color: #6e56a0; }
-  &.badge-home-manager { background-color: #e07020; }
-  &.badge-other { background-color: #888; }
-}

--- a/frontend/tests/UrlRoundtrip.elm
+++ b/frontend/tests/UrlRoundtrip.elm
@@ -39,8 +39,14 @@ searchArgsFuzzer =
         |> Fuzz.andMap (Fuzz.maybe Fuzz.string)
         |> Fuzz.andMap (Fuzz.maybe Fuzz.string)
         |> Fuzz.andMap (Fuzz.maybe searchTypeFuzzer)
+        |> Fuzz.andMap optionSourceFuzzer
 
 
 searchTypeFuzzer : Fuzzer SearchType
 searchTypeFuzzer =
     Fuzz.oneOfValues [ Route.OptionSearch, Route.PackageSearch ]
+
+
+optionSourceFuzzer : Fuzzer Route.OptionSource
+optionSourceFuzzer =
+    Fuzz.oneOfValues Route.allOptionSources


### PR DESCRIPTION
switch option categories from checkboxes to tabs to improve cacheability and decrease visual clutter.

<img width="891" height="772" alt="image" src="https://github.com/user-attachments/assets/456c5900-db9e-4e2e-ae20-0dcf8b777495" />

Replaces the multi-checkbox `includedOptionSources : Set String` with a single `activeOptionSource : OptionSource`. The Options page now shows one source at a time per tab.
Each tab issues a single ES query with a fixed `term: { type: <one> }` filter, so the request body is byte-stable across users on identical input. With the new `?request_cache=true` opt-in (added on the new `Search.makeRequestTask` Task-based path used by Options), repeated queries become near-free shard cache hits rather than per-user noise.

Compared to the previous "single query with `terms` array" shape:

- Up to 7 distinct cache keys per popular query (one per checkbox combo) collapses to 1 per tab.
- Per-result source badges become redundant (one tab = one docType) and are dropped.

Each tab carries a hit-count badge. The active tab's count comes from the in-flight query result; inactive tabs are populated by a `size: 0` count query per tab fired alongside the main request. `size: 0` is the workload ES's `request_cache` was designed for, so once a popular query has been seen on any source the count queries cost almost nothing. Counts render as `1234`, `1.2k`, or `10k+` (ES caps `total.value` at 10000 unless we ask otherwise, so don't pretend the larger numbers are exact). Counts clear on every fresh load so stale badges don't linger; inactive errors are swallowed silently since the badge is a hint, not a result.

The new URL shape is `?source=<id>` (omitted for the default `nixos` tab).

Tackles https://github.com/NixOS/nixos-search/pull/1237#issuecomment-4351203986's concern regarding load on Elastic Search, and #1210's suggestion to return to a pre-badge uncluttered UI.

Disclaimer: I used a coding agent in the creation of this patch.
