### PR TITLE
enhance(frontend): package licenses

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -29,7 +29,9 @@ type Flake = super::Flake;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct License {
     url: Option<String>,
-    fullName: String,
+    fullName: Option<String>,
+    shortName: Option<String>,
+    spdxId: Option<String>,
 }
 
 impl From<import::License> for License {
@@ -38,26 +40,35 @@ impl From<import::License> for License {
         match license {
             import::License::None { .. } => License {
                 url: None,
-                fullName: "no license specified".to_string(),
+                fullName: Some("no license specified".to_string()),
+                shortName: None,
+                spdxId: None,
             },
             import::License::Simple { license } => License {
                 url: None,
-                fullName: license,
+                fullName: Some(license),
+                shortName: None,
+                spdxId: None,
             },
             import::License::Full {
                 fullName,
                 shortName,
+                spdxId,
                 url,
                 ..
             } => License {
                 url,
-                fullName: fullName.unwrap_or(shortName.unwrap_or("custom".into())),
+                fullName,
+                shortName,
+                spdxId,
             },
             // Compound variants should be flattened before reaching this point;
             // if one slips through, use its SPDX expression as the display name.
             other => License {
                 url: None,
-                fullName: other.spdx_expression(),
+                fullName: Some(other.spdx_expression()),
+                shortName: None,
+                spdxId: None,
             },
         }
     }
@@ -73,7 +84,11 @@ impl From<import::License> for License {
 pub enum LicenseExpression {
     Leaf {
         #[serde(rename = "fullName")]
-        full_name: String,
+        full_name: Option<String>,
+        #[serde(rename = "shortName")]
+        short_name: Option<String>,
+        #[serde(rename = "spdxId")]
+        spdx_id: Option<String>,
         url: Option<String>,
     },
     And {
@@ -95,22 +110,27 @@ impl From<import::License> for LicenseExpression {
     fn from(license: import::License) -> Self {
         match license {
             import::License::None { .. } => LicenseExpression::Leaf {
-                full_name: "no license specified".to_string(),
+                full_name: Some("no license specified".to_string()),
+                short_name: None,
+                spdx_id: None,
                 url: None,
             },
             import::License::Simple { license } => LicenseExpression::Leaf {
-                full_name: license,
+                full_name: Some(license),
+                short_name: None,
+                spdx_id: None,
                 url: None,
             },
             import::License::Full {
                 fullName,
                 shortName,
+                spdxId,
                 url,
                 ..
             } => LicenseExpression::Leaf {
-                full_name: fullName
-                    .or(shortName)
-                    .unwrap_or_else(|| "custom".to_string()),
+                full_name: fullName,
+                short_name: shortName,
+                spdx_id: spdxId,
                 url,
             },
             import::License::Compound {
@@ -276,7 +296,14 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                     .collect();
                 let package_license_set: Vec<String> = package_license
                     .iter()
-                    .map(|l| l.fullName.to_owned())
+                    .map(|l| {
+                        l.fullName
+                            .as_ref()
+                            .or(l.shortName.as_ref())
+                            .or(l.spdxId.as_ref())
+                            .map(|s| s.to_owned())
+                            .unwrap_or_else(|| "custom".to_string())
+                    })
                     .collect();
 
                 let maintainer: Maintainer = f.into();
@@ -357,7 +384,14 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
 
                 let package_license_set = package_license
                     .iter()
-                    .map(|l: &License| l.fullName.to_owned())
+                    .map(|l: &License| {
+                        l.fullName
+                            .as_ref()
+                            .or(l.shortName.as_ref())
+                            .or(l.spdxId.as_ref())
+                            .map(|s| s.to_owned())
+                            .unwrap_or_else(|| "custom".to_string())
+                    })
                     .collect();
 
                 let platforms: HashSet<String> =
@@ -656,5 +690,50 @@ mod tests {
         let option: Derivation = option.try_into().unwrap();
 
         println!("{}", serde_json::to_string_pretty(&option).unwrap());
+    }
+
+    #[test]
+    fn test_license_from_import() {
+        use crate::data::import;
+        let import_license = import::License::Full {
+            fullName: Some("GNU General Public License v3.0 only".to_string()),
+            shortName: Some("GPL v3".to_string()),
+            spdxId: Some("GPL-3.0-only".to_string()),
+            url: Some("https://spdx.org/licenses/GPL-3.0-only.html".to_string()),
+        };
+
+        let export_license = License::from(import_license.clone());
+        assert_eq!(
+            export_license.fullName,
+            Some("GNU General Public License v3.0 only".to_string())
+        );
+        assert_eq!(export_license.shortName, Some("GPL v3".to_string()));
+        assert_eq!(export_license.spdxId, Some("GPL-3.0-only".to_string()));
+        assert_eq!(
+            export_license.url,
+            Some("https://spdx.org/licenses/GPL-3.0-only.html".to_string())
+        );
+
+        let export_expr = LicenseExpression::from(import_license);
+        if let LicenseExpression::Leaf {
+            full_name,
+            short_name,
+            spdx_id,
+            url,
+        } = export_expr
+        {
+            assert_eq!(
+                full_name,
+                Some("GNU General Public License v3.0 only".to_string())
+            );
+            assert_eq!(short_name, Some("GPL v3".to_string()));
+            assert_eq!(spdx_id, Some("GPL-3.0-only".to_string()));
+            assert_eq!(
+                url,
+                Some("https://spdx.org/licenses/GPL-3.0-only.html".to_string())
+            );
+        } else {
+            panic!("Expected LicenseExpression::Leaf");
+        }
     }
 }

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -114,6 +114,8 @@ lazy_static! {
                     "type": "nested",
                     "properties": {
                         "fullName": {"type": "text"},
+                        "shortName": {"type": "text"},
+                        "spdxId": {"type": "text"},
                         "url": {"type": "text"}},
                 },
                 "package_license_set": {"type": "keyword"},

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -101,6 +101,8 @@ type alias ResultItemSource =
 
 type alias ResultPackageLicense =
     { fullName : Maybe String
+    , shortName : Maybe String
+    , spdxId : Maybe String
     , url : Maybe String
     }
 
@@ -111,7 +113,12 @@ satisfied; OR licenses offer a choice; WITH applies an exception; PLUS is
 "or any later version".
 -}
 type LicenseExpression
-    = LicenseLeaf { fullName : String, url : Maybe String }
+    = LicenseLeaf
+        { fullName : Maybe String
+        , shortName : Maybe String
+        , spdxId : Maybe String
+        , url : Maybe String
+        }
     | LicenseAnd (List LicenseExpression)
     | LicenseOr (List LicenseExpression)
     | LicenseWith LicenseExpression LicenseExpression
@@ -450,7 +457,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                     Just expression ->
                                         [ li []
                                             (text "License: "
-                                                :: renderLicenseExpression createShortDetailsItem expression
+                                                :: renderLicenseExpression expression
                                             )
                                         ]
 
@@ -458,19 +465,7 @@ viewResultItem nixosChannels channel showInstallDetails show item =
                                         let
                                             licenses =
                                                 item.source.licenses
-                                                    |> List.filterMap
-                                                        (\license ->
-                                                            case license.url of
-                                                                Nothing ->
-                                                                    Maybe.map text license.fullName
-
-                                                                Just url ->
-                                                                    Just
-                                                                        (createShortDetailsItem
-                                                                            (Maybe.withDefault "Unknown" license.fullName)
-                                                                            url
-                                                                        )
-                                                        )
+                                                    |> List.map renderLicenseLeaf
                                         in
                                         optionals (not (List.isEmpty licenses))
                                             [ li []
@@ -1078,47 +1073,104 @@ baseInlineList className wrapper items =
         )
 
 
-renderLicenseExpression :
-    (String -> String -> Html Msg)
-    -> LicenseExpression
-    -> List (Html Msg)
-renderLicenseExpression mkLink expr =
-    case expr of
-        LicenseLeaf { fullName, url } ->
-            case url of
-                Just u ->
-                    [ mkLink fullName u ]
+getLicenseDisplayAndTooltip :
+    { a | fullName : Maybe String, shortName : Maybe String, spdxId : Maybe String }
+    -> { display : String, tooltip : Maybe String }
+getLicenseDisplayAndTooltip license =
+    let
+        display =
+            case license.spdxId of
+                Just spdxId ->
+                    spdxId
 
                 Nothing ->
-                    [ text fullName ]
+                    case license.shortName of
+                        Just shortName ->
+                            shortName
+
+                        Nothing ->
+                            Maybe.withDefault "Unknown" license.fullName
+
+        tooltip =
+            case license.fullName of
+                Just fullName ->
+                    Just fullName
+
+                Nothing ->
+                    case license.shortName of
+                        Just shortName ->
+                            Just shortName
+
+                        Nothing ->
+                            license.spdxId
+    in
+    { display = display, tooltip = tooltip }
+
+
+renderLicenseLeaf :
+    { a | fullName : Maybe String, shortName : Maybe String, spdxId : Maybe String, url : Maybe String }
+    -> Html Msg
+renderLicenseLeaf license =
+    let
+        info =
+            getLicenseDisplayAndTooltip license
+
+        titleAttr =
+            case info.tooltip of
+                Just t ->
+                    [ title t ]
+
+                Nothing ->
+                    []
+    in
+    case license.url of
+        Just u ->
+            a
+                ([ href u
+                 , target "_blank"
+                 ]
+                    ++ titleAttr
+                )
+                [ text info.display ]
+
+        Nothing ->
+            span titleAttr [ text info.display ]
+
+
+renderLicenseExpression :
+    LicenseExpression
+    -> List (Html Msg)
+renderLicenseExpression expr =
+    case expr of
+        LicenseLeaf leaf ->
+            [ renderLicenseLeaf leaf ]
 
         LicenseAnd children ->
-            renderJoined mkLink "AND" children
+            renderJoined "AND" children
 
         LicenseOr children ->
-            renderJoined mkLink "OR" children
+            renderJoined "OR" children
 
         LicenseWith license exception ->
-            renderChild mkLink license
+            renderChild license
                 ++ [ text " ", span [ class "license-operator" ] [ text "WITH" ], text " " ]
-                ++ renderChild mkLink exception
+                ++ renderChild exception
 
         LicensePlus license ->
-            renderChild mkLink license ++ [ text "+" ]
+            renderChild license ++ [ text "+" ]
 
 
 renderJoined :
-    (String -> String -> Html Msg)
-    -> String
+    String
     -> List LicenseExpression
     -> List (Html Msg)
-renderJoined mkLink op children =
+renderJoined op children =
     let
         separator =
             [ text " ", span [ class "license-operator" ] [ text op ], text " " ]
     in
     children
-        |> List.map (renderChild mkLink)
+        |> List.map renderChild
         |> List.intersperse separator
         |> List.concat
 
@@ -1127,13 +1179,12 @@ renderJoined mkLink op children =
 precedence is unambiguous.
 -}
 renderChild :
-    (String -> String -> Html Msg)
-    -> LicenseExpression
+    LicenseExpression
     -> List (Html Msg)
-renderChild mkLink expr =
+renderChild expr =
     let
         inner =
-            renderLicenseExpression mkLink expr
+            renderLicenseExpression expr
     in
     case expr of
         LicenseLeaf _ ->
@@ -1433,9 +1484,11 @@ decodeHomepage =
 
 decodeResultPackageLicense : Json.Decode.Decoder ResultPackageLicense
 decodeResultPackageLicense =
-    Json.Decode.map2 ResultPackageLicense
-        (Json.Decode.field "fullName" (Json.Decode.nullable Json.Decode.string))
-        (Json.Decode.field "url" (Json.Decode.nullable Json.Decode.string))
+    Json.Decode.map4 ResultPackageLicense
+        (Json.Decode.oneOf [ Json.Decode.field "fullName" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
+        (Json.Decode.oneOf [ Json.Decode.field "shortName" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
+        (Json.Decode.oneOf [ Json.Decode.field "spdxId" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
+        (Json.Decode.oneOf [ Json.Decode.field "url" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
 
 
 decodeLicenseExpression : Json.Decode.Decoder LicenseExpression
@@ -1449,10 +1502,12 @@ decodeLicenseExpression =
             (\kind ->
                 case kind of
                     "leaf" ->
-                        Json.Decode.map2
-                            (\n u -> LicenseLeaf { fullName = n, url = u })
-                            (Json.Decode.field "fullName" Json.Decode.string)
-                            (Json.Decode.field "url" (Json.Decode.nullable Json.Decode.string))
+                        Json.Decode.map4
+                            (\f s idx u -> LicenseLeaf { fullName = f, shortName = s, spdxId = idx, url = u })
+                            (Json.Decode.oneOf [ Json.Decode.field "fullName" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
+                            (Json.Decode.oneOf [ Json.Decode.field "shortName" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
+                            (Json.Decode.oneOf [ Json.Decode.field "spdxId" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
+                            (Json.Decode.oneOf [ Json.Decode.field "url" (Json.Decode.nullable Json.Decode.string), Json.Decode.succeed Nothing ])
 
                     "and" ->
                         Json.Decode.map LicenseAnd


### PR DESCRIPTION
FIXES: #1326

Display Licenses text as spdxId, fallback to their shortname, fallback to their fullname, in this order

For the tooltip, it's the other way around, display their fullname, fallback to their shortname, fallback to their spdxId

### Before

[<img width="1121" height="185" alt="image" src="https://github.com/user-attachments/assets/fb83b0eb-91b0-4cfb-b6e7-72d84760ecbb" />](https://search.nixos.org/packages?query=kdePackages.ark#show=kdePackages.ark)

### After

<img width="831" height="148" alt="image" src="https://github.com/user-attachments/assets/eef55c15-ca97-4ea4-ac50-4efe6c5dfa12" />