### PR TITLE
feat(frontend): copy confirmation toast and copy buttons for option values

### DIFF
--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -117,8 +117,8 @@ update navKey msg model nixosChannels =
                     in
                     ( newModel, Cmd.map Page.Options.SearchMsg newCmd ) |> Tuple.mapBoth OptionModel (Cmd.map OptionsMsg)
 
-                Page.Options.CopyOptionName name ->
-                    ( OptionModel model_, Ports.copyToClipboard name )
+                Page.Options.CopyToClipboard text_ ->
+                    ( OptionModel model_, Ports.copyToClipboard text_ )
 
         ( PackagesMsg msg_, PackagesModel model_ ) ->
             case msg_ of

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -140,7 +140,7 @@ init searchArgs defaultNixOSChannel nixosChannels includeChannelInUrl model =
 
 type Msg
     = SearchMsg (Search.Msg ResultItemSource ResultAggregations)
-    | CopyOptionName String
+    | CopyToClipboard String
 
 
 update :
@@ -163,8 +163,8 @@ update navKey msg model nixosChannels =
             in
             ( newModel, Cmd.map SearchMsg newCmd )
 
-        CopyOptionName name ->
-            ( model, Ports.copyToClipboard name )
+        CopyToClipboard text_ ->
+            ( model, Ports.copyToClipboard text_ )
 
 
 
@@ -357,7 +357,7 @@ viewResultItem nixosChannels channel show activeSource item =
                                     |> Maybe.map
                                         (\default ->
                                             [ div [] [ text "Default" ]
-                                            , div [] <| Maybe.withDefault [ asPreCode default ] (Utils.showHtml default)
+                                            , div [] <| Maybe.withDefault [ copyable default (asPreCode default) ] (Utils.showHtml default)
                                             ]
                                         )
                                     |> Maybe.withDefault []
@@ -366,7 +366,7 @@ viewResultItem nixosChannels channel show activeSource item =
                                     |> Maybe.map
                                         (\example ->
                                             [ div [] [ text "Example" ]
-                                            , div [] <| Maybe.withDefault [ asHighlightPreCode example ] (Utils.showHtml example)
+                                            , div [] <| Maybe.withDefault [ copyable example (asHighlightPreCode example) ] (Utils.showHtml example)
                                             ]
                                         )
                                     |> Maybe.withDefault []
@@ -446,6 +446,20 @@ viewResultItem nixosChannels channel show activeSource item =
             ]
 
 
+copyable : String -> Html Msg -> Html Msg
+copyable textToCopy rendered =
+    div [ class "code-block-wrapper" ]
+        [ rendered
+        , button
+            [ type_ "button"
+            , class "code-copy-button"
+            , title "Copy to clipboard"
+            , onClick (CopyToClipboard textToCopy)
+            ]
+            [ text "Copy" ]
+        ]
+
+
 asHighlightPreCode : String -> Html msg
 asHighlightPreCode value =
     div []
@@ -460,7 +474,7 @@ asHighlightPreCode value =
 {-| Render a "Usage" section showing how to use this option in the appropriate
 context, including `_class` to clarify which module system it belongs to.
 -}
-viewUsageSnippet : ResultItemSource -> List (Html msg)
+viewUsageSnippet : ResultItemSource -> List (Html Msg)
 viewUsageSnippet source =
     let
         -- Re-indent a (possibly multi-line) value so every line after the
@@ -493,13 +507,17 @@ viewUsageSnippet source =
 
         nestedOption indent =
             indent ++ source.name ++ " = " ++ leafValue indent ++ ";\n"
+
+        usage snippet =
+            [ div [] [ text "Usage" ]
+            , copyable snippet (asHighlightPreCode snippet)
+            ]
     in
     case source.docType of
         "service" ->
             case ( source.servicePackage, source.serviceModule ) of
                 ( Just pkg, Just mod_ ) ->
-                    [ div [] [ text "Usage" ]
-                    , asHighlightPreCode
+                    usage
                         ("system.services.<name> = {\n"
                             ++ "  _class = \"service\";\n"
                             ++ "  imports = [ pkgs."
@@ -510,32 +528,27 @@ viewUsageSnippet source =
                             ++ nestedOption "  "
                             ++ "};"
                         )
-                    ]
 
                 _ ->
                     []
 
         "option" ->
