### PR TITLE
feat(frontend): add manual dark/light/auto theme toggle

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -1,4 +1,4 @@
-module Main exposing (Flags, Model, Msg, Page, main)
+port module Main exposing (Flags, Model, Msg, Page, main)
 
 import Browser
 import Browser.Dom
@@ -8,6 +8,7 @@ import Html
     exposing
         ( Html
         , a
+        , button
         , div
         , footer
         , header
@@ -22,12 +23,15 @@ import Html
 import Html.Attributes
     exposing
         ( alt
+        , attribute
         , class
         , classList
         , href
         , id
         , src
+        , title
         )
+import Html.Events exposing (onClick)
 import Json.Decode
 import Page.Flakes exposing (Model(..))
 import Page.Options
@@ -55,7 +59,53 @@ type alias Flags =
     , elasticsearchUsername : String
     , elasticsearchPassword : String
     , nixosChannels : Json.Decode.Value
+    , theme : String
     }
+
+
+type Theme
+    = Auto
+    | Light
+    | Dark
+
+
+themeFromString : String -> Theme
+themeFromString s =
+    case s of
+        "light" ->
+            Light
+
+        "dark" ->
+            Dark
+
+        _ ->
+            Auto
+
+
+themeToString : Theme -> String
+themeToString t =
+    case t of
+        Auto ->
+            "auto"
+
+        Light ->
+            "light"
+
+        Dark ->
+            "dark"
+
+
+themeLabel : Theme -> String
+themeLabel t =
+    case t of
+        Auto ->
+            "Auto"
+
+        Light ->
+            "Light"
+
+        Dark ->
+            "Dark"
 
 
 type alias Model =
@@ -65,7 +115,11 @@ type alias Model =
     , defaultNixOSChannel : String
     , nixosChannels : List NixOSChannel
     , page : Page
+    , theme : Theme
     }
+
+
+port setTheme : String -> Cmd msg
 
 
 type Page
@@ -107,6 +161,7 @@ init flags url navKey =
             , nixosChannels = nixosChannels.channels
             , page = NotFound
             , route = Route.Home
+            , theme = themeFromString flags.theme
             }
     in
     changeRouteTo model url
@@ -124,6 +179,7 @@ type Msg
     | FlakesMsg Page.Flakes.Msg
     | CtrlKRegistered
     | SearchFocusResult
+    | SetTheme Theme
 
 
 updateWith :
@@ -358,6 +414,11 @@ update msg model =
         ( CtrlKRegistered, _ ) ->
             ( model, Browser.Dom.focus "search-query-input" |> Task.attempt (\_ -> SearchFocusResult) )
 
+        ( SetTheme theme, _ ) ->
+            ( { model | theme = theme }
+            , setTheme (themeToString theme)
+            )
+
         _ ->
             -- Disregard messages that arrived for the wrong page.
             ( model, Cmd.none )
@@ -430,6 +491,7 @@ view model =
                                 , div []
                                     [ ul [ class "nav pull-left" ]
                                         (viewNavigation model.route)
+                                    , viewThemeSelector model.theme
                                     ]
                                 ]
                             ]
@@ -500,6 +562,48 @@ viewNavigationItem currentRoute ( route, title ) =
     li
         [ classList [ ( "active", currentRoute == route ) ] ]
         [ a [ Route.href route ] [ title ] ]
+
+
+themeIcon : Theme -> String
+themeIcon t =
+    case t of
+        Auto ->
+            "◐"
+
+        Light ->
+            "☀"
+
+        Dark ->
+            "☾"
+
+
+viewThemeSelector : Theme -> Html Msg
+viewThemeSelector currentTheme =
+    div
+        [ class "btn-group pull-right theme-toggle"
+        , attribute "role" "group"
+        , attribute "aria-label" "Theme"
+        ]
+        (List.map
+            (\t ->
+                button
+                    [ class "btn"
+                    , classList [ ( "active", t == currentTheme ) ]
+                    , title (themeLabel t)
+                    , attribute "aria-label" (themeLabel t)
+                    , attribute "aria-pressed"
+                        (if t == currentTheme then
+                            "true"
+
+                         else
+                            "false"
+                        )
+                    , onClick (SetTheme t)
+                    ]
+                    [ span [ class "theme-icon" ] [ text (themeIcon t) ] ]
+            )
+            [ Auto, Light, Dark ]
+        )
 
 
 viewPage : Model -> Html Msg

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,6 +5,21 @@ require("elm-keyboard-shortcut");
 
 const { Elm } = require("./Main");
 
