### PR TITLE
chore: bump package and option count

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -271,7 +271,7 @@ view :
 view nixosChannels model =
     Search.view { categoryName = "packages" }
         [ text "Search more than "
-        , strong [] [ text "120 000 packages" ]
+        , strong [] [ text "140 000 packages" ]
         ]
         nixosChannels
         model


### PR DESCRIPTION
We are providing `144159` packages (`144078` on Yarara)!

```
#!/usr/bin/env nix-shell
#!nix-shell -i bash -p curl jq brotli

function parse_unstable_json() {
    local url="https://channels.nixos.org/nixos-unstable/$1.json.br"
    echo $(curl -L "$url" | brotli -d --stdout | jq "$2")
}

pkg_count=$(parse_unstable_json "packages" ".packages | length")
opt_count=$(parse_unstable_json "options" "length")

echo "{ 'packages': $pkg_count, 'options': $opt_count }" | tr "'" '"'
```

See:
- Hard-coded package and option count on search.nixos.org #701