### PR TITLE
frontend/search: add benchmark ci report

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,36 @@
+name: "Frontend: Relevance benchmark comment"
+
+# Trusted workflow that posts performance reports as comment
+on:
+  workflow_run:
+    workflows: ["Frontend: Relevance benchmark"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: "Post benchmark comment"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Post report as PR comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          path: benchmark_report.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,55 @@
+name: "Frontend: Relevance benchmark"
+
+on:
+  pull_request:
+    paths:
+      - "frontend/src/Search.elm"
+      - "frontend/src/Page/Packages.elm"
+      - "frontend/src/Page/Options.elm"
+      - "frontend/src/Benchmark.elm"
+      - "frontend/benchmark/**"
+      - ".github/workflows/benchmark.yml"
+
+# This job builds and runs untrusted PR code
+# We produce a markdown report as artifact; which the trusted workflow downloads
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: "Relevance benchmark"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Run relevance benchmark
+        run: npm --prefix frontend --silent run benchmark > benchmark_report.md
+
+      - name: report
+        run: |
+          echo "UPLOADING BENCHMARK REPORT"
+          cat benchmark_report.md
+          echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-report
+          path: |
+            benchmark_report.md
+            pr_number.txt
+          if-no-files-found: error

--- a/frontend/benchmark/queries.json
+++ b/frontend/benchmark/queries.json
@@ -1,0 +1,1064 @@
+[
+    {
+        "id": "g001",
+        "q": "ripgrep",
+        "category": "exact",
+        "relevant": ["pkg:ripgrep"]
+    },
+    {
+        "id": "g002",
+        "q": "htop",
+        "category": "exact",
+        "relevant": ["pkg:htop"]
+    },
+    {
+        "id": "g003",
+        "q": "jq",
+        "category": "exact",
+        "relevant": ["pkg:jq"]
+    },
+    {
+        "id": "g004",
+        "q": "tmux",
+        "category": "exact",
+        "relevant": ["pkg:tmux"]
+    },
+    {
+        "id": "g005",
+        "q": "neovim",
+        "category": "exact",
+        "relevant": ["pkg:neovim"]
+    },
+    {
+        "id": "g006",
+        "q": "fzf",
+        "category": "exact",
+        "relevant": ["pkg:fzf"]
+    },
+    {
+        "id": "g007",
+        "q": "bat",
+        "category": "exact",
+        "relevant": ["pkg:bat"]
+    },
+    {
+        "id": "g008",
+        "q": "nginx",
+        "category": "exact",
+        "relevant": [
+            "pkg:nginx",
+            "pkg:nginxMainline",
+            "pkg:nginxStable",
+            "opt:services.nginx.enable"
+        ]
+    },
+    {
+        "id": "g009",
+        "q": "grafana",
+        "category": "exact",
+        "relevant": ["pkg:grafana", "opt:services.grafana.enable"]
+    },
+    {
+        "id": "g010",
+        "q": "prometheus",
+        "category": "exact",
+        "relevant": ["pkg:prometheus", "opt:services.prometheus.enable"]
+    },
+    {
+        "id": "g011",
+        "q": "postgresql",
+        "category": "exact",
+        "relevant": [
+            "pkg:postgresql",
+            "pkg:postgresql_14",
+            "pkg:postgresql_15",
+            "pkg:postgresql_16",
+            "pkg:postgresql_17",
+            "pkg:postgresql_18",
+            "opt:services.postgresql.enable"
+        ]
+    },
+    {
+        "id": "g012",
+        "q": "openssh",
+        "category": "exact",
+        "relevant": ["pkg:openssh", "opt:services.openssh.enable"]
+    },
+    {
+        "id": "g013",
+        "q": "caddy",
+        "category": "exact",
+        "relevant": ["pkg:caddy", "opt:services.caddy.enable"]
+    },
+    {
+        "id": "g014",
+        "q": "gitea",
+        "category": "exact",
+        "relevant": ["pkg:gitea", "opt:services.gitea.enable"]
+    },
+    {
+        "id": "g015",
+        "q": "jellyfin",
+        "category": "exact",
+        "relevant": ["pkg:jellyfin", "opt:services.jellyfin.enable"]
+    },
+    {
+        "id": "g016",
+        "q": "services.openssh.enable",
+        "category": "exact",
+        "relevant": ["opt:services.openssh.enable"]
+    },
+    {
+        "id": "g017",
+        "q": "services.grafana.enable",
+        "category": "exact",
+        "relevant": ["opt:services.grafana.enable"]
+    },
+    {
+        "id": "g018",
+        "q": "networking.firewall.enable",
+        "category": "exact",
+        "relevant": ["opt:networking.firewall.enable"]
+    },
+    {
+        "id": "g019",
+        "q": "services.redis.servers",
+        "category": "exact",
+        "relevant": ["opt:services.redis.servers"]
+    },
+    {
+        "id": "g020",
+        "q": "services.syncthing.enable",
+        "category": "exact",
+        "relevant": ["opt:services.syncthing.enable"]
+    },
+    {
+        "id": "g021",
+        "q": "services.printing.enable",
+        "category": "exact",
+        "relevant": ["opt:services.printing.enable"]
+    },
+    {
+        "id": "g022",
+        "q": "services.nginx.virtualHosts",
+        "category": "exact",
+        "relevant": ["opt:services.nginx.virtualHosts"]
+    },
+    {
+        "id": "g023",
+        "q": "networking.firewall.allowedTCPPorts",
+        "category": "exact",
+        "relevant": ["opt:networking.firewall.allowedTCPPorts"]
+    },
+    {
+        "id": "g024",
+        "q": "services.nextcloud.hostName",
+        "category": "exact",
+        "relevant": ["opt:services.nextcloud.hostName"]
+    },
+    {
+        "id": "g025",
+        "q": "networking.networkmanager.logLevel",
+        "category": "exact",
+        "relevant": ["opt:networking.networkmanager.logLevel"]
+    },
+    {
+        "id": "g026",
+        "q": "postgres",
+        "category": "prefix",
+        "relevant": [
+            "pkg:postgresql",
+            "pkg:postgresql_14",
+            "pkg:postgresql_15",
+            "pkg:postgresql_16",
+            "pkg:postgresql_17",
+            "pkg:postgresql_18",
+            "opt:services.postgresql.enable"
+        ]
+    },
+    {
+        "id": "g027",
+        "q": "graf",
+        "category": "prefix",
+        "relevant": ["pkg:grafana", "opt:services.grafana.enable"]
+    },
+    {
+        "id": "g028",
+        "q": "prom",
+        "category": "prefix",
+        "relevant": ["pkg:prometheus", "opt:services.prometheus.enable"]
+    },
+    {
+        "id": "g029",
+        "q": "ripgr",
+        "category": "prefix",
+        "relevant": ["pkg:ripgrep"]
+    },
+    {
+        "id": "g030",
+        "q": "jelly",
+        "category": "prefix",
+        "relevant": ["pkg:jellyfin", "opt:services.jellyfin.enable"]
+    },
+    {
+        "id": "g031",
+        "q": "syncth",
+        "category": "prefix",
+        "relevant": ["pkg:syncthing", "opt:services.syncthing.enable"]
+    },
+    {
+        "id": "g032",
+        "q": "wireg",
+        "category": "prefix",
+        "relevant": ["opt:networking.wireguard.enable"]
+    },
+    {
+        "id": "g033",
+        "q": "nftab",
+        "category": "prefix",
+        "relevant": ["opt:networking.nftables.enable"]
+    },
+    {
+        "id": "g034",
+        "q": "hypr",
+        "category": "prefix",
+        "relevant": ["opt:programs.hyprland.enable"]
+    },
+    {
+        "id": "g035",
+        "q": "ngin",
+        "category": "prefix",
+        "relevant": [
+            "pkg:nginx",
+            "pkg:nginxMainline",
+            "pkg:nginxStable",
+            "pkg:nginxShibboleth",
+            "opt:services.nginx.enable"
+        ]
+    },
+    {
+        "id": "g036",
+        "q": "mariad",
+        "category": "prefix",
+        "relevant": [
+            "pkg:mariadb",
+            "pkg:mariadb_1011",
+            "pkg:mariadb_106",
+            "pkg:mariadb_114",
+            "pkg:mariadb_118"
+        ]
+    },
+    {
+        "id": "g037",
+        "q": "fail2",
+        "category": "prefix",
+        "relevant": ["pkg:fail2ban", "opt:services.fail2ban.enable"]
+    },
+    {
+        "id": "g038",
+        "q": "tailsc",
+        "category": "prefix",
+        "relevant": ["pkg:tailscale", "opt:services.tailscale.enable"]
+    },
+    {
+        "id": "g039",
+        "q": "nextcl",
+        "category": "prefix",
+        "relevant": [
+            "pkg:nextcloud32",
+            "pkg:nextcloud33",
+            "pkg:nextcloud34",
+            "opt:services.nextcloud.enable"
+        ]
+    },
+    {
+        "id": "g040",
+        "q": "traef",
+        "category": "prefix",
+        "relevant": ["pkg:traefik", "opt:services.traefik.enable"]
+    },
+    {
+        "id": "g041",
+        "q": "cadd",
+        "category": "prefix",
+        "relevant": ["pkg:caddy", "opt:services.caddy.enable"]
+    },
+    {
+        "id": "g042",
+        "q": "transm",
+        "category": "prefix",
+        "relevant": ["pkg:transmission_4", "opt:services.transmission.enable"]
+    },
+    {
+        "id": "g043",
+        "q": "unbou",
+        "category": "prefix",
+        "relevant": ["pkg:unbound", "opt:services.unbound.enable"]
+    },
+    {
+        "id": "g044",
+        "q": "dnsma",
+        "category": "prefix",
+        "relevant": ["pkg:dnsmasq", "opt:services.dnsmasq.enable"]
+    },
+    {
+        "id": "g045",
+        "q": "neovi",
+        "category": "prefix",
+        "relevant": ["pkg:neovim"]
+    },
+    {
+        "id": "g046",
+        "q": "thunder",
+        "category": "prefix",
+        "relevant": ["pkg:thunderbird"]
+    },
+    {
+        "id": "g047",
+        "q": "chrom",
+        "category": "prefix",
+        "relevant": ["pkg:chromium"]
+    },
+    {
+        "id": "g048",
+        "q": "borgb",
+        "category": "prefix",
+        "relevant": ["pkg:borgbackup"]
+    },
+    {
+        "id": "g049",
+        "q": "mosqui",
+        "category": "prefix",
+        "relevant": ["pkg:mosquitto", "opt:services.mosquitto.enable"]
+    },
+    {
+        "id": "g050",
+        "q": "elastic",
+        "category": "prefix",
+        "relevant": [
+            "pkg:elasticsearch",
+            "pkg:elasticsearch7",
+            "opt:services.elasticsearch.enable"
+        ]
+    },
+    {
+        "id": "g051",
+        "q": "ngnix",
+        "category": "typo",
+        "relevant": [
+            "pkg:nginx",
+            "pkg:nginxStable",
+            "pkg:nginxMainline",
+            "opt:services.nginx.enable"
+        ]
+    },
+    {
+        "id": "g052",
+        "q": "postgrsql",
+        "category": "typo",
+        "relevant": [
+            "pkg:postgresql",
+            "pkg:postgresql_14",
+            "pkg:postgresql_15",
+            "pkg:postgresql_16",
+            "pkg:postgresql_17",
+            "pkg:postgresql_18",
+            "pkg:postgresql_jit",
+            "pkg:postgresql_14_jit",
+            "pkg:postgresql_15_jit",
+            "pkg:postgresql_16_jit",
+            "pkg:postgresql_17_jit",
+            "pkg:postgresql_18_jit",
+            "opt:services.postgresql.enable"
+        ]
+    },
+    {
+        "id": "g053",
+        "q": "promethues",
+        "category": "typo",
+        "relevant": ["pkg:prometheus", "opt:services.prometheus.enable"]
+    },
+    {
+        "id": "g054",
+        "q": "grafan",
+        "category": "typo",
+        "relevant": ["pkg:grafana", "opt:services.grafana.enable"]
+    },
+    {
+        "id": "g055",
+        "q": "firefx",
+        "category": "typo",
+        "relevant": ["pkg:firefox"]
+    },
+    {
+        "id": "g056",
+        "q": "ripgrap",
+        "category": "typo",
+        "relevant": ["pkg:ripgrep"]
+    },
+    {
+        "id": "g057",
+        "q": "jellifin",
+        "category": "typo",
+        "relevant": ["pkg:jellyfin", "opt:services.jellyfin.enable"]
+    },
+    {
+        "id": "g058",
+        "q": "sytemd-boot",
+        "category": "typo",
+        "relevant": ["opt:boot.loader.systemd-boot.enable"]
+    },
+    {
+        "id": "g059",
+        "q": "wireguad",
+        "category": "typo",
+        "relevant": ["opt:networking.wireguard.enable"]
+    },
+    {
+        "id": "g060",
+        "q": "samaba",
+        "category": "typo",
+        "relevant": [
+            "pkg:samba",
+            "pkg:samba4",
+            "pkg:samba4Full",
+            "pkg:sambaFull",
+            "opt:services.samba.enable"
+        ]
+    },
+    {
+        "id": "g061",
+        "q": "redsi",
+        "category": "typo",
+        "relevant": ["pkg:redis"]
+    },
+    {
+        "id": "g062",
+        "q": "openssg",
+        "category": "typo",
+        "relevant": [
+            "pkg:openssh",
+            "pkg:opensshWithKerberos",
+            "pkg:openssh_gssapi",
+            "pkg:openssh_hpn",
+            "pkg:openssh_hpnWithKerberos",
+            "opt:services.openssh.enable"
+        ]
+    },
+    {
+        "id": "g063",
+        "q": "kubctl",
+        "category": "typo",
+        "relevant": ["pkg:kubectl"]
+    },
+    {
+        "id": "g064",
+        "q": "terrafrom",
+        "category": "typo",
+        "relevant": ["pkg:terraform", "pkg:terraform_1"]
+    },
+    {
+        "id": "g065",
+        "q": "chromiun",
+        "category": "typo",
+        "relevant": ["pkg:chromium"]
+    },
+    {
+        "id": "g066",
+        "q": "thunderbrid",
+        "category": "typo",
+        "relevant": ["pkg:thunderbird"]
+    },
+    {
+        "id": "g067",
+        "q": "dcoker",
+        "category": "typo",
+        "relevant": [
+            "pkg:docker",
+            "pkg:docker_25",
+            "pkg:docker_29",
+            "opt:virtualisation.docker.enable"
+        ]
+    },
+    {
+        "id": "g068",
+        "q": "nextcoud",
+        "category": "typo",
+        "relevant": [
+            "pkg:nextcloud32",
+            "pkg:nextcloud33",
+            "pkg:nextcloud34",
+            "opt:services.nextcloud.enable"
+        ]
+    },
+    {
+        "id": "g069",
+        "q": "gitae",
+        "category": "typo",
+        "relevant": ["pkg:gitea", "opt:services.gitea.enable"]
+    },
+    {
+        "id": "g070",
+        "q": "vaultwardn",
+        "category": "typo",
+        "relevant": ["pkg:vaultwarden", "opt:services.vaultwarden.enable"]
+    },
+    {
+        "id": "g071",
+        "q": "tailscle",
+        "category": "typo",
+        "relevant": ["pkg:tailscale", "opt:services.tailscale.enable"]
+    },
+    {
+        "id": "g072",
+        "q": "fial2ban",
+        "category": "typo",
+        "relevant": ["pkg:fail2ban", "opt:services.fail2ban.enable"]
+    },
+    {
+        "id": "g073",
+        "q": "mosquito",
+        "category": "typo",
+        "relevant": ["pkg:mosquitto", "opt:services.mosquitto.enable"]
+    },
+    {
+        "id": "g074",
+        "q": "syncthign",
+        "category": "typo",
+        "relevant": ["pkg:syncthing", "opt:services.syncthing.enable"]
+    },
+    {
+        "id": "g075",
+        "q": "cady",
+        "category": "typo",
+        "relevant": ["pkg:caddy", "opt:services.caddy.enable"]
+    },
+    {
+        "id": "g076",
+        "q": "services.nginx",
+        "category": "dotted",
+        "relevant": ["opt:services.nginx.enable"]
+    },
+    {
+        "id": "g077",
+        "q": "virtualisation.docker",
+        "category": "dotted",
+        "relevant": ["opt:virtualisation.docker.enable"]
+    },
+    {
+        "id": "g078",
+        "q": "services.openssh",
+        "category": "dotted",
+        "relevant": ["opt:services.openssh.enable"]
+    },
+    {
+        "id": "g079",
+        "q": "services.postgresql",
+        "category": "dotted",
+        "relevant": ["opt:services.postgresql.enable"]
+    },
+    {
+        "id": "g080",
+        "q": "services.grafana",
+        "category": "dotted",
+        "relevant": ["opt:services.grafana.enable"]
+    },
+    {
+        "id": "g081",
+        "q": "services.prometheus",
+        "category": "dotted",
+        "relevant": ["opt:services.prometheus.enable"]
+    },
+    {
+        "id": "g082",
+        "q": "networking.firewall",
+        "category": "dotted",
+        "relevant": ["opt:networking.firewall.enable"]
+    },
+    {
+        "id": "g083",
+        "q": "networking.wireguard",
+        "category": "dotted",
+        "relevant": ["opt:networking.wireguard.enable"]
+    },
+    {
+        "id": "g084",
+        "q": "services.redis",
+        "category": "dotted",
+        "relevant": ["opt:services.redis.servers"]
+    },
+    {
+        "id": "g085",
+        "q": "services.caddy",
+        "category": "dotted",
+        "relevant": ["opt:services.caddy.enable"]
+    },
+    {
+        "id": "g086",
+        "q": "boot.loader.systemd-boot",
+        "category": "dotted",
+        "relevant": ["opt:boot.loader.systemd-boot.enable"]
+    },
+    {
+        "id": "g087",
+        "q": "programs.hyprland",
+        "category": "dotted",
+        "relevant": ["opt:programs.hyprland.enable"]
+    },
+    {
+        "id": "g088",
+        "q": "services.jellyfin",
+        "category": "dotted",
+        "relevant": ["opt:services.jellyfin.enable"]
+    },
+    {
+        "id": "g089",
+        "q": "services.syncthing",
+        "category": "dotted",
+        "relevant": ["opt:services.syncthing.enable"]
+    },
+    {
+        "id": "g090",
+        "q": "hardware.bluetooth",
+        "category": "dotted",
+        "relevant": ["opt:hardware.bluetooth.enable"]
+    },
+    {
+        "id": "g091",
+        "q": "services.samba",
+        "category": "dotted",
+        "relevant": ["opt:services.samba.enable"]
+    },
+    {
+        "id": "g092",
+        "q": "services.tailscale",
+        "category": "dotted",
+        "relevant": ["opt:services.tailscale.enable"]
+    },
+    {
+        "id": "g093",
+        "q": "services.restic",
+        "category": "dotted",
+        "relevant": ["opt:services.restic.backups"]
+    },
+    {
+        "id": "g094",
+        "q": "services.openssh.ports",
+        "category": "dotted",
+        "relevant": ["opt:services.openssh.ports"]
+    },
+    {
+        "id": "g095",
+        "q": "services.nginx.enable",
+        "category": "dotted",
+        "relevant": ["opt:services.nginx.enable"]
+    },
+    {
+        "id": "g096",
+        "q": "virtualisation.docker.enable",
+        "category": "dotted",
+        "relevant": ["opt:virtualisation.docker.enable"]
+    },
+    {
+        "id": "g097",
+        "q": "services.grafana.settings",
+        "category": "dotted",
+        "relevant": ["opt:services.grafana.settings"]
+    },
+    {
+        "id": "g098",
+        "q": "services.postgresql.dataDir",
+        "category": "dotted",
+        "relevant": ["opt:services.postgresql.dataDir"]
+    },
+    {
+        "id": "g099",
+        "q": "services.mysql",
+        "category": "dotted",
+        "relevant": ["opt:services.mysql.enable"]
+    },
+    {
+        "id": "g100",
+        "q": "services.fail2ban",
+        "category": "dotted",
+        "relevant": ["opt:services.fail2ban.enable"]
+    },
+    {
+        "id": "g101",
+        "q": "docker container",
+        "category": "multiterm",
+        "relevant": [
+            "pkg:docker",
+            "pkg:docker_25",
+            "pkg:docker_29",
+            "opt:virtualisation.docker.enable"
+        ]
+    },
+    {
+        "id": "g102",
+        "q": "ssh daemon",
+        "category": "multiterm",
+        "relevant": [
+            "pkg:openssh",
+            "pkg:opensshWithKerberos",
+            "pkg:openssh_gssapi",
+            "pkg:openssh_hpn",
+            "pkg:openssh_hpnWithKerberos",
+            "opt:services.openssh.enable"
+        ]
+    },
+    {
+        "id": "g103",
+        "q": "home assistant",
+        "category": "multiterm",
+        "relevant": ["pkg:home-assistant", "opt:services.home-assistant.enable"]
+    },
+    {
+        "id": "g104",
+        "q": "matrix synapse",
+        "category": "multiterm",
+        "relevant": ["pkg:matrix-synapse", "opt:services.matrix-synapse.enable"]
+    },
+    {
+        "id": "g105",
+        "q": "docker compose",
+        "category": "multiterm",
+        "relevant": ["pkg:docker-compose"]
+    },
+    {
+        "id": "g106",
+        "q": "vault warden",
+        "category": "multiterm",
+        "relevant": ["pkg:vaultwarden", "opt:services.vaultwarden.enable"]
+    },
+    {
+        "id": "g107",
+        "q": "next cloud",
+        "category": "multiterm",
+        "relevant": [
+            "pkg:nextcloud32",
+            "pkg:nextcloud33",
+            "pkg:nextcloud34",
+            "opt:services.nextcloud.enable"
+        ]
+    },
+    {
+        "id": "g108",
+        "q": "paperless ngx",
+        "category": "multiterm",
+        "relevant": ["pkg:paperless-ngx"]
+    },
+    {
+        "id": "g109",
+        "q": "network manager",
+        "category": "multiterm",
+        "relevant": ["opt:networking.networkmanager.enable"]
+    },
+    {
+        "id": "g110",
+        "q": "virtual hosts",
+        "category": "multiterm",
+        "relevant": ["opt:services.nginx.virtualHosts"]
+    },
+    {
+        "id": "g111",
+        "q": "allowed tcp ports",
+        "category": "multiterm",
+        "relevant": ["opt:networking.firewall.allowedTCPPorts"]
+    },
+    {
+        "id": "g112",
+        "q": "allowed udp ports",
+        "category": "multiterm",
+        "relevant": ["opt:networking.firewall.allowedUDPPorts"]
+    },
+    {
+        "id": "g113",
+        "q": "enable on boot",
+        "category": "multiterm",
+        "relevant": ["opt:virtualisation.docker.enableOnBoot"]
+    },
+    {
+        "id": "g114",
+        "q": "allow ping",
+        "category": "multiterm",
+        "relevant": ["opt:networking.firewall.allowPing"]
+    },
+    {
+        "id": "g115",
+        "q": "host keys",
+        "category": "multiterm",
+        "relevant": ["opt:services.openssh.hostKeys"]
+    },
+    {
+        "id": "g116",
+        "q": "listen addresses",
+        "category": "multiterm",
+        "relevant": ["opt:services.openssh.listenAddresses"]
+    },
+    {
+        "id": "g117",
+        "q": "enable nvidia",
+        "category": "multiterm",
+        "relevant": ["opt:virtualisation.docker.enableNvidia"]
+    },
+    {
+        "id": "g118",
+        "q": "object storage",
+        "category": "multiterm",
+        "relevant": ["pkg:minio", "opt:services.minio.enable"]
+    },
+    {
+        "id": "g119",
+        "q": "secret management",
+        "category": "multiterm",
+        "relevant": ["pkg:vault", "opt:services.vault.enable"]
+    },
+    {
+        "id": "g120",
+        "q": "network firewall",
+        "category": "multiterm",
+        "relevant": ["opt:networking.firewall.enable"]
+    },
+    {
+        "id": "g121",
+        "q": "wireguard vpn",
+        "category": "multiterm",
+        "relevant": ["opt:networking.wireguard.enable"]
+    },
+    {
+        "id": "g122",
+        "q": "container runtime",
+        "category": "multiterm",
+        "relevant": [
+            "pkg:docker",
+            "pkg:docker_25",
+            "pkg:docker_29",
+            "opt:virtualisation.docker.enable",
+            "pkg:podman",
+            "opt:virtualisation.podman.enable"
+        ]
+    },
+    {
+        "id": "g123",
+        "q": "mesh vpn",
+        "category": "multiterm",
+        "relevant": ["pkg:tailscale", "opt:services.tailscale.enable"]
+    },
+    {
+        "id": "g124",
+        "q": "password manager",
+        "category": "multiterm",
+        "relevant": ["pkg:vaultwarden", "opt:services.vaultwarden.enable"]
+    },
+    {
+        "id": "g125",
+        "q": "boot loader",
+        "category": "multiterm",
+        "relevant": [
+            "opt:boot.loader.systemd-boot.enable",
+            "opt:boot.loader.grub.enable"
+        ]
+    },
+    {
+        "id": "g126",
+        "q": "web server",
+        "category": "intent",
+        "relevant": [
+            "pkg:nginx",
+            "pkg:nginxMainline",
+            "pkg:nginxStable",
+            "pkg:nginxShibboleth",
+            "opt:services.nginx.enable",
+            "pkg:caddy",
+            "opt:services.caddy.enable"
+        ]
+    },
+    {
+        "id": "g127",
+        "q": "reverse proxy",
+        "category": "intent",
+        "relevant": [
+            "pkg:nginx",
+            "pkg:nginxMainline",
+            "pkg:nginxStable",
+            "pkg:nginxShibboleth",
+            "opt:services.nginx.enable",
+            "pkg:caddy",
+            "opt:services.caddy.enable",
+            "pkg:traefik",
+            "opt:services.traefik.enable"
+        ]
+    },
+    {
+        "id": "g128",
+        "q": "version control system",
+        "category": "intent",
+        "relevant": ["pkg:git", "pkg:gitFull", "pkg:gitMinimal", "pkg:gitSVN"]
+    },
+    {
+        "id": "g129",
+        "q": "interactive process viewer",
+        "category": "intent",
+        "relevant": ["pkg:htop", "pkg:btop", "pkg:xfce4-taskmanager"]
+    },
+    {
+        "id": "g130",
+        "q": "virtual private network",
+        "category": "intent",
+        "relevant": [
+            "opt:networking.wireguard.enable",
+            "pkg:tailscale",
+            "opt:services.tailscale.enable"
+        ]
+    },
+    {
+        "id": "g131",
+        "q": "self hosted password manager",
+        "category": "intent",
+        "relevant": ["pkg:vaultwarden", "opt:services.vaultwarden.enable"]
+    },
+    {
+        "id": "g132",
+        "q": "media streaming server",
+        "category": "intent",
+        "relevant": ["pkg:jellyfin", "opt:services.jellyfin.enable"]
+    },
+    {
+        "id": "g133",
+        "q": "backup tool",
+        "category": "intent",
+        "relevant": ["pkg:restic", "pkg:borgbackup"]
+    },
+    {
+        "id": "g134",
+        "q": "file synchronization",
+        "category": "intent",
+        "relevant": [
+            "pkg:syncthing",
+            "opt:services.syncthing.enable",
+            "pkg:maestral"
+        ]
+    },
+    {
+        "id": "g135",
+        "q": "relational database server",
+        "category": "intent",
+        "relevant": [
+            "pkg:postgresql",
+            "pkg:postgresql_14",
+            "pkg:postgresql_15",
+            "pkg:postgresql_16",
+            "pkg:postgresql_17",
+            "pkg:postgresql_18",
+            "opt:services.postgresql.enable",
+            "pkg:mariadb",
+            "pkg:mariadb_1011",
+            "pkg:mariadb_106",
+            "pkg:mariadb_114",
+            "pkg:mariadb_118",
+            "pkg:mysql84",
+            "opt:services.mysql.enable"
+        ]
+    },
+    {
+        "id": "g136",
+        "q": "in memory key value store",
+        "category": "intent",
+        "relevant": ["pkg:redis", "opt:services.redis.servers.<name>.enable"]
+    },
+    {
+        "id": "g137",
+        "q": "secret storage",
+        "category": "intent",
+        "relevant": ["pkg:vault", "opt:services.vault.enable"]
+    },
+    {
+        "id": "g138",
+        "q": "s3 compatible object storage",
+        "category": "intent",
+        "relevant": ["pkg:minio", "opt:services.minio.enable"]
+    },
+    {
+        "id": "g139",
+        "q": "metrics monitoring stack",
+        "category": "intent",
+        "relevant": [
+            "pkg:prometheus",
+            "opt:services.prometheus.enable",
+            "pkg:grafana",
+            "opt:services.grafana.enable"
+        ]
+    },
+    {
+        "id": "g140",
+        "q": "document management",
+        "category": "intent",
+        "relevant": ["pkg:paperless-ngx", "opt:services.paperless.enable"]
+    },
+    {
+        "id": "g141",
+        "q": "printing support",
+        "category": "intent",
+        "relevant": ["pkg:cups", "opt:services.printing.enable"]
+    },
+    {
+        "id": "g142",
+        "q": "wireless bluetooth support",
+        "category": "intent",
+        "relevant": ["opt:hardware.bluetooth.enable"]
+    },
+    {
+        "id": "g143",
+        "q": "caching dns resolver",
+        "category": "intent",
+        "relevant": [
+            "pkg:unbound",
+            "opt:services.unbound.enable",
+            "pkg:dnsmasq",
+            "opt:services.dnsmasq.enable"
+        ]
+    },
+    {
+        "id": "g144",
+        "q": "text editor",
+        "category": "intent",
+        "relevant": ["pkg:emacs", "pkg:emacs30", "pkg:neovim", "pkg:vim"]
+    },
+    {
+        "id": "g145",
+        "q": "graphical web browser",
+        "category": "intent",
+        "relevant": ["pkg:firefox", "pkg:chromium"]
+    },
+    {
+        "id": "g146",
+        "q": "desktop email client",
+        "category": "intent",
+        "relevant": ["pkg:thunderbird"]
+    },
+    {
+        "id": "g147",
+        "q": "video player",
+        "category": "intent",
+        "relevant": ["pkg:vlc", "pkg:mpv"]
+    },
+    {
+        "id": "g148",
+        "q": "raster image editor",
+        "category": "intent",
+        "relevant": ["pkg:gimp", "pkg:gimp2", "pkg:gimp2-with-plugins"]
+    },
+    {
+        "id": "g149",
+        "q": "bittorrent client",
+        "category": "intent",
+        "relevant": ["pkg:transmission_4", "opt:services.transmission.enable"]
+    },
+    {
+        "id": "g150",
+        "q": "terminal multiplexer",
+        "category": "intent",
+        "relevant": ["pkg:tmux"]
+    }
+]

--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Relevance benchmark test driver
+ *
+ * scores curated queries against our live ES instance.
+ *
+ * Usage:
+ *   node benchmark/run.mjs [--queries <path>] [--channel <branch>] [--schema <n>] [--k <n>]
+ *
+ */
+
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_DIR = resolve(__dirname, "..");
+const REPO_ROOT = resolve(FRONTEND_DIR, "..");
+
+/// Grep the schema version
+function frontendSchema() {
+    const version_nix = readFileSync(join(REPO_ROOT, "version.nix"), "utf8");
+    const match = version_nix.match(/frontend\s*=\s*"(\d+)"/);
+    if (!match) {
+        throw new Error("could not parse `frontend` schema from version.nix");
+    }
+    return match[1];
+}
+
+const { values: args } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+        queries: { type: "string", default: join(__dirname, "queries.json") },
+        channel: { type: "string", default: "nixos-unstable" },
+        schema: { type: "string" },
+        k: { type: "string", default: "10" },
+    },
+    strict: false,
+});
+
+// Settings
+const K = parseInt(args.k, 10);
+const SCHEMA = args.schema ?? frontendSchema();
+const INDEX = `latest-${SCHEMA}-${args.channel}`;
+const ES_URL =
+    process.env.ELASTICSEARCH_URL || "https://search.nixos.org/backend";
+const ES_USER = process.env.ELASTICSEARCH_USERNAME || "aWVSALXpZv";
+const ES_PASS =
+    process.env.ELASTICSEARCH_PASSWORD || "X8gPHnzL52wFEekuxsfQ9cSh";
+const AUTH = "Basic " + Buffer.from(`${ES_USER}:${ES_PASS}`).toString("base64");
+
+// Compile elm
+const tmpDir = mkdtempSync(join(tmpdir(), "nixos-search-benchmark-"));
+const workerPath = join(tmpDir, "benchmark.js");
+console.error(`[benchmark] compiling Benchmark.elm → ${workerPath}`);
+execSync(
+    `node_modules/.bin/elm make src/Benchmark.elm --optimize --output ${workerPath}`,
+    { cwd: FRONTEND_DIR, stdio: ["ignore", "ignore", "inherit"] },
+);
+
+const require = createRequire(import.meta.url);
+const { Elm } = require(workerPath);
+const app = Elm.Benchmark.init({ flags: {} });
+
+// Helpers
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+const MAX_ATTEMPTS = 5;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function esSearch(bodyJson) {
+    const url = `${ES_URL}/${INDEX}/_search`;
+    let lastErr;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+            const resp = await fetch(url, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Authorization: AUTH },
+                body: bodyJson,
+            });
+            if (resp.ok) return resp.json();
+            const text = await resp.text();
+            // Non-retryable (e.g. auth/query errors): fail immediately.
+            if (!RETRYABLE_STATUS.has(resp.status)) {
+                throw new Error(`ES ${resp.status}: ${text}`);
+            }
+            lastErr = new Error(`ES ${resp.status}: ${text}`);
+        } catch (err) {
+            // fetch() rejects on network faults (ECONNRESET, DNS, TLS); retry those.
+            if (err instanceof TypeError && err.cause) {
+                lastErr = err;
+            } else {
+                throw err;
+            }
+        }
+        if (attempt < MAX_ATTEMPTS) {
+            // Exponential backoff with jitter: ~0.5s, 1s, 2s, 4s.
+            const backoff = 500 * 2 ** (attempt - 1) + Math.random() * 250;
+            console.error(
+                `[benchmark] request failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${lastErr.message}; retrying in ${Math.round(backoff)}ms`,
+            );
+            await sleep(backoff);
+        }
+    }
+    throw lastErr;
+}
+
+function mergeHits(pkgData, optData, k) {
+    const hits = [];
+    for (const h of pkgData.hits.hits) {
+        const name = h._source?.package_attr_name;
+        if (name) hits.push([h._score, "pkg:" + name]);
+    }
+    for (const h of optData.hits.hits) {
+        const name = h._source?.option_name;
+        if (name) hits.push([h._score, "opt:" + name]);
+    }
+    hits.sort((a, b) => b[0] - a[0]);
+    const out = [];
+    const seen = new Set();
+    for (const [, id] of hits) {
+        if (!seen.has(id)) {
+            seen.add(id);
+            out.push(id);
+        }
+        if (out.length === k) break;
+    }
+    return out;
+}
+
+function reciprocalRank(ranked, relevant) {
+    const rel = new Set(relevant);
+    for (let i = 0; i < ranked.length; i++) {
+        if (rel.has(ranked[i])) return 1 / (i + 1);
+    }
+    return 0;
+}
+
+function successAtK(ranked, relevant, k) {
+    const rel = new Set(relevant);
+    return ranked.slice(0, k).some((id) => rel.has(id)) ? 1 : 0;
+}
+
+function recallAtK(ranked, relevant, k) {
+    const rel = new Set(relevant);
+    const hits = ranked.slice(0, k).filter((id) => rel.has(id)).length;
+    return relevant.length > 0 ? hits / relevant.length : 0;
+}
+
+const queries = JSON.parse(readFileSync(args.queries, "utf8"));
+const results = [];
+
+function nextBody(query, k) {
+    return new Promise((resolve) => {
+        const sub = app.ports.gotBodies.subscribe(function handler(bodies) {
+            app.ports.gotBodies.unsubscribe(handler);
+            resolve(bodies);
+        });
+        app.ports.sendQuery.send({ query, k });
+    });
+}
+
+console.error(`[benchmark] scoring ${queries.length} queries against ${INDEX}`);
+
+for (const q of queries) {
+    const bodies = await nextBody(q.q, K);
+    const [pkgData, optData] = await Promise.all([
+        esSearch(bodies.packages),
+        esSearch(bodies.options),
+    ]);
+    const ranked = mergeHits(pkgData, optData, K);
+    results.push({
+        id: q.id,
+        q: q.q,
+        category: q.category,
+        relevant: q.relevant,
+        ranked,
+        mrr: reciprocalRank(ranked, q.relevant),
+        success: successAtK(ranked, q.relevant, K),
+        recall: recallAtK(ranked, q.relevant, K),
+    });
+}
+
+function mean(arr) {
+    return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+const overall = {
+    success: mean(results.map((r) => r.success)),
+    mrr: mean(results.map((r) => r.mrr)),
+    recall: mean(results.map((r) => r.recall)),
+};
+
+const byCategory = {};
+for (const r of results) {
+    (byCategory[r.category] ??= []).push(r);
+}
+
+const table = (header, rows) =>
+    [
+        `| ${header.join(" | ")} |`,
+        `| ${header.map(() => "---").join(" | ")} |`,
+        ...rows.map((r) => `| ${r.join(" | ")} |`),
+    ].join("\n");
+
+const lines = [
+    "## Relevance benchmark: frontend query vs deployed ES",
+    "",
+    `> Index: \`${INDEX}\` (${results.length} queries, k=${K})  `,
+    `> metrics: (Success@${K}, MRR, Recall@${K}).`,
+    "",
+    "### Overall",
+    "",
+    table(
+        ["metric", "value"],
+        [
+            ["Success@" + K, overall.success.toFixed(3)],
+            ["MRR", overall.mrr.toFixed(3)],
+            ["Recall@" + K, overall.recall.toFixed(3)],
+        ],
+    ),
+    "",
+    "### By category",
+    "",
+    table(
+        ["category", "n", "Success@" + K, "MRR"],
+        Object.entries(byCategory)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([cat, rs]) => [
+                cat,
+                String(rs.length),
+                mean(rs.map((r) => r.success)).toFixed(3),
+                mean(rs.map((r) => r.mrr)).toFixed(3),
+            ]),
+    ),
+    "",
+    "<details>",
+    "<summary>Per-query results</summary>",
+    "",
+    table(
+        ["id", "q", "category", "success", "mrr", "top-3 ranked"],
+        results.map((r) => [
+            r.id,
+            r.q,
+            r.category,
+            r.success.toFixed(0),
+            r.mrr.toFixed(3),
+            r.ranked.slice(0, 3).join(", "),
+        ]),
+    ),
+    "",
+    "</details>",
+];
+
+console.log(lines.join("\n"));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
         "dev": "npm run build:autocomplete && rsbuild dev",
         "preview": "rsbuild preview",
         "review": "elm-review",
