### PR TITLE
flakes: remove TamtamHero/fw-fanctrl

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -40,10 +40,6 @@ url = "git+https://github.com/raboof/octopin?ref=nix"
 
 [[sources]]
 type = "git"
-url = "git+https://github.com/TamtamHero/fw-fanctrl?ref=packaging/nix"
-
-[[sources]]
-type = "git"
 url = "git+https://github.com/xddxdd/nix-cachyos-kernel?ref=release"
 
 [[sources]]


### PR DESCRIPTION
Seems this branch was deleted, likely because
fw-fanctrl is now packaged in nixpkgs
https://github.com/TamtamHero/fw-fanctrl/issues/123