### PR TITLE
don't add `channel` query param in flakes section that didn't exist already

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -283,7 +283,7 @@ changeRouteTo currentModel url =
                         _ ->
                             Nothing
             in
-            Page.Packages.init searchArgs currentModel.defaultNixOSChannel currentModel.nixosChannels modelPage
+            Page.Packages.init searchArgs currentModel.defaultNixOSChannel currentModel.nixosChannels True modelPage
                 |> updateWith Packages PackagesMsg model
                 |> avoidReinit
                 |> attemptQuery
@@ -298,7 +298,7 @@ changeRouteTo currentModel url =
                         _ ->
                             Nothing
             in
-            Page.Options.init searchArgs currentModel.defaultNixOSChannel currentModel.nixosChannels modelPage
+            Page.Options.init searchArgs currentModel.defaultNixOSChannel currentModel.nixosChannels True modelPage
                 |> updateWith Options OptionsMsg model
                 |> avoidReinit
                 |> attemptQuery

--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -66,7 +66,7 @@ init searchArgs defaultNixOSChannel nixosChannels model =
     case searchType of
         OptionSearch ->
             Tuple.mapBoth OptionModel (Cmd.map OptionsMsg) <|
-                Page.Options.init searchArgs defaultNixOSChannel nixosChannels <|
+                Page.Options.init searchArgs defaultNixOSChannel nixosChannels False <|
                     case model of
                         Just (OptionModel model_) ->
                             Just model_
@@ -76,7 +76,7 @@ init searchArgs defaultNixOSChannel nixosChannels model =
 
         PackageSearch ->
             Tuple.mapBoth PackagesModel (Cmd.map PackagesMsg) <|
-                Page.Packages.init searchArgs defaultNixOSChannel nixosChannels <|
+                Page.Packages.init searchArgs defaultNixOSChannel nixosChannels False <|
                     case model of
                         Just (PackagesModel model_) ->
                             Just model_

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -114,14 +114,22 @@ init :
     Route.SearchArgs
     -> String
     -> List NixOSChannel
+    -> Bool
     -> Maybe Model
     -> ( Model, Cmd Msg )
-init searchArgs defaultNixOSChannel nixosChannels model =
+init searchArgs defaultNixOSChannel nixosChannels includeChannelInUrl model =
     let
         ( newModel, newCmd ) =
             Search.init searchArgs defaultNixOSChannel nixosChannels model
+
+        finalModel =
+            if includeChannelInUrl then
+                { newModel | urlChannel = Just newModel.channel }
+
+            else
+                newModel
     in
-    ( newModel
+    ( finalModel
     , Cmd.map SearchMsg newCmd
     )
 

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -201,14 +201,22 @@ init :
     Route.SearchArgs
     -> String
     -> List NixOSChannel
+    -> Bool
     -> Maybe Model
     -> ( Model, Cmd Msg )
-init searchArgs defaultNixOSChannel nixosChannels model =
+init searchArgs defaultNixOSChannel nixosChannels includeChannelInUrl model =
     let
         ( newModel, newCmd ) =
             Search.init searchArgs defaultNixOSChannel nixosChannels model
+
+        finalModel =
+            if includeChannelInUrl then
+                { newModel | urlChannel = Just newModel.channel }
+
+            else
+                newModel
     in
-    ( newModel
+    ( finalModel
     , Cmd.map SearchMsg newCmd
     )
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -108,6 +108,7 @@ type alias Model a b =
     , showInstallDetails : Details
     , searchType : Route.SearchType
     , redirectedChannel : Maybe String
+    , urlChannel : Maybe String
     , activeOptionSource : Route.OptionSource
 
     -- Hit counts per option source, keyed by `Route.optionSourceId`.
@@ -361,6 +362,7 @@ init args defaultNixOSChannel nixosChannels maybeModel =
       , activeOptionSource = args.activeOptionSource
       , sourceCounts = Dict.empty
       , previousResult = Nothing
+      , urlChannel = args.channel
       }
         |> ensureLoading nixosChannels
     , Browser.Dom.focus "search-query-input" |> Task.attempt (\_ -> NoOp)
@@ -520,6 +522,7 @@ update toRoute navKey msg model nixosChannels =
             else
                 { model
                     | channel = channel
+                    , urlChannel = Just channel
                     , redirectedChannel = Nothing
                     , show = Nothing
                     , from = 0
@@ -655,7 +658,7 @@ createUrl toRoute model =
     in
     Route.routeToString <|
         toRoute
-            { channel = Just model.channel
+            { channel = model.urlChannel
             , query = justIfNotDefault model.query defaultSearchArgs.query
             , show = model.show
             , from = justIfNotDefault model.from defaultSearchArgs.from


### PR DESCRIPTION
Prevents having searches in the flakes section for no reason add `channel` query params.

In other words, the URL when issuing a search from the flakes section, will be like:

- before: https://search.nixos.org/flakes?channel=25.11&query=nix
- after: http://localhost:3000/flakes?query=nix

Closes #1263.
