### PR TITLE
Add thinkorswim flake

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -605,6 +605,11 @@ owner = "simple-nixos-mailserver"
 repo = "nixos-mailserver"
 
 [[sources]]
+type = "gitlab"
+owner = "yisraeldov"
+repo = "thinkorswim-flake"
+
+[[sources]]
 type = "sourcehut"
 owner = "~alexdavid"
 repo = "jail.nix"


### PR DESCRIPTION
Add `gitlab:yisraeldov/thinkorswim-flake` to the manually indexed third-party flakes.

Validated with:

```sh
nix run github:nixos/nixos-search#flake-info -- --json flake gitlab:yisraeldov/thinkorswim-flake
```