### PR TITLE
mark Home Manager as part of `nix-community`

### DIFF
--- a/frontend/src/Route.elm
+++ b/frontend/src/Route.elm
@@ -116,7 +116,7 @@ optionSourceLabel source =
             "Modular services"
 
         HomeManagerOptionSource ->
-            "Home Manager"
+            "nix-community/home-manager"
 
 
 type SearchType


### PR DESCRIPTION
we could revert this when the project is officially marked as part of the NixOS org (see #1281), but until then this may set more realistic expectations