### PR TITLE
fix(frontend): fix search-form

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -1228,7 +1228,7 @@ viewSearchInput nixosChannels outMsg categoryName selectedChannel searchQuery ma
         [ onSubmit (outMsg QueryInputSubmit)
         , class "search-input"
         ]
-        (div []
+        (div [ class "search-input-top" ]
             [ div [ class "search-input-with-typeahead" ]
                 [ input
                     [ type_ "text"
@@ -1259,7 +1259,7 @@ viewSearchInput nixosChannels outMsg categoryName selectedChannel searchQuery ma
                     Nothing ->
                         text ""
                 ]
-            , viewButton [ type_ "submit" ]
+            , viewButton [ type_ "submit", class "search-input-submit" ]
                 [ text "Search" ]
             ]
             :: (selectedChannel

--- a/frontend/src/scss/bootstrap.scss
+++ b/frontend/src/scss/bootstrap.scss
@@ -308,57 +308,10 @@ label {
   margin-bottom:5px
 }
 
-input[type=email],
-input[type=password],
-input[type=search],
-input[type=text],
-input[type=url],
-select {
-  -webkit-border-radius:4px;
-  -moz-border-radius:4px;
-  border-radius:4px;
-  color:#555;
-  display:inline-block;
-  font-size:14px;
-  height:20px;
-  line-height:20px;
-  margin-bottom:10px;
-  padding:4px 6px;
-  vertical-align:middle
-}
-
 input {
   width:206px
 }
 
-input[type=email],
-input[type=password],
-input[type=search],
-input[type=text],
-input[type=url] {
-  background-color:#fff;
-  border:1px solid #ccc;
-  -webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);
-  -moz-box-shadow:inset 0 1px 1px rgba(0,0,0,.075);
-  box-shadow:inset 0 1px 1px rgba(0,0,0,.075);
-  -webkit-transition:border .2s linear,box-shadow .2s linear;
-  -moz-transition:border .2s linear,box-shadow .2s linear;
-  -o-transition:border .2s linear,box-shadow .2s linear;
-  transition:border .2s linear,box-shadow .2s linear
-}
-
-input[type=email]:focus,
-input[type=password]:focus,
-input[type=search]:focus,
-input[type=text]:focus,
-input[type=url]:focus {
-  border-color:rgba(82,168,236,.8);
-  -webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(82,168,236,.6);
-  -moz-box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(82,168,236,.6);
-  box-shadow:inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(82,168,236,.6);
-  outline:0;
-  outline:thin dotted\9
-}
 input[type=checkbox] {
   line-height:normal;
   margin:4px 0 0;

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -246,37 +246,14 @@
   }
 
   // Override bootstrap styles for the search box
-  .search-input {
-    >div:first-child:first-child:first-child {
-      display: flex;
-      gap: 2rem;
+  .search-input-top {
 
-      div {
-        flex-grow: 1;
-      }
+    input {
+      background: var(--button-background);
+      color: var(--text-color);
 
-      input {
-        background: var(--button-background);
-        box-shadow: none;
-        border: 1px solid transparent;
-        color: var(--text-color);
-
-        &::placeholder {
-          font-weight: bold;
-          opacity: 1;
-          color: var(--text-color-light);
-        }
-      }
-
-    }
-
-    .btn-group {
-      border: none;
-      border-radius: 4px;
-      background: inherit;
-
-      button+button {
-        border-left: 1px solid var(--line-color);
+      &::placeholder {
+        color: var(--text-color-light);
       }
     }
   }
@@ -571,21 +548,32 @@ header .navbar.navbar-static-top ul.nav > li.external {
   // Search input section
   & > .search-input {
 
-    // Search Input and Button
-    & > div:nth-child(1) {
-      display: grid;
-      grid-template-columns: auto 8em;
+    .search-input-top {
+      margin-bottom: 1em;
+      display: flex;
+      gap: 1ch;
 
-      & > div > input {
-        font-size: 18px;
-        height: 40px;
+      #search-query-input {
+        height: 100%;
         width: 100%;
+        margin: 0;
+        padding: .5em;
+        box-sizing: border-box;
+        border: 2px solid var(--search-sidebar-container-border-color);
+        border-radius: 4px;
+        font-size: 1.2rem;
+        font-weight: 500; // TODO: introduce medium font variant
+        outline: 0;
+
+        &:focus, &:focus-within {
+          border: 2px solid var(--dark-blue);
+        }
       }
 
-      & > button {
-        font-size: 24px;
-        height: 50px;
-        min-width: 4em;
+      button.btn.btn.search-input-submit {
+        font-size: 1.2rem;
+        font-weight: 600;
+        border: 2px solid var(--search-sidebar-container-border-color);
       }
     }
 


### PR DESCRIPTION
## before

Currently the input form present inconsistent styling between themes:

<img width="306" height="108" alt="image" src="https://github.com/user-attachments/assets/3923e264-acb5-4883-aa0b-460c3ec8f6d2" />
<img width="299" height="110" alt="image" src="https://github.com/user-attachments/assets/1fbb013a-fcf9-4709-b10b-e443aa290a45" />

<img width="246" height="113" alt="image" src="https://github.com/user-attachments/assets/a7abe4eb-aaa1-4517-890a-7ade8237e7be" />
<img width="243" height="128" alt="image" src="https://github.com/user-attachments/assets/020e45dd-e7f9-47c5-8f5b-e3b51e28648b" />


The input & button also goes weirdly outside their boxes:

<img width="1257" height="175" alt="image" src="https://github.com/user-attachments/assets/9d812519-0017-4673-a558-f4a157375fea" />

## after

<img width="805" height="231" alt="image" src="https://github.com/user-attachments/assets/8f76bee9-2ffc-4a38-b09d-6db7ea41dfc5" />
<img width="805" height="242" alt="image" src="https://github.com/user-attachments/assets/866739a5-7e81-4bf0-b183-6584c5c14afa" />

<img width="252" height="127" alt="image" src="https://github.com/user-attachments/assets/c29a2bc3-a3cd-414b-9790-6181db305f60" />
<img width="252" height="133" alt="image" src="https://github.com/user-attachments/assets/1329b0c0-caed-4dac-8d79-cf79a8caab9c" />

