### PR TITLE
comment fenix, whose x86_64-darwin now throws

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -337,10 +337,11 @@ type = "github"
 owner = "nix-community"
 repo = "autofirma-nix"
 
-[[sources]]
-type = "github"
-owner = "nix-community"
-repo = "fenix"
+# x86_64-darwin throws deprecated
+# [[sources]]
+# type = "github"
+# owner = "nix-community"
+# repo = "fenix"
 
 [[sources]]
 type = "github"


### PR DESCRIPTION
Closes #1382.

a better solution would be to not break the periodic import as soon as any flake build fails.
