### PR TITLE
feat(frontend): suggest the other search when one comes up empty

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -989,7 +989,7 @@ viewResult nixosChannels outMsg categoryName model viewSuccess viewBuckets searc
             if result.hits.total.value == 0 && List.isEmpty buckets then
                 div [ class "search-results" ]
                     [ ul [ class "search-sidebar" ] searchBuckets
-                    , viewNoResults categoryName model.query
+                    , viewNoResults categoryName model.query model.channel
                     ]
 
             else if not (List.isEmpty buckets) then
@@ -1036,11 +1036,13 @@ viewResult nixosChannels outMsg categoryName model viewSuccess viewBuckets searc
 viewNoResults :
     String
     -> String
+    -> String
     -> Html c
-viewNoResults categoryName query =
+viewNoResults categoryName query channel =
     div [ class "search-no-results" ]
         ([ h2 [] [ text <| "No " ++ categoryName ++ " found!" ]
          ]
+            ++ crossSearchHint categoryName query channel
             ++ (if categoryName == "modular services" then
                     [ text "Not all packages provide modular services. You might want to "
                     , Html.a [ href ("https://github.com/NixOS/nixpkgs/issues?q=" ++ query) ] [ text "search nixpkgs issues" ]
@@ -1056,6 +1058,46 @@ viewNoResults categoryName query =
                     ]
                )
         )
+
+
+{-| Packages and options live on separate tabs, and it's easy to land on
+the wrong one (issue #1062). When a search comes up empty on one, point the
+user at the other with the same query and channel carried over.
+-}
+crossSearchHint : String -> String -> String -> List (Html c)
+crossSearchHint categoryName query channel =
+    let
+        args : Route.SearchArgs
+        args =
+            { query = Just query
+            , channel = Just channel
+            , show = Nothing
+            , from = Nothing
+            , size = Nothing
+            , buckets = Nothing
+            , sort = Nothing
+            , type_ = Nothing
+            , activeOptionSource = Route.defaultOptionSource
+            }
+
+        hint : String -> String -> Route.Route -> List (Html c)
+        hint lead linkText route =
+            [ p [ class "search-cross-hint" ]
+                [ text lead
+                , Html.a [ Route.href route ] [ text linkText ]
+                , text " instead."
+                ]
+            ]
+    in
+    case categoryName of
+        "packages" ->
+            hint "Looking for a NixOS option? " ("Search options for " ++ query) (Route.Options args)
+
+        "options" ->
+            hint "Looking for a package? " ("Search packages for " ++ query) (Route.Packages args)
+
+        _ ->
+            []
 
 
 closeButton : Html a

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -577,6 +577,13 @@ header .navbar.navbar-static-top ul.nav > li.external {
      & > h2 {
        margin-top: 0;
      }
+
+     // Nudge toward the other search (packages vs options) when a query
+     // comes up empty -- the two tabs are easy to confuse.
+     & > .search-cross-hint {
+       margin: 0.5em 0;
+       font-size: 1.1em;
+     }
   }
 
 


### PR DESCRIPTION
Packages and options live on separate tabs, and it's easy to land on the wrong one. Searching for a package name on the Options tab (or the other way round) just shows "No options found!" with no hint that you're on the wrong page.

When a search comes up empty on packages or options, this adds a line pointing at the other tab, carrying the same query and channel over. On the options page it reads:

> Looking for a package? **Search packages for oversteer** instead.

Clicking it lands on the packages tab with the query already filled in. Only the two main tabs are touched; the flakes tab and the modular-services view keep their current empty state.

Closes #1062.
