### PR TITLE
fix(maintainers): truncate text properly

### DIFF
--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -531,6 +531,7 @@ footer {
               }
 
               & > span:first-child {
+                text-overflow: ellipsis;
                 overflow: hidden;
               }
               & > span:last-child {


### PR DESCRIPTION
<img width="334" height="144" alt="image" src="https://github.com/user-attachments/assets/cd6f4bc5-c608-4c25-a49c-026bdd32e103" />

closes: https://github.com/NixOS/nixos-search/issues/1407