### PR TITLE
frontent/search: add fuzzy matching to elastic parameters

### DIFF
--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -297,8 +297,25 @@ searchFields positiveWords mainFields fields =
                     ]
               )
             ]
+
+        fuzzyMatch : List ( String, Json.Encode.Value )
+        fuzzyMatch =
+            [ ( "multi_match"
+              , Json.Encode.object
+                    [ ( "type", Json.Encode.string "best_fields" )
+                    , ( "query", Json.Encode.string (String.join " " positiveWords) )
+                    , ( "fuzziness", Json.Encode.string "AUTO" )
+                    , ( "prefix_length", Json.Encode.int 1 )
+                    , ( "_name", Json.Encode.string <| "fuzzy_" ++ String.join "_" positiveWords )
+                    , ( "fields"
+                      , Json.Encode.list Json.Encode.string
+                            (List.map (\( field, score ) -> field ++ "^" ++ String.fromFloat (score * 0.5)) fields)
+                      )
+                    ]
+              )
+            ]
     in
-    multiMatch :: List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
+    multiMatch :: fuzzyMatch :: List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
 
 
 shouldClauses :


### PR DESCRIPTION
This enables fuzzy matching capabilities of elastic search.

Which in my search performance evaluation showed to add better support for `typo` and `prefix` queries.

https://github.com/hsjobeki/nixos-search-queries