### PR TITLE
chore: update nixos-infra flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
     "nixos-infra": {
       "flake": false,
       "locked": {
-        "lastModified": 1779188651,
-        "narHash": "sha256-+zWaPaV7yxS3miI1vQNnHYcNVdmy34BjpRwIhawUJRg=",
+        "lastModified": 1779801085,
+        "narHash": "sha256-CMqx4aIIVVVw4CbbLIQEW3JrVOUjgnlmGE49+E6ZFMc=",
         "owner": "NixOS",
         "repo": "infra",
-        "rev": "4f1686fed14a3bbb63b0ffbd3254bf0d43b9f02f",
+        "rev": "31d036844ad260135b94f5564389c3717deccd1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This flake update adds 26.05 as beta to packages and options.
Ref: https://github.com/NixOS/nixpkgs/issues/503391

A follow up will have to be done upon release, which I am happy to do.