-        "test": "elm-test"
+        "test": "elm-test",
+        "benchmark": "node benchmark/run.mjs"
     },
     "devDependencies": {
         "@rsbuild/core": "^1.2.0",

--- a/frontend/src/Benchmark.elm
+++ b/frontend/src/Benchmark.elm
@@ -1,0 +1,47 @@
+port module Benchmark exposing (main)
+
+{-| Headless worker: receives query emits two Elasticsearch
+request bodies
+
+  - Packages
+  - Options
+
+Used for benchmarking
+
+-}
+
+import Json.Encode
+import Page.Options
+import Page.Packages
+import Platform
+import Search
+
+
+port sendQuery : ({ query : String, k : Int } -> msg) -> Sub msg
+
+
+port gotBodies : { packages : String, options : String } -> Cmd msg
+
+
+main : Program () () { query : String, k : Int }
+main =
+    Platform.worker
+        { init = \_ -> ( (), Cmd.none )
+        , update = \msg _ -> ( (), emit msg )
+        , subscriptions = \_ -> sendQuery identity
+        }
+
+
+emit : { query : String, k : Int } -> Cmd msg
+emit { query, k } =
+    let
+        pkgBody =
+            Page.Packages.encodeRequestBody query 0 k Nothing Search.Relevance
+
+        optBody =
+            Page.Options.encodeRequestBody [ "option" ] query 0 k Search.Relevance
+    in
+    gotBodies
+        { packages = Json.Encode.encode 0 pkgBody
+        , options = Json.Encode.encode 0 optBody
+        }

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -6,6 +6,7 @@ module Page.Options exposing
     , ResultItemSource
     , decodeResultAggregations
     , decodeResultItemSource
+    , encodeRequestBody
     , init
     , makeRequest
     , makeRequestBody
@@ -52,6 +53,7 @@ import Html.Events
 import Http exposing (Body)
 import Json.Decode
 import Json.Decode.Pipeline
+import Json.Encode
 import List.Extra
 import Ports
 import RemoteData
@@ -820,9 +822,9 @@ makeRequest options nixosChannels _ channel query from size _ sort activeSource 
         |> Cmd.map SearchMsg
 
 
-makeRequestBody : List String -> String -> Int -> Int -> Search.Sort -> Body
-makeRequestBody types query from size sort =
-    Search.makeRequestBody
+encodeRequestBody : List String -> String -> Int -> Int -> Search.Sort -> Json.Encode.Value
+encodeRequestBody types query from size sort =
+    Search.encodeRequestBody
         (String.trim query)
         from
         size
@@ -842,6 +844,11 @@ makeRequestBody types query from size sort =
         ]
         [ "option_description^3" ]
         Nothing
