### PR TITLE
feat(frontend): link flake packages to their flake options search

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -654,20 +654,29 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                         )
                 ]
 
-        nixosOptions =
-            if item.source.flakeUrl == Nothing then
-                div []
-                    [ h4 [] [ text "NixOS options" ]
-                    , p []
-                        [ a [ href ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name) ]
-                            [ text "Search NixOS options for "
-                            , em [] [ text item.source.attr_name ]
+        optionsLink =
+            let
+                searchLink heading label url =
+                    div []
+                        [ h4 [] [ text heading ]
+                        , p []
+                            [ a [ href url ]
+                                [ text label
+                                , em [] [ text item.source.attr_name ]
+                                ]
                             ]
                         ]
-                    ]
+            in
+            case item.source.flakeUrl of
+                Nothing ->
+                    searchLink "NixOS options"
+                        "Search NixOS options for "
+                        ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name)
 
-            else
-                text ""
+                Just _ ->
+                    searchLink "Flake options"
+                        "Search flake options for "
+                        ("/flakes?type=options&query=" ++ item.source.attr_name)
 
         longerPackageDetails =
             optionals (Just item.source.attr_name == show)
@@ -927,7 +936,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                 ]
                     , programs
                     , maintainersTeamsAndPlatforms
-                    , nixosOptions
+                    , optionsLink
                     , if List.isEmpty item.source.modularServices then
                         text ""
 

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -656,13 +656,13 @@ viewResultItem nixosChannels channel showInstallDetails show item =
 
         optionsLink =
             let
-                searchLink heading label url =
+                searchLink heading label term url =
                     div []
                         [ h4 [] [ text heading ]
                         , p []
                             [ a [ href url ]
                                 [ text label
-                                , em [] [ text item.source.attr_name ]
+                                , em [] [ text term ]
                                 ]
                             ]
                         ]
@@ -671,12 +671,30 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                 Nothing ->
                     searchLink "NixOS options"
                         "Search NixOS options for "
+                        item.source.attr_name
                         ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name)
 
-                Just _ ->
+                Just ( flakeRef, _ ) ->
+                    let
+                        repoName =
+                            flakeRef
+                                |> String.split "/"
+                                |> List.filter (\segment -> not (String.isEmpty segment))
+                                |> List.reverse
+                                |> List.head
+                                |> Maybe.withDefault item.source.attr_name
+
+                        term =
+                            if item.source.attr_name == "default" && String.contains "/" flakeRef then
+                                repoName
+
+                            else
+                                item.source.attr_name
+                    in
                     searchLink "Flake options"
                         "Search flake options for "
-                        ("/flakes?type=options&query=" ++ item.source.attr_name)
+                        term
+                        ("/flakes?type=options&query=" ++ term)
 
         longerPackageDetails =
             optionals (Just item.source.attr_name == show)


### PR DESCRIPTION
Follow-up to #1315 (issue #1270). In that review, @raboof noted the package options link could work for flakes too, pointing at the flakes options search.

#1315 only added the "NixOS options" link for nixpkgs packages. This adds the equivalent for flake packages: a "Flake options" link that runs the flakes options search for the package name (`/flakes?type=options&query=...`).

nixpkgs packages are unchanged and still link to `/options` with the channel carried over.
