### PR TITLE
chore: update flake lock to make 26.05 stable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
     "nixos-infra": {
       "flake": false,
       "locked": {
-        "lastModified": 1780012293,
-        "narHash": "sha256-H1p/3HiLR0R06OK00ce7e7WpYHdbXu2Ck0o/Q0dri4k=",
+        "lastModified": 1780147631,
+        "narHash": "sha256-gcb2dfdk2tAx7rKB1StTpYOozWfZ1iBf4qn4upACUqU=",
         "owner": "NixOS",
         "repo": "infra",
-        "rev": "b753296d3503c5a6cae3ecab04d88105c596bd2b",
+        "rev": "1c683a33ad3d6cffcfa80f474e009a65954d47d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates infra lock to latest for release: https://nixos.org/blog/announcements/2026/nixos-2605

Cc @yayayayaka and @jopejoe1 for review.