### PR TITLE
chore: remove <nixpkgs> impurity and use pure flake overrides

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -5,8 +5,9 @@
 let
   resolved = builtins.getFlake input-flake;
 
-  nixpkgs = (import <nixpkgs> { });
-  lib = nixpkgs.lib;
+  nixpkgsFlake = builtins.getFlake "nixpkgs";
+  inherit (nixpkgsFlake) lib;
+  nixpkgs = nixpkgsFlake.legacyPackages.${referenceSystem};
 
   # filter = lib.filterAttrs (key: _ : key == "apps" || key == "packages");
 
@@ -187,7 +188,7 @@ let
             # argument to import modules from the nixos tree. However, most of the time
             # this is done to import *profiles* which do not declare any options, so we
             # can allow it.
-            modulesPath = "${nixpkgs.path}/nixos/modules";
+            modulesPath = "${nixpkgsFlake}/nixos/modules";
 
             # Provide commonly-used arguments so module evaluation that expects them
             # (e.g. `pkgs` or `config`) does not fail during CI evaluation.
@@ -490,8 +491,8 @@ let
     ) { } list;
 
   # nixpkgs-specific, doesn't use the flake argument
-  nixpkgsBaseModules = import <nixpkgs/nixos/modules/module-list.nix> ++ [
-    <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix>
+  nixpkgsBaseModules = import "${nixpkgsFlake}/nixos/modules/module-list.nix" ++ [
+    "${nixpkgsFlake}/nixos/modules/virtualisation/qemu-vm.nix"
     { nixpkgs.hostPlatform = "x86_64-linux"; }
   ];
 
@@ -499,7 +500,7 @@ let
   # `pkgs` attributes (which would force shallow evaluation of every package
   # and is too expensive -- see NixOS/nixpkgs#509117).
   serviceDocModules =
-    (import <nixpkgs/nixos/modules/misc/documentation/modular-services.nix> {
+    (import "${nixpkgsFlake}/nixos/modules/misc/documentation/modular-services.nix" {
       inherit lib;
       pkgs = nixpkgs;
     }).documentation.nixos.extraModules;

--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -167,41 +167,56 @@ let
   # Filter for user-visible, non-internal options
   filterOptions = opts: lib.filter (x: x.visible && !x.internal && lib.head x.loc != "_module") opts;
 
+  evalOptionsWith =
+    {
+      evalModules ? lib.evalModules,
+      modules,
+      specialArgs ? { },
+      class ? null,
+      extraAttrs ? { },
+    }:
+    let
+      declarations =
+        (evalModules (
+          {
+            modules = modules ++ [
+              (
+                { lib, ... }:
+                {
+                  _module.check = lib.mkForce false;
+                }
+              )
+            ];
+            specialArgs = {
+              pkgs = nixpkgs;
+            }
+            // specialArgs;
+          }
+          // lib.optionalAttrs (class != null) { inherit class; }
+        )).options;
+
+      opts = lib.optionAttrSetToDocList declarations;
+    in
+    map (cleanUpOption extraAttrs) (filterOptions opts);
+
   readNixOSOptions =
     {
       module,
       modulePath ? null,
     }:
-    let
-      declarations =
-        (lib.evalModules {
-          modules = (if lib.isList module then module else [ module ]) ++ [
-            (
-              { ... }:
-              {
-                _module.check = false;
-              }
-            )
-          ];
-          specialArgs = {
-            # !!! NixOS-specific. Unfortunately, NixOS modules can rely on the `modulesPath`
-            # argument to import modules from the nixos tree. However, most of the time
-            # this is done to import *profiles* which do not declare any options, so we
-            # can allow it.
-            modulesPath = "${nixpkgsFlake}/nixos/modules";
-
-            # Provide commonly-used arguments so module evaluation that expects them
-            # (e.g. `pkgs` or `config`) does not fail during CI evaluation.
-            pkgs = nixpkgs;
-          };
-        }).options;
-
-      opts = lib.optionAttrSetToDocList declarations;
+    evalOptionsWith {
+      modules = if lib.isList module then module else [ module ];
+      specialArgs = {
+        # !!! NixOS-specific. Unfortunately, NixOS modules can rely on the `modulesPath`
+        # argument to import modules from the nixos tree. However, most of the time
+        # this is done to import *profiles* which do not declare any options, so we
+        # can allow it.
+        modulesPath = "${nixpkgsFlake}/nixos/modules";
+      };
       extraAttrs = lib.optionalAttrs (modulePath != null) {
         flake = modulePath;
       };
-    in
-    map (cleanUpOption extraAttrs) (filterOptions opts);
+    };
 
   # Parses the angle-bracket prefix from modular service option names to extract
   # service_package and service_module, strips the prefix, and tags as entry_type = "service".
@@ -321,25 +336,14 @@ let
           }
         else
           fn;
-
-      declarations =
-        (hmLib.evalModules {
-          modules = hmModuleList ++ [
-            (
-              { lib, ... }:
-              {
-                _module.check = lib.mkForce false;
-              }
-            )
-          ];
-          specialArgs = {
-            pkgs = nixpkgs;
-          };
-        }).options;
-
-      opts = hmLib.optionAttrSetToDocList declarations;
     in
-    map (cleanUpOption { entry_type = "home-manager-option"; }) (filterOptions opts);
+    evalOptionsWith {
+      evalModules = hmLib.evalModules;
+      modules = hmModuleList;
+      extraAttrs = {
+        entry_type = "home-manager-option";
+      };
+    };
 
   read = reader: set: lib.flatten (lib.attrValues (withSystem reader set));
 
@@ -510,6 +514,15 @@ let
   # with "<" come from modular services.
   nixpkgsAllOpts = readNixOSOptions { module = nixpkgsBaseModules ++ serviceDocModules; };
   isServiceOption = opt: lib.hasPrefix "<" opt.name;
+  readOptionsIf =
+    {
+      cond,
+      reader,
+    }:
+    let
+      check = builtins.tryEval cond;
+    in
+    if check.success && check.value then reader else [ ];
 
 in
 
@@ -518,19 +531,17 @@ rec {
   packages = lib.attrValues (collectSystems allPackageSets.packages packages');
   apps = lib.attrValues (collectSystems { } apps'); # apps don't need fallback evaluation
   options = readFlakeOptions;
-  home-manager-options =
-    let
-      # Require both `modules/modules.nix` and `modules/lib/stdlib-extended.nix`
-      # to avoid false positives. Other flakes (e.g. `nix-bitcoin`) ship a
-      # `modules/modules.nix` that is unrelated to home-manager; only
-      # home-manager itself also provides the `stdlib-extended.nix` helper
-      # that `readHomeManagerOptions` imports.
-      isHomeManager = builtins.tryEval (
-        builtins.pathExists "${resolved}/modules/modules.nix"
-        && builtins.pathExists "${resolved}/modules/lib/stdlib-extended.nix"
-      );
-    in
-    if isHomeManager.success && isHomeManager.value then readHomeManagerOptions else [ ];
+  home-manager-options = readOptionsIf {
+    # Require both `modules/modules.nix` and `modules/lib/stdlib-extended.nix`
+    # to avoid false positives. Other flakes (e.g. `nix-bitcoin`) ship a
+    # `modules/modules.nix` that is unrelated to home-manager; only
+    # home-manager itself also provides the `stdlib-extended.nix` helper
+    # that `readHomeManagerOptions` imports.
+    cond =
+      builtins.pathExists "${resolved}/modules/modules.nix"
+      && builtins.pathExists "${resolved}/modules/lib/stdlib-extended.nix";
+    reader = readHomeManagerOptions;
+  };
   all = packages ++ apps ++ options;
 
   nixos-options = builtins.filter (opt: !(isServiceOption opt)) nixpkgsAllOpts;

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -32,3 +32,12 @@ pub fn run_garbage_collection() -> Result<()> {
 
     Ok(())
 }
+
+pub fn nix_eval_command(args: &[&str]) -> Command {
+    let mut command = Command::with_args("nix", args.iter());
+    command.add_arg_pair("-f", EXTRACT_SCRIPT.clone());
+    command.enable_capture();
+    command.log_to = LogTo::Log;
+    command.log_output_on_error = true;
+    command
+}

--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -1,7 +1,5 @@
 use crate::data::import::{FlakeEntry, Kind};
 use anyhow::{Context, Result};
-use command_run::{Command, LogTo};
-use serde_json::Deserializer;
 use std::fmt::Display;
 use std::path::PathBuf;
 
@@ -20,11 +18,10 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
     temp_store: bool,
     extra: &[String],
 ) -> Result<Vec<FlakeEntry>> {
-    let mut command = Command::with_args("nix", ARGS.iter());
+    let mut command = super::nix_eval_command(&ARGS);
     command
         .env
         .insert("NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM".into(), "1".into());
-    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
     command.add_args(
         [
             "--override-flake",
@@ -45,16 +42,13 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
         command.add_arg_pair("--store", temp_store_path.canonicalize()?);
     }
     command.add_args(extra);
-    command.enable_capture();
-    command.log_to = LogTo::Log;
-    command.log_output_on_error = true;
 
     let parsed: Result<Vec<FlakeEntry>> = command
         .run()
         .with_context(|| format!("Failed to gather information about {}", flake_ref))
         .and_then(|o| {
             let output = &*o.stdout_string_lossy();
-            let de = &mut Deserializer::from_str(output);
+            let de = &mut serde_json::Deserializer::from_str(output);
             serde_path_to_error::deserialize(de)
                 .with_context(|| format!("Failed to analyze flake {}", flake_ref))
         });

--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -25,9 +25,13 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
         .env
         .insert("NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM".into(), "1".into());
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_arg_pair(
-        "-I",
-        "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz",
+    command.add_args(
+        [
+            "--override-flake",
+            "nixpkgs",
+            "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz",
+        ]
+        .iter(),
     );
     command.add_args(["--override-flake", "input-flake", flake_ref.as_ref()].iter());
     command.add_args(["--argstr", "flake", flake_ref.as_ref()].iter());

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -79,22 +79,18 @@ pub fn get_nixpkgs_info(
 }
 
 pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {
-    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
-    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
+    let mut command = super::nix_eval_command(&["eval", "--json", "--no-write-lock-file"]);
     command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
     command.add_arg("nixos-package-services");
-
-    command.enable_capture();
-    command.log_to = LogTo::Log;
-    command.log_output_on_error = true;
 
     let cow = command
         .run()
         .with_context(|| "Failed to gather modular service mapping for packages")?;
 
     let output = &*cow.stdout_string_lossy();
-    let map: HashMap<String, Vec<String>> =
-        serde_json::from_str(output).with_context(|| "Could not parse package-services map")?;
+    let de = &mut serde_json::Deserializer::from_str(output);
+    let map: HashMap<String, Vec<String>> = serde_path_to_error::deserialize(de)
+        .with_context(|| "Could not parse package-services map")?;
     Ok(map)
 }
 
@@ -137,85 +133,68 @@ pub fn get_nixpkgs_programs(nixpkgs: &Nixpkgs) -> Result<HashMap<String, HashSet
     Ok(programs)
 }
 
-pub fn get_nixpkgs_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
-    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
-    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
+fn get_options_from_script(
+    nixpkgs: &Source,
+    attribute: &str,
+    override_flake: Option<(&str, &str)>,
+) -> Result<Vec<NixOption>> {
+    let mut command = super::nix_eval_command(&["eval", "--json", "--no-write-lock-file"]);
     command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
-    command.add_arg("nixos-options");
-
-    command.enable_capture();
-    command.log_to = LogTo::Log;
-    command.log_output_on_error = true;
+    if let Some((name, flake_ref)) = override_flake {
+        command.add_args(["--override-flake", name, flake_ref].iter());
+    }
+    command.add_arg(attribute);
 
     let cow = command
         .run()
-        .with_context(|| "Failed to gather information about nixpkgs options")?;
+        .with_context(|| format!("Failed to gather information about {}", attribute))?;
 
     let output = &*cow.stdout_string_lossy();
     let de = &mut serde_json::Deserializer::from_str(output);
-    let attr_set: Vec<NixOption> =
-        serde_path_to_error::deserialize(de).with_context(|| "Could not parse options")?;
+    let attr_set: Vec<NixOption> = serde_path_to_error::deserialize(de)
+        .with_context(|| format!("Could not parse {}", attribute))?;
 
-    Ok(attr_set.into_iter().map(NixpkgsEntry::Option).collect())
+    Ok(attr_set)
+}
+
+pub fn get_nixpkgs_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
+    let options = get_options_from_script(nixpkgs, "nixos-options", None)?;
+    Ok(options.into_iter().map(NixpkgsEntry::Option).collect())
 }
 
 pub fn get_nixpkgs_services(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
-    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
-    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
-    command.add_arg("nixos-services");
+    let options = get_options_from_script(nixpkgs, "nixos-services", None)?;
+    Ok(options.into_iter().map(NixpkgsEntry::Service).collect())
+}
 
-    command.enable_capture();
-    command.log_to = LogTo::Log;
-    command.log_output_on_error = true;
-
-    let cow = command
-        .run()
-        .with_context(|| "Failed to gather information about nixpkgs modular services")?;
-
-    let output = &*cow.stdout_string_lossy();
-    let de = &mut serde_json::Deserializer::from_str(output);
-    let attr_set: Vec<NixOption> =
-        serde_path_to_error::deserialize(de).with_context(|| "Could not parse services")?;
-
-    Ok(attr_set.into_iter().map(NixpkgsEntry::Service).collect())
+fn flake_ref_for(nixpkgs: &Source, base: &str, suffix_pattern: Option<&str>) -> String {
+    match nixpkgs {
+        Source::Nixpkgs(Nixpkgs { channel, .. }) if channel != "unstable" => {
+            let suffix = match suffix_pattern {
+                Some(pat) => pat.replace("{channel}", channel),
+                None => format!("release-{channel}"),
+            };
+            format!("{base}/{suffix}")
+        }
+        _ => base.to_string(),
+    }
 }
 
 /// Home-manager flake reference matching a given nixpkgs channel. Stable
 /// nixpkgs channels (`nixos-XX.YY`) get the corresponding `release-XX.YY`
 /// branch in `nix-community/home-manager`; `nixos-unstable` gets `master`.
 fn home_manager_flake_ref(nixpkgs: &Source) -> String {
-    let base = "github:nix-community/home-manager";
-    match nixpkgs {
-        Source::Nixpkgs(Nixpkgs { channel, .. }) if channel != "unstable" => {
-            format!("{base}/release-{channel}")
-        }
-        _ => base.to_string(),
-    }
+    flake_ref_for(nixpkgs, "github:nix-community/home-manager", None)
 }
 
 pub fn get_home_manager_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
     let hm_flake_ref = home_manager_flake_ref(nixpkgs);
-    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
-    command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
-    command.add_args(["--override-flake", "input-flake", &hm_flake_ref].iter());
-    command.add_arg("home-manager-options");
-
-    command.enable_capture();
-    command.log_to = LogTo::Log;
-    command.log_output_on_error = true;
-
-    let cow = command
-        .run()
-        .with_context(|| "Failed to gather information about home-manager options")?;
-
-    let output = &*cow.stdout_string_lossy();
-    let de = &mut serde_json::Deserializer::from_str(output);
-    let attr_set: Vec<NixOption> = serde_path_to_error::deserialize(de)
-        .with_context(|| "Could not parse home-manager options")?;
-
-    Ok(attr_set
+    let options = get_options_from_script(
+        nixpkgs,
+        "home-manager-options",
+        Some(("input-flake", &hm_flake_ref)),
+    )?;
+    Ok(options
         .into_iter()
         .map(NixpkgsEntry::HomeManagerOption)
         .collect())

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -79,9 +79,9 @@ pub fn get_nixpkgs_info(
 }
 
 pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {
-    let mut command = Command::with_args("nix", &["eval", "--json"]);
+    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
     command.add_arg("nixos-package-services");
 
     command.enable_capture();
@@ -138,9 +138,9 @@ pub fn get_nixpkgs_programs(nixpkgs: &Nixpkgs) -> Result<HashMap<String, HashSet
 }
 
 pub fn get_nixpkgs_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
-    let mut command = Command::with_args("nix", &["eval", "--json"]);
+    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
     command.add_arg("nixos-options");
 
     command.enable_capture();
@@ -160,9 +160,9 @@ pub fn get_nixpkgs_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
 }
 
 pub fn get_nixpkgs_services(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
-    let mut command = Command::with_args("nix", &["eval", "--json"]);
+    let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
     command.add_arg("nixos-services");
 
     command.enable_capture();
@@ -198,7 +198,7 @@ pub fn get_home_manager_options(nixpkgs: &Source) -> Result<Vec<NixpkgsEntry>> {
     let hm_flake_ref = home_manager_flake_ref(nixpkgs);
     let mut command = Command::with_args("nix", &["eval", "--json", "--no-write-lock-file"]);
     command.add_arg_pair("-f", super::EXTRACT_SCRIPT.clone());
-    command.add_arg_pair("-I", format!("nixpkgs={}", nixpkgs.to_flake_ref()));
+    command.add_args(["--override-flake", "nixpkgs", &nixpkgs.to_flake_ref()].iter());
     command.add_args(["--override-flake", "input-flake", &hm_flake_ref].iter());
     command.add_arg("home-manager-options");
 

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -539,23 +539,28 @@ findSource :
     -> List (Html a)
 findSource nixosChannels channel source =
     let
-        githubUrlPrefix branch =
-            "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
-
-        -- Home Manager options are imported from the `release-XX.YY` branch of
-        -- `nix-community/home-manager` matching the nixpkgs channel
-        -- (see `flake-info/src/commands/nixpkgs_info.rs`), or `master` for
-        -- `nixos-unstable`. Their `option_source` paths resolve against that
-        -- repo, not nixpkgs.
-        homeManagerBranch nixpkgsBranch =
+        stableBranch nixpkgsBranch prefixPattern =
             if nixpkgsBranch == "nixos-unstable" then
                 "master"
 
             else
-                "release-" ++ String.dropLeft (String.length "nixos-") nixpkgsBranch
+                let
+                    version =
+                        String.dropLeft (String.length "nixos-") nixpkgsBranch
+                in
+                prefixPattern ++ version
+
+        repoUrlPrefix owner repo branch =
+            "https://github.com/" ++ owner ++ "/" ++ repo ++ "/blob/" ++ branch ++ "/"
+
+        githubUrlPrefix branch =
+            "https://github.com/NixOS/nixpkgs/blob/" ++ branch ++ "/"
+
+        homeManagerBranch nixpkgsBranch =
+            stableBranch nixpkgsBranch "release-"
 
         homeManagerUrlPrefix branch =
-            "https://github.com/nix-community/home-manager/blob/" ++ branch ++ "/"
+            repoUrlPrefix "nix-community" "home-manager" branch
 
         cleanPosition value =
             if String.startsWith "source/" value then


### PR DESCRIPTION
This PR cleans up the option evaluator to remove impurities and reduce duplicate boilerplate:

- **Impurities**: Replaces legacy `<nixpkgs>` paths and `-I` search path overrides with pure `builtins.getFlake "nixpkgs"` and `--override-flake` CLI arguments.
- **DRY Refactor**: Consolidates repetitive `nix eval` Command builder boilerplate in Rust under a new `nix_eval_command` helper, and DRYs up option module evaluation in `flake_info.nix` with a generic `evalOptionsWith` helper.