### PR TITLE
fix(frontend): avoid HTTP 400 by not combining rescore with field sort

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -1659,6 +1659,30 @@ makeRequestBody query from sizeRaw sort types sortField otherSortFields terms fi
         primaryField : String
         primaryField =
             List.head mainFields |> Maybe.withDefault ""
+
+        -- only emit `rescore` for the `Relevance` sort.
+        rescoreActive : Bool
+        rescoreActive =
+            case ( sort, rescoreField ) of
+                ( Relevance, Just _ ) ->
+                    True
+
+                _ ->
+                    False
+
+        sortQuery : ( String, Json.Encode.Value )
+        sortQuery =
+            if rescoreActive then
+                -- Sort by `_score` descending only: the one sort Elasticsearch
+                -- permits alongside `rescore`. The rescore provides the
+                -- tie-break in place of the dropped alphabetical secondary field.
+                ( "sort"
+                , Json.Encode.list Json.Encode.object
+                    [ [ ( "_score", Json.Encode.string "desc" ) ] ]
+                )
+
+            else
+                toSortQuery sort sortField otherSortFields
     in
     Http.jsonBody
         (Json.Encode.object
@@ -1668,7 +1692,7 @@ makeRequestBody query from sizeRaw sort types sortField otherSortFields terms fi
              , ( "size"
                , Json.Encode.int size
                )
-             , toSortQuery sort sortField otherSortFields
+             , sortQuery
              , toAggregations terms
              , ( "query"
                , Json.Encode.object
@@ -1717,11 +1741,11 @@ makeRequestBody query from sizeRaw sort types sortField otherSortFields terms fi
                     ]
                )
              ]
-                ++ (case rescoreField of
-                        Just field ->
+                ++ (case ( rescoreActive, rescoreField ) of
+                        ( True, Just field ) ->
                             [ rescoreQuery field ]
 
-                        Nothing ->
+                        _ ->
                             []
                    )
             )


### PR DESCRIPTION
## Problem

Every package search on search.nixos.org fails with `Bad Status: Server returned 400` (e.g. https://search.nixos.org/packages?channel=26.05&query=nginx). Options search is unaffected.

PR #1375 (`3c38273`) added a top-level `rescore` block to the packages query. The packages query already sends a `sort` that references `package_attr_name` (as a `_score` tie-break under Relevance, and as the primary key under an explicit alphabetical sort). Elasticsearch [rejects any query combining `rescore` with a `sort`](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/filter-search-results.html) on a field other than `_score`:

> `illegal_argument_exception: Cannot use [sort] option in conjunction with [rescore].` (status 400)

Options search escapes this because it passes `rescoreField = Nothing`.

## Fix

Only emit `rescore` for the `Relevance` sort, and when it is active, sort by `_score` alone. The rescore signal (shorter attr names rank higher) then provides the tie-break in place of the alphabetical secondary field -- which is closer to the CLI parity goal #1375 aimed for. Alphabetical sorts and options search keep their existing multi-field sort and simply omit `rescore`.

The gating lives entirely in `makeRequestBody`; the `Page/Packages.elm` and `Page/Options.elm` call sites are unchanged.

## Verification

Reproduced both query shapes against the live index `latest-48-nixos-26.05` via the read-only `manage-elasticsearch.yml` workflow:

- Relevance branch -- `sort:[{"_score":"desc"}]` + `rescore` -> 200, returns hits (run 29235152186).
- Alphabetical branch -- multi-field `sort`, no `rescore` -> 200, returns hits, no error (run 29235753338).

`nix build .#frontend` compiles clean.

Disclaimer: I used a coding agent in the creation of this patch.

Fixes #1390