### PR TITLE
Allow evaluating flakes for unsupported systems

### DIFF
--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -21,6 +21,9 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
     extra: &[String],
 ) -> Result<Vec<FlakeEntry>> {
     let mut command = Command::with_args("nix", ARGS.iter());
+    command
+        .env
+        .insert("NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM".into(), "1".into());
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
     command.add_arg_pair(
         "-I",


### PR DESCRIPTION
for example to make `flake-info --json flake github:felbinger/srsran.nix` work (#1232)