### PR TITLE
Style wiki and noogle.dev nav links as external links

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -27,6 +27,7 @@ import Html.Attributes
         , href
         , id
         , src
+        , target
         )
 import Json.Decode
 import Page.Flakes exposing (Model(..))
@@ -487,8 +488,8 @@ viewNavigation route =
             , ( Route.Options searchArgs, text "Options" )
             , ( Route.Flakes searchArgs, text "3rd-party Flakes" )
             ]
-        ++ [ li [] [ a [ href "https://noogle.dev" ] [ text "Functions" ] ]
-           , li [] [ a [ href "https://wiki.nixos.org" ] [ text "NixOS Wiki" ] ]
+        ++ [ li [ class "external" ] [ a [ href "https://noogle.dev", target "_blank", Html.Attributes.rel "noopener noreferrer" ] [ text "Functions" ] ]
+           , li [ class "external" ] [ a [ href "https://wiki.nixos.org", target "_blank", Html.Attributes.rel "noopener noreferrer" ] [ text "NixOS Wiki" ] ]
            ]
 
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -312,6 +312,17 @@
         }
 
       }
+
+      li.external > a {
+        color: var(--light-blue);
+        background: transparent;
+        border-radius: 0;
+
+        &:hover {
+          background: transparent;
+          text-decoration: underline;
+        }
+      }
     }
   }
 
@@ -446,6 +457,26 @@ header .navbar.navbar-static-top {
     line-height: 20px;
     sup {
       margin-left: 0.5em;
+    }
+  }
+}
+
+header .navbar.navbar-static-top ul.nav > li.external {
+
+  > a {
+    color: var(--link-color);
+    text-decoration: none;
+    background: none !important;
+    border-radius: 0;
+
+    &:hover {
+      text-decoration: underline;
+      background: none !important;
+    }
+
+    &::after {
+      content: " \2197";
+      font-size: 0.75em;
     }
   }
 }


### PR DESCRIPTION
Links to noogle.dev and the wiki look like tabs, but they navigate to completely different pages.
This is not expected and shout be communicated through different styling