### PR TITLE
strip out backward compatibility with `show` as query parameter, fixing a bug when switching option category

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -285,7 +285,7 @@ pageMatch m1 m2 =
                 == { model_b | show = Nothing, showInstallDetails = Search.Unset, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
 
         ( Options model_a, Options model_b ) ->
-            { model_a | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
+            { model_a | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing, activeOptionSource = model_b.activeOptionSource }
                 == { model_b | show = Nothing, result = NotAsked, sourceCounts = Dict.empty, previousResult = Nothing }
 
         ( Flakes (OptionModel model_a), Flakes (OptionModel model_b) ) ->

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -245,7 +245,7 @@ viewSourceTab activeSource count source =
             -- anchor.
             [ classList [ ( "selected", isActive ) ]
             , href "#"
-            , Html.Events.onClick (SearchMsg (Search.SetActiveOptionSource source))
+            , Html.Events.preventDefaultOn "click" (Json.Decode.succeed ( SearchMsg (Search.SetActiveOptionSource source), True ))
             ]
             (span [] [ text (Route.optionSourceLabel source) ] :: badge)
         ]
@@ -435,7 +435,7 @@ viewResultItem nixosChannels channel show activeSource item =
                 ul [ class "search-result-button" ]
                     [ li []
                         [ a
-                            [ onClick toggle
+                            [ Html.Events.preventDefaultOn "click" (Json.Decode.succeed ( toggle, True ))
                             , href ""
                             ]
                             [ text displayName ]

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -334,13 +334,8 @@ init args defaultNixOSChannel nixosChannels maybeModel =
       , redirectedChannel = redirected
       , flake = defaultFlakeId
       , query =
-            case args.query of
-                Just q ->
-                    q
-
-                Nothing ->
-                    args.show
-                        |> Maybe.withDefault defaultSearchArgs.query
+            args.query
+                |> Maybe.withDefault defaultSearchArgs.query
       , result = getField .result RemoteData.NotAsked
       , show = args.show
       , from =


### PR DESCRIPTION
drops backward compatibility with the `show` query param.

this fixes an issue reported by @kranzes that makes the `show` fragment param into a query when switching option categories when using the ClearURLs extension on firefox v150:

<img width="869" height="354" alt="image" src="https://github.com/user-attachments/assets/278983c4-a38b-41ac-9c07-bf01d0d65757" />

not having managed to reproduce this without extension tho, that makes me feel somewhat hesitant on a path forward:

- reverting to the query param would make it harder to get cache hits
- breaking compatibility with the query param could break deep-linking predating the switch
- the issue reported here so far we've managed to manually reproduce only with ClearURLs so far

like all options there seem kinda imperfect, out of what i've come up with so far.