+
+
+makeRequestBody : List String -> String -> Int -> Int -> Search.Sort -> Body
+makeRequestBody types query from size sort =
+    Http.jsonBody (encodeRequestBody types query from size sort)
 
 
 

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -12,6 +12,7 @@ module Page.Packages exposing
     , ResultPackageTeam
     , decodeResultAggregations
     , decodeResultItemSource
+    , encodeRequestBody
     , init
     , makeRequest
     , makeRequestBody
@@ -1209,8 +1210,8 @@ makeRequest options nixosChannels _ channel query from size maybeBuckets sort =
         |> Cmd.map SearchMsg
 
 
-makeRequestBody : String -> Int -> Int -> Maybe String -> Search.Sort -> Body
-makeRequestBody query from size maybeBuckets sort =
+encodeRequestBody : String -> Int -> Int -> Maybe String -> Search.Sort -> Json.Encode.Value
+encodeRequestBody query from size maybeBuckets sort =
     let
         currentBuckets =
             initBuckets maybeBuckets
@@ -1262,7 +1263,7 @@ makeRequestBody query from size maybeBuckets sort =
               )
             ]
     in
-    Search.makeRequestBody
+    Search.encodeRequestBody
         (String.trim query)
         from
         size
@@ -1287,6 +1288,11 @@ makeRequestBody query from size maybeBuckets sort =
         ]
         [ "package_description^3", "package_longDescription^1" ]
         (Just "package_attr_name")