+function normalizeTheme(value) {
+    return value === "light" || value === "dark" ? value : "auto";
+}
+
+function applyTheme(theme) {
+    if (theme === "auto") {
+        delete document.documentElement.dataset.theme;
+    } else {
+        document.documentElement.dataset.theme = theme;
+    }
+}
+
+const initialTheme = normalizeTheme(localStorage.getItem("theme"));
+applyTheme(initialTheme);
+
 const app = Elm.Main.init({
     flags: {
         elasticsearchMappingSchemaVersion: parseInt(
@@ -16,8 +31,19 @@ const app = Elm.Main.init({
         elasticsearchPassword:
             process.env.ELASTICSEARCH_PASSWORD || "X8gPHnzL52wFEekuxsfQ9cSh",
         nixosChannels: JSON.parse(process.env.NIXOS_CHANNELS),
+        theme: initialTheme,
     },
 });
+
+if (app.ports && app.ports.setTheme) {
+    app.ports.setTheme.subscribe((value) => {
+        const theme = normalizeTheme(value);
+        try {
+            localStorage.setItem("theme", theme);
+        } catch (_) {}
+        applyTheme(theme);
+    });
+}
 
 if (app.ports && app.ports.copyToClipboard) {
     app.ports.copyToClipboard.subscribe((text) => {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -33,10 +33,17 @@
 /* -- Darkmode specific styles --------------------------------------------- */
 /* ------------------------------------------------------------------------- */
 
-@media (prefers-color-scheme: dark) {
+@mixin outline-visible() {
+  border-radius: 4px !important;
+  outline-color: var(--light-blue) !important;
+  outline-style: solid !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
 
+@mixin dark-theme {
   // Define darkmode colors
-  :root {
+  & {
     --text-color: rgba(255, 255, 255, 0.85);
     --text-color-light: rgba(255, 255, 255, 0.5);
     --text-color-warning: #f8e45c;
@@ -99,14 +106,6 @@
 
   * {
     transition: background 0.2s;
-  }
-
-  @mixin outline-visible() {
-    border-radius: 4px !important;
-    outline-color: var(--light-blue) !important;
-    outline-style: solid !important;
-    outline-width: 2px !important;
-    outline-offset: -2px !important;
   }
 
   *:focus {
@@ -358,6 +357,16 @@
   }
 }
 
+:root[data-theme="dark"] {
+  @include dark-theme;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    @include dark-theme;
+  }
+}
+
 /* ------------------------------------------------------------------------- */
 /* -- Utils ---------------------------------------------------------------- */
 /* ------------------------------------------------------------------------- */
@@ -430,6 +439,11 @@ footer {
   bottom: 0;
   width: 100%;
   height: 4rem;
+}
+
+.theme-toggle .theme-icon {
+  font-size: 1.4em;
+  line-height: 1;
 }
 
 header .navbar.navbar-static-top {


### PR DESCRIPTION
Some privacy-minded browsers suppress or always report `light` for `prefers-color-scheme` (fingerprinting mitigation), leaving those users stuck with the light theme. This adds a 3-way **Auto / Light / Dark** toggle in the navbar that overrides the OS preference, with the choice persisted across visits.

Closes #1245.

### How it works

- A small JS snippet in `index.js` reads `localStorage.theme` synchronously before Elm boots and sets `data-theme` on `<html>`, so the first paint already reflects the saved choice (no flash).
- The SCSS dark-mode rules are extracted into `@mixin dark-theme`, invoked under `:root[data-theme="dark"]` (explicit override) and under `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])` (auto path). Selecting Auto removes the attribute and lets the media query take over, so live OS-preference changes still work.
- Elm owns the toggle UI (three always-visible icon buttons (◐ ☀ ☾) in a `btn-group` in the navbar), and writes back via `port setTheme`.

### Accessibility

- Each button carries `title`, `aria-label`, and `aria-pressed` (toggle button pattern for mutually exclusive selection).
- The wrapper has `role="group"` and `aria-label="Theme"`.

### No new dependencies

Only stdlib Elm + existing Bootstrap CSS classes. No icon library.

## Test plan

- [x] All three buttons visible in navbar simultaneously; active one is highlighted.
- [x] Clicking a button immediately repaints and updates the highlight.
- [x] Auto follows OS preference; Light/Dark override it regardless.
- [x] Reload preserves the choice; first paint matches (no flash).
- [x] Hovering shows tooltip ("Auto" / "Light" / "Dark").
- [x] `elm make src/Main.elm --output=/dev/null` produces no warnings.

Disclaimer: I used a coding agent in the creation of this patch.
