### PR TITLE
fix(layout): better handling for narrow screens

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1083,3 +1083,13 @@ a:focus-visible {
   font-weight: bold;
 }
 
+@media (max-width: 760px) {
+  .search-page {
+    & .search-results {
+      flex-direction: column;
+    }
+    & ul.search-sidebar {
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
Previously, on narrow screens of e.g phones, the site did not adjust beyond a `max-width` of 760px, causing overflows like in #736 and generally making it hard to navigate.

This simple media query fixes that, and also expands the sidebar to full-width in such a case.

The only downside is that the user now needs to scroll past the filters and such.

## Screenshots

### before

<img width="360" height="780" alt="image" src="https://github.com/user-attachments/assets/4dc7207c-b5a3-4dfb-9f71-817d1b475800" />

### after
<img width="360" height="949" alt="image" src="https://github.com/user-attachments/assets/b3b2180f-5782-4021-825b-98493b7d9038" />
