### PR TITLE
fix(frontend): repair `frontend` devShell by installing `node_modules` with `npm ci`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,8 +138,7 @@
             ];
             extraShellHook = ''
               export PATH=$PWD/frontend/node_modules/.bin:$PATH
-              rm -rf frontend/node_modules
-              ln -sf ${packages.frontend.node_modules}/node_modules frontend/
+              ( cd frontend && npm ci --no-audit --no-fund )
               echo "==========================================================="
               echo "= To develop the frontend run: cd frontend && npm run dev ="
               echo "==========================================================="


### PR DESCRIPTION
Makes `npm_modules` reproducible again in local development.

The `frontend` devShell referenced `packages.frontend.node_modules`, an attribute the frontend derivation never exposed, so `nix develop .#frontend` failed to evaluate. Replace the broken symlink with `npm ci` against the pinned lockfile on shell entry, matching the flow the shell already documents (`cd frontend && npm run dev`).

Assisted-by: Claude:claude-opus-4-8