### PR TITLE
enhance(frontend): header top nav-bar

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -14,6 +14,7 @@ import Html
         , header
         , img
         , li
+        , nav
         , small
         , span
         , sup
@@ -483,7 +484,7 @@ view model =
             [ id "shortcut-list-el" ]
             [ div []
                 [ header []
-                    [ div [ class "navbar navbar-static-top" ]
+                    [ nav [ class "navbar navbar-static-top" ]
                         [ div [ class "navbar-inner" ]
                             [ div [ class "container" ]
                                 [ a [ class "brand", href "https://nixos.org" ]

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -465,22 +465,28 @@ footer {
   line-height: 1;
 }
 
-header .navbar.navbar-static-top {
-  .brand {
-    padding-bottom: 0;
-  }
-  img.logo {
-    margin-top: -5px;
-    padding-right: 5px;
-    line-height: 25px;
-    height: 25px;
-  }
-  ul.nav > li {
-    line-height: 20px;
-    sup {
-      margin-left: 0.5em;
-    }
-  }
+header {
+	position: sticky;
+	top: 0;
+	z-index: 100;
+
+	.navbar.navbar-static-top {
+	  .brand {
+	    padding-bottom: 0;
+	  }
+	  img.logo {
+	    margin-top: -5px;
+	    padding-right: 5px;
+	    line-height: 25px;
+	    height: 25px;
+	  }
+	  ul.nav > li {
+	    line-height: 20px;
+	    sup {
+	      margin-left: 0.5em;
+	    }
+	  }
+	}
 }
 
 header .navbar.navbar-static-top ul.nav > li.external {


### PR DESCRIPTION
FIXES: #1325

The legacy Bootstrap 2 being EOL is beginning to be a PITA, i.e. `navbar-static-top`; also Elm being in low maintenance mode and not interfacing with JS directly doesn't help
Maybe a rewrite in Leptos would help and make sense if Rust is adopted more officially in Nix impl