### PR TITLE
refactor(frontend): modernize navbar css

### DIFF
--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -489,11 +489,9 @@ view model =
                                 [ a [ class "brand", href "https://nixos.org" ]
                                     [ img [ alt "NixOS logo", src "/images/nix-logo-pride.png", class "logo" ] []
                                     ]
-                                , div []
-                                    [ ul [ class "nav pull-left" ]
-                                        (viewNavigation model.route)
-                                    , viewThemeSelector model.theme
-                                    ]
+                                , ul [ class "nav" ]
+                                    (viewNavigation model.route)
+                                , viewThemeSelector model.theme
                                 ]
                             ]
                         ]

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -295,7 +295,6 @@
         text-shadow: none;
         box-shadow: none;
         border-radius: 4px;
-        margin: 4px;
         padding: 6px 12px;
 
         &:hover,
@@ -465,20 +464,37 @@ footer {
   line-height: 1;
 }
 
-header .navbar.navbar-static-top {
-  .brand {
-    padding-bottom: 0;
+header .navbar .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding-block: 4px;
+  gap: 4px;
+
+  a.brand {
+    all: unset;
+    display: flex;
+
+    img {
+      height: 25px;
+    }
   }
-  img.logo {
-    margin-top: -5px;
-    padding-right: 5px;
-    line-height: 25px;
-    height: 25px;
+
+  &::before, &::after {
+    all: unset; /* remove pseudo-elements added by bootstrap */
   }
-  ul.nav > li {
-    line-height: 20px;
-    sup {
-      margin-left: 0.5em;
+
+  .nav {
+    display: flex;
+    flex-flow: row wrap;
+    margin: unset;
+    gap: 8px;
+
+    & + .btn-group {
+      /* theme selection */
+      margin: unset;
+      margin-left: auto;
     }
   }
 }


### PR DESCRIPTION
This modernize the css used for the navbar, while shaving off a bunch of nasty bootstrap properties. We avoid relying on weird hacks for position thing, like `margin-top: -5px;`.
I also removed an useless div wrapper in the way.

The different is minimal:

<img width="1648" height="278" alt="image" src="https://github.com/user-attachments/assets/5aaa6c2c-ca3b-4268-a043-e1ef64106f24" />

