### PR TITLE
fix: devshell for darwin machines

### DIFF
--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -20,7 +20,7 @@ pkgs.rustPlatform.buildRustPackage rec {
     ]
     ++ lib.optional pkgs.stdenv.isDarwin [
       libiconv
-      darwin.apple_sdk.frameworks.Security
+      apple-sdk
     ];
 
   checkInputs = with pkgs; [ pandoc ];


### PR DESCRIPTION
Fixes the issue with running devshell with apple-sdk on darwin machines.