-            [ div [] [ text "Usage" ]
-            , asHighlightPreCode
+            usage
                 ("# configuration.nix\n"
                     ++ "{\n"
                     ++ "  _class = \"nixos\";\n"
                     ++ nestedOption "  "
                     ++ "}"
                 )
-            ]
 
         "home-manager-option" ->
-            [ div [] [ text "Usage" ]
-            , asHighlightPreCode
+            usage
                 ("# home.nix\n"
                     ++ "{\n"
                     ++ "  _class = \"homeManager\";\n"
                     ++ nestedOption "  "
                     ++ "}"
                 )
-            ]
 
         _ ->
             []
@@ -716,7 +729,7 @@ viewOptionNamePath channel activeSource optionName segments =
             [ type_ "button"
             , class "option-copy-button"
             , title "Copy option name"
-            , onClick (CopyOptionName optionName)
+            , onClick (CopyToClipboard optionName)
             ]
             [ text "Copy" ]
         ]

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -45,10 +45,34 @@ if (app.ports && app.ports.setTheme) {
     });
 }
 
+let copyToast = null;
+let copyToastTimer = null;
+
+function showCopyToast(message) {
+    if (!copyToast) {
+        copyToast = document.createElement("div");
+        copyToast.className = "copy-toast";
+        copyToast.setAttribute("role", "status");
+        copyToast.setAttribute("aria-live", "polite");
+        document.body.appendChild(copyToast);
+    }
+    copyToast.textContent = message;
+    copyToast.classList.add("visible");
+    if (copyToastTimer) {
+        clearTimeout(copyToastTimer);
+    }
+    copyToastTimer = setTimeout(() => {
+        copyToast.classList.remove("visible");
+    }, 2000);
+}
+
 if (app.ports && app.ports.copyToClipboard) {
     app.ports.copyToClipboard.subscribe((text) => {
         if (!text || !navigator.clipboard) return;
-        navigator.clipboard.writeText(text).catch(() => {});
+        navigator.clipboard
+            .writeText(text)
+            .then(() => showCopyToast("Copied to clipboard"))
+            .catch(() => {});
     });
 }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1150,8 +1150,9 @@ a:focus-visible {
 .code-block-wrapper {
   position: relative;
 
-  // Keep the command text clear of the floating button.
-  & > pre.code-block {
+  // Keep the text clear of the button. The block is a bare <pre> for package
+  // commands but a nested <pre> for option values, so match either.
+  & pre {
     padding-right: 4em;
   }
 }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1176,6 +1176,47 @@ a:focus-visible {
   }
 }
 
+.copy-toast {
+  position: fixed;
+  bottom: 1.5em;
+  left: 50%;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  max-width: calc(100vw - 2em);
+  padding: 0.5em 0.9em;
+  border-radius: 6px;
+  border: 1px solid var(--search-sidebar-container-border-color, #ccc);
+  background: var(--background-color, #fff);
+  color: var(--text-color, #333);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  font-size: 0.9em;
+
+  opacity: 0;
+  transform: translate(-50%, 0.6em);
+  pointer-events: none;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+
+  &::before {
+    content: "✓";
+    font-weight: bold;
+  }
+
+  &.visible {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-toast {
+    transition: none;
+  }
+}
+
 // Make the "Please provide more precise search terms." hint stand out so
 // users notice when their query has been truncated to 10000 results.
 .search-refine-hint {


### PR DESCRIPTION
Two related improvements to the copy buttons.

1. A toast. Every copy button (package commands, option names) wrote to the clipboard with no feedback. They all go through the copyToClipboard port, so a "Copied to clipboard" toast is added to that one handler and shows only when the write succeeds. It uses the existing theme variables, respects prefers-reduced-motion, and has role="status" for screen readers.

2. More copy buttons. The options page only had a copy button on the option name. The Default, Example and Usage code blocks now have one too, Usage being the ready-to-paste configuration.nix snippet. They reuse the same port, so the toast covers them as well.

Tested against the production index: package install commands, option names, and the option Default/Example/Usage blocks all copy the right text and raise the toast, in light and dark themes.