+
+
+makeRequestBody : String -> Int -> Int -> Maybe String -> Search.Sort -> Body
+makeRequestBody query from size maybeBuckets sort =
+    Http.jsonBody (encodeRequestBody query from size maybeBuckets sort)
 
 
 

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -13,16 +13,16 @@ module Search exposing
     , ResultHitsTotal
     , ResultItem
     , SearchResult
-    , Sort
+    , Sort(..)
     , Terms
     , decodeAggregation
     , decodeNixOSChannels
     , decodeResolvedFlake
     , defaultFlakeId
     , elementId
+    , encodeRequestBody
     , init
     , makeRequest
-    , makeRequestBody
     , makeRequestTask
     , onClickStop
     , shouldLoad
@@ -1674,7 +1674,7 @@ rescoreQuery field =
     )
 
 
-makeRequestBody :
+encodeRequestBody :
     String
     -> Int
     -> Int
@@ -1688,8 +1688,8 @@ makeRequestBody :
     -> List ( String, Float )
     -> List String
     -> Maybe String
-    -> Http.Body
-makeRequestBody query from sizeRaw sort types sortField otherSortFields terms filterByBuckets mainFields fields phraseFields rescoreField =
+    -> Json.Encode.Value
+encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms filterByBuckets mainFields fields phraseFields rescoreField =
     let
         -- you can not request more then 10000 results otherwise it will return 404
         size =
