### PR TITLE
Add skelettor/nix-openlinkhub to flakes index

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -450,6 +450,11 @@ repo = "agenix"
 
 [[sources]]
 type = "github"
+owner = "skelettor"
+repo = "nix-openlinkhub"
+
+[[sources]]
+type = "github"
 owner = "slendidev"
 repo = "yavsrg-flake"
 


### PR DESCRIPTION
Adds skelettor/nix-openlinkhub, an unofficial NixOS module/package integration for OpenLinkHub (Corsair iCUE LINK controller support on Linux). Verified with flake-info — output attached.
[flake-info.json](https://github.com/user-attachments/files/29884706/flake-info.json)
