### PR TITLE
feat(frontend): add copy buttons to package install commands

### DIFF
--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -26,6 +26,7 @@ import Html.Events exposing (onClick)
 import Http exposing (Body)
 import Page.Options exposing (Msg(..))
 import Page.Packages exposing (Msg(..))
+import Ports
 import RemoteData
 import Route
     exposing
@@ -117,7 +118,7 @@ update navKey msg model nixosChannels =
                     ( newModel, Cmd.map Page.Options.SearchMsg newCmd ) |> Tuple.mapBoth OptionModel (Cmd.map OptionsMsg)
 
                 Page.Options.CopyOptionName name ->
-                    ( OptionModel model_, Page.Options.copyToClipboard name )
+                    ( OptionModel model_, Ports.copyToClipboard name )
 
         ( PackagesMsg msg_, PackagesModel model_ ) ->
             case msg_ of
@@ -132,6 +133,9 @@ update navKey msg model nixosChannels =
                                 nixosChannels
                     in
                     ( newModel, Cmd.map Page.Packages.SearchMsg newCmd ) |> Tuple.mapBoth PackagesModel (Cmd.map PackagesMsg)
+
+                Page.Packages.CopyToClipboard text_ ->
+                    ( PackagesModel model_, Ports.copyToClipboard text_ )
 
         _ ->
             ( model, Cmd.none )

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -1,10 +1,9 @@
-port module Page.Options exposing
+module Page.Options exposing
     ( AggregationsAll
     , Model
     , Msg(..)
     , ResultAggregations
     , ResultItemSource
-    , copyToClipboard
     , decodeResultAggregations
     , decodeResultItemSource
     , init
@@ -53,6 +52,7 @@ import Http exposing (Body)
 import Json.Decode
 import Json.Decode.Pipeline
 import List.Extra
+import Ports
 import RemoteData
 import Route exposing (OptionSource, SearchType)
 import Search
@@ -135,15 +135,6 @@ init searchArgs defaultNixOSChannel nixosChannels includeChannelInUrl model =
 
 
 
--- PORTS
-
-
-{-| Ask the JS side to copy the given text to the clipboard.
--}
-port copyToClipboard : String -> Cmd msg
-
-
-
 -- UPDATE
 
 
@@ -173,7 +164,7 @@ update navKey msg model nixosChannels =
             ( newModel, Cmd.map SearchMsg newCmd )
 
         CopyOptionName name ->
-            ( model, copyToClipboard name )
+            ( model, Ports.copyToClipboard name )
 
 
 

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -25,6 +25,7 @@ import Html
     exposing
         ( Html
         , a
+        , button
         , code
         , div
         , em
@@ -44,6 +45,8 @@ import Html.Attributes
         , href
         , id
         , target
+        , title
+        , type_
         )
 import Html.Events exposing (onClick)
 import Http exposing (Body)
@@ -51,6 +54,7 @@ import Json.Decode
 import Json.Decode.Pipeline
 import Json.Encode
 import List.Extra
+import Ports
 import Regex
 import Route exposing (SearchType)
 import Search
@@ -237,6 +241,7 @@ platforms =
 
 type Msg
     = SearchMsg (Search.Msg ResultItemSource ResultAggregations)
+    | CopyToClipboard String
 
 
 update :
@@ -258,6 +263,9 @@ update navKey msg model nixosChannels =
                         nixosChannels
             in
             ( newModel, Cmd.map SearchMsg newCmd )
+
+        CopyToClipboard text_ ->
+            ( model, Ports.copyToClipboard text_ )
 
 
 
@@ -348,6 +356,25 @@ viewSuccess nixosChannels channel showInstallDetails show hits =
             (viewResultItem nixosChannels channel showInstallDetails show)
             hits
         )
+
+
+{-| Render an install command or configuration snippet together with a
+button that copies its plain-text form to the clipboard. The package name
+inside the snippet is rendered in bold, so the exact text to copy is passed
+separately from the displayed content.
+-}
+copyableCommand : String -> String -> List (Html Msg) -> Html Msg
+copyableCommand preClass commandText content =
+    div [ class "code-block-wrapper" ]
+        [ pre [ class preClass ] content
+        , button
+            [ type_ "button"
+            , class "code-copy-button"
+            , title "Copy to clipboard"
+            , onClick (CopyToClipboard commandText)
+            ]
+            [ text "Copy" ]
+        ]
 
 
 viewResultItem :
@@ -667,7 +694,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                             , ( "active", True )
                                             ]
                                         ]
-                                        [ pre [ class "code-block shell-command" ]
+                                        [ copyableCommand "code-block shell-command"
+                                            ("nix profile add " ++ flakeUrl ++ "#" ++ item.source.attr_name)
                                             [ text "nix profile add "
                                             , strong [] [ text flakeUrl ]
                                             , text "#"
@@ -783,7 +811,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         , class "tab-pane"
                                         , id "package-details-nixpkgs"
                                         ]
-                                        [ pre [ class "code-block shell-command" ]
+                                        [ copyableCommand "code-block shell-command"
+                                            ("nix-env -iA nixos." ++ item.source.attr_name)
                                             [ text "nix-env -iA nixos."
                                             , strong [] [ text item.source.attr_name ]
                                             ]
@@ -805,7 +834,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         , class "tab-pane"
                                         , id "package-details-nixpkgs"
                                         ]
-                                        [ pre [ class "code-block shell-command" ]
+                                        [ copyableCommand "code-block shell-command"
+                                            ("# without flakes:\nnix-env -iA nixpkgs." ++ item.source.attr_name ++ "\n# with flakes:\nnix profile add nixpkgs#" ++ item.source.attr_name)
                                             [ text "# without flakes:\nnix-env -iA nixpkgs."
                                             , strong [] [ text item.source.attr_name ]
                                             , text "\n# with flakes:\nnix profile add nixpkgs#"
@@ -830,7 +860,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         , class "tab-pane"
                                         , id "package-details-nixpkgs"
                                         ]
-                                        [ pre [ class "code-block" ]
+                                        [ copyableCommand "code-block"
+                                            ("  environment.systemPackages = [\n    pkgs." ++ item.source.attr_name ++ "\n  ];")
                                             [ text <| "  environment.systemPackages = [\n    pkgs."
                                             , strong [] [ text item.source.attr_name ]
                                             , text <| "\n  ];"
@@ -858,7 +889,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                             , ( "active", List.member showInstallDetails [ Search.Unset, Search.ViaNixShell, Search.FromFlake ] )
                                             ]
                                         ]
-                                        [ pre [ class "code-block shell-command" ]
+                                        [ copyableCommand "code-block shell-command"
+                                            ("nix-shell -p " ++ item.source.attr_name)
                                             [ text "nix-shell -p "
                                             , strong [] [ text item.source.attr_name ]
                                             ]
@@ -870,7 +902,8 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         , class "tab-pane"
                                         , id "package-details-nixpkgs"
                                         ]
-                                        [ pre [ class "code-block shell-command" ]
+                                        [ copyableCommand "code-block shell-command"
+                                            ("nix profile add nixpkgs#" ++ item.source.attr_name)
                                             [ text "nix profile add nixpkgs#"
                                             , strong [] [ text item.source.attr_name ]
                                             ]

--- a/frontend/src/Ports.elm
+++ b/frontend/src/Ports.elm
@@ -1,0 +1,7 @@
+port module Ports exposing (copyToClipboard)
+
+{-| Ask the JS side to copy the given text to the clipboard.
+-}
+
+
+port copyToClipboard : String -> Cmd msg

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1135,6 +1135,40 @@ a:focus-visible {
   }
 }
 
+// Each install command / configuration snippet in the package details hosts
+// a copy button pinned to its top-right corner. The wrapper is the
+// positioning context so the button overlays the code without shifting it.
+// Pinned to the top (rather than centred) since some snippets span multiple
+// lines.
+.code-block-wrapper {
+  position: relative;
+
+  // Keep the command text clear of the floating button.
+  & > pre.code-block {
+    padding-right: 4em;
+  }
+}
+
+.code-copy-button {
+  position: absolute;
+  top: 0.4em;
+  right: 0.4em;
+  padding: 0.3em 0.7em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  line-height: 1.3;
+  cursor: pointer;
+  user-select: none;
+  color: var(--search-result-short-details-color, #666);
+  border: 1px solid var(--search-sidebar-container-border-color, #ccc);
+  background: var(--background-color, #fff);
+
+  &:hover {
+    color: var(--text-color);
+    background: var(--hover-background, rgba(0, 0, 0, 0.05));
+  }
+}
+
 // Make the "Please provide more precise search terms." hint stand out so
 // users notice when their query has been truncated to 10000 results.
 .search-refine-hint {


### PR DESCRIPTION
The options page already has a copy button for option names, but the package install commands didn't, even though they're probably the most copied thing on the site. This adds the same button to each snippet under "How to install".

It covers all the install tabs: the flake `nix profile add`, `nix-env` on and off NixOS, the `environment.systemPackages` config block, `nix-shell -p`, and `nix profile`. The button copies the plain command, without the `$` prompt or the bold styling on the package name.

Both pages need the clipboard port now, so I moved it out of `Page.Options` into a small shared `Ports` module that Options, Packages and Flakes all use.

Addresses the package-commands part of #1295. The options snippets already have buttons; maintainer/team handles could be a follow-up.