@@ -1733,71 +1733,69 @@ makeRequestBody query from sizeRaw sort types sortField otherSortFields terms fi
             else
                 toSortQuery sort sortField otherSortFields
     in
-    Http.jsonBody
-        (Json.Encode.object
-            ([ ( "from"
-               , Json.Encode.int from
-               )
-             , ( "size"
-               , Json.Encode.int size
-               )
-             , sortQuery
-             , toAggregations terms
-             , ( "query"
-               , Json.Encode.object
-                    [ ( "bool"
-                      , Json.Encode.object
-                            [ ( "filter"
-                              , Json.Encode.list Json.Encode.object
-                                    (List.append
-                                        [ filterByType types ]
-                                        (if List.isEmpty filterByBuckets then
-                                            []
+    Json.Encode.object
+        ([ ( "from"
+           , Json.Encode.int from
+           )
+         , ( "size"
+           , Json.Encode.int size
+           )
+         , sortQuery
+         , toAggregations terms
+         , ( "query"
+           , Json.Encode.object
+                [ ( "bool"
+                  , Json.Encode.object
+                        [ ( "filter"
+                          , Json.Encode.list Json.Encode.object
+                                (List.append
+                                    [ filterByType types ]
+                                    (if List.isEmpty filterByBuckets then
+                                        []
 
-                                         else
-                                            [ filterByBuckets ]
-                                        )
+                                     else
+                                        [ filterByBuckets ]
                                     )
-                              )
-                            , ( "must_not"
-                              , Json.Encode.list Json.Encode.object
-                                    (negativeWords
-                                        |> List.concatMap dashUnderscoreVariants
-                                        |> List.Extra.unique
-                                        |> List.concatMap (\w -> List.map (\mf -> toWildcardQuery mf w) mainFields)
+                                )
+                          )
+                        , ( "must_not"
+                          , Json.Encode.list Json.Encode.object
+                                (negativeWords
+                                    |> List.concatMap dashUnderscoreVariants
+                                    |> List.Extra.unique
+                                    |> List.concatMap (\w -> List.map (\mf -> toWildcardQuery mf w) mainFields)
+                                )
+                          )
+                        , ( "must"
+                          , Json.Encode.list Json.Encode.object
+                                [ [ ( "dis_max"
+                                    , Json.Encode.object
+                                        [ ( "tie_breaker", Json.Encode.float 0.7 )
+                                        , ( "queries"
+                                          , Json.Encode.list Json.Encode.object
+                                                (searchFields positiveWords mainFields fields)
+                                          )
+                                        ]
                                     )
-                              )
-                            , ( "must"
-                              , Json.Encode.list Json.Encode.object
-                                    [ [ ( "dis_max"
-                                        , Json.Encode.object
-                                            [ ( "tie_breaker", Json.Encode.float 0.7 )
-                                            , ( "queries"
-                                              , Json.Encode.list Json.Encode.object
-                                                    (searchFields positiveWords mainFields fields)
-                                              )
-                                            ]
-                                        )
-                                      ]
-                                    ]
-                              )
-                            , ( "should"
-                              , Json.Encode.list Json.Encode.object
-                                    (shouldClauses primaryField positiveWords phraseFields)
-                              )
-                            ]
-                      )
-                    ]
-               )
-             ]
-                ++ (case ( rescoreActive, rescoreField ) of
-                        ( True, Just field ) ->
-                            [ rescoreQuery field ]
+                                  ]
+                                ]
+                          )
+                        , ( "should"
+                          , Json.Encode.list Json.Encode.object
+                                (shouldClauses primaryField positiveWords phraseFields)
+                          )
+                        ]
+                  )
+                ]
+           )
+         ]
+            ++ (case ( rescoreActive, rescoreField ) of
+                    ( True, Just field ) ->
+                        [ rescoreQuery field ]
 
-                        _ ->
-                            []
-                   )
-            )
+                    _ ->
+                        []
+               )
         )
 
 


### PR DESCRIPTION
Adds a benchmark report for search results

Inspired by https://github.com/hsjobeki/nixos-search-queries.

- Added 150 curated queries in different categories.
- Report metrics for each category.

New workflow should post a comment on PRs touching these files.

TODOs for follow up PRs:

- Before / After comparison
- Also move "attr_name" boost and other query modifications into one file.
- Test backend updates



Assisted-by: Opus-4-8