### PR TITLE
feat(frontend): link from a package to its NixOS options search

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -654,6 +654,21 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                         )
                 ]
 
+        nixosOptions =
+            if item.source.flakeUrl == Nothing then
+                div []
+                    [ h4 [] [ text "NixOS options" ]
+                    , p []
+                        [ a [ href ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name) ]
+                            [ text "Search NixOS options for "
+                            , em [] [ text item.source.attr_name ]
+                            ]
+                        ]
+                    ]
+
+            else
+                text ""
+
         longerPackageDetails =
             optionals (Just item.source.attr_name == show)
                 [ div [ trapClick ]
@@ -912,6 +927,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                 ]
                     , programs
                     , maintainersTeamsAndPlatforms
+                    , nixosOptions
                     , if List.isEmpty item.source.modularServices then
                         text ""
 


### PR DESCRIPTION
Addresses #1270.

From a package's expanded details there was no quick way to see which NixOS options relate to it; you had to switch to the Options tab and retype the name. This adds a "NixOS options" line to the package details with a link that runs the options search for the package, carrying the current channel over.

It only shows for nixpkgs packages, not third-party flake packages, which don't have NixOS options.

Tested against the production index: opening firefox shows "Search NixOS options for firefox" linking to /options?channel=unstable&query=firefox, which returns the programs.firefox.* options.
