### PR TITLE
Add nix-futo-notes flake

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -10,6 +10,10 @@ url = "git+https://codeberg.org/eicas/omeka-s-flake"
 
 [[sources]]
 type = "git"
+url = "git+https://codeberg.org/NMedvesky/nix-futo-notes?ref=main"
+
+[[sources]]
+type = "git"
 url = "git+https://codeberg.org/raboof/browserify?ref=nix"
 
 [[sources]]


### PR DESCRIPTION
Adds NMedvesky/nix-futo-notes flake which repackages the deb binary provided by FUTO Notes on their GitLab.
`flake-info` runs without errors.