### PR TITLE
collapse Usage attrsets to take no more lines than needed

### DIFF
--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -480,31 +480,8 @@ viewUsageSnippet source =
                     )
                 |> Maybe.withDefault "..."
 
-        -- Expand "php-fpm.settings" into nested:
-        --   php-fpm = {
-        --     settings = <default>;
-        --   };
-        nestOption parts indent =
-            case parts of
-                [] ->
-                    ""
-
-                [ leaf ] ->
-                    indent ++ leaf ++ " = " ++ leafValue indent ++ ";\n"
-
-                head_ :: rest ->
-                    indent
-                        ++ head_
-                        ++ " = {\n"
-                        ++ nestOption rest (indent ++ "  ")
-                        ++ indent
-                        ++ "};\n"
-
-        optionParts =
-            String.split "." source.name
-
         nestedOption indent =
-            nestOption optionParts indent
+            indent ++ source.name ++ " = " ++ leafValue indent ++ ";\n"
     in
     case source.docType of
         "service" ->


### PR DESCRIPTION
For example, usage for `services.nginx.appendHttpConfig`:

before:

```nix
# configuration.nix
{
  _class = "nixos";
  services = {
    nginx = {
      appendHttpConfig = "";
    };
  };
}
```

after:

```nix
# configuration.nix
{
  _class = "nixos";
  services.nginx.appendHttpConfig = "";
}
```
