### PR TITLE
index: remove meta language attr since it is discouraged by w3c

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -9,7 +9,6 @@
       <meta name="title" content="NixOS Search" />
       <meta name="description" content="Search through thousands of packages, NixOS configuration options, and flakes available in the Nix ecosystem." />
       <meta name="robots" content="index, follow" />
-      <meta name="language" content="English" />
 
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://search.nixos.org/" />


### PR DESCRIPTION
While it is good to serve as much information as possible, W3C discourages using other methods of setting language in HTML apart from `<html lang=... >` [1]. To prevent possible bugs across browsers etc. I'd suggest removing this meta information.

[1] https://www.w3.org/International/questions/qa-http-and-lang#meta_summary