### PR TITLE
flakes: disable github:surrealdb/surrealdb

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -508,10 +508,11 @@ type = "github"
 owner = "StardustXR"
 repo = "telescope"
 
-[[sources]]
-type = "github"
-owner = "surrealdb"
-repo = "surrealdb"
+# seems to rely on allow-import-from-derivation now
+#[[sources]]
+#type = "github"
+#owner = "surrealdb"
+#repo = "surrealdb"
 
 [[sources]]
 type = "github"


### PR DESCRIPTION
as it seems to require `allow-import-from-derivation` now

fixes #1291

/cc @rushmorem 