### PR TITLE
ci(manage-es): quote URL substitution to preserve query params

### DIFF
--- a/.github/workflows/manage-elasticsearch.yml
+++ b/.github/workflows/manage-elasticsearch.yml
@@ -20,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FI_ES_URL: ${{ secrets.ELASTICSEARCH_URL2 }}
+      FI_ES_METHOD: ${{ inputs.method }}
+      FI_ES_PATH: ${{ inputs.path }}
     steps:
       - name: Manage ElasticSearch
         run: |
-            curl -sS -X ${{ inputs.method }} ${{ secrets.ELASTICSEARCH_URL2 }}/${{ inputs.path }}
+            curl -sS -X "$FI_ES_METHOD" "$FI_ES_URL/$FI_ES_PATH"


### PR DESCRIPTION
Without quotes, the runtime curl command read e.g. `curl -X GET https://.../foo?v&h=name,active`
where bash parses the first `&` as a background operator: the curl process forks on `?v` and the rest of the URL turns into separate shell commands (`h=name,active`, `request_cache=true`), silently dropping every query parameter past the first. Looked like a multi-parameter request from the dispatch UI but came out as a one-parameter GET on the wire.

Quoting both substitutions preserves `&` as part of the URL.

The effect of this may be found by comparing queries to Elastic Search [before](https://github.com/NixOS/nixos-search/actions/runs/25187013444/job/73846863836) vs [after](https://github.com/NixOS/nixos-search/actions/runs/25187040077/job/73846954970) this change - showing that only after will the [`h` header filter](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/cat.html#headers) correctly apply.

Assisted-by: Claude:claude-opus-4-7[1m]
