### PR TITLE
feat(flakes): gitlab:nobodyinperson/yannix

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -596,6 +596,11 @@ repo = "zed"
 
 [[sources]]
 type = "gitlab"
+owner = "nobodyinperson"
+repo = "yannix"
+
+[[sources]]
+type = "gitlab"
 owner = "pi-lar"
 repo = "neuropil"
 


### PR DESCRIPTION
Adds my yannix flake. I tried really hard to check this locally but no matter what I did (envvars, opensearch-vm, npm run, etc. according to README) I couldn't get it to show in the `http://localhost:3001/flakes`. 🤷