### PR TITLE
mark modular services as experimental

### DIFF
--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -229,6 +229,16 @@ viewSourceTab activeSource count source =
         id =
             Route.optionSourceId source
 
+        labelChildren =
+            text (Route.optionSourceLabel source)
+                :: (case source of
+                        Route.ModularServiceOptions ->
+                            [ span [ class "label label-info experimental-badge" ] [ text "Experimental" ] ]
+
+                        _ ->
+                            []
+                   )
+
         badge =
             case count of
                 Just n ->
@@ -247,7 +257,7 @@ viewSourceTab activeSource count source =
             , href "#"
             , Html.Events.onClick (SearchMsg (Search.SetActiveOptionSource source))
             ]
-            (span [] [ text (Route.optionSourceLabel source) ] :: badge)
+            (span [ class "source-label" ] labelChildren :: badge)
         ]
 
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1082,6 +1082,19 @@ a:focus-visible {
   &.selected > span:last-child {
     display: inline-block;
   }
+
+  // Nested inside the source label so it travels with the label text
+  // rather than affecting the flex layout of the tab row.
+  .experimental-badge {
+    margin-left: 0.3em;
+  }
+
+  // The selected-tab background is already saturated blue; flip the
+  // experimental badge to read against it instead of blending in.
+  &.selected .experimental-badge {
+    background: var(--search-sidebar-selected-link-color);
+    color: var(--search-sidebar-selected-link-background);
+  }
 }
 
 // The Name code block in the expanded option view hosts a floating copy


### PR DESCRIPTION
Mark modular services in the options tab as experimental, as suggested in #1281.

Disclaimer: I used a coding agent in the creation of this patch.
