### PR TITLE
flake-info: add package metadata from repology 

### DIFF
--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -60,13 +60,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 
+      - name: Compute cache date
+        id: date
+        shell: sh
+        run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Repology counts from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: repology-counts.json
+          # Falls back to the newest available daily cache; a total miss (e.g. a
+          # branch outside the default-branch cache scope) leaves the file
+          # absent, and the importer warns and drops the Repology signal.
+          key: repology-counts-v1-${{ steps.date.outputs.date }}
+          restore-keys: |
+            repology-counts-v1-
+
       - name: Import ${{ matrix.channel }} channel
         if: github.repository_owner == 'NixOS'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: sh
         run: |
-          nix run --accept-flake-config .#flake-info -- --push --elastic-schema-version=$(nix eval --raw --file ./version.nix import) nixpkgs ${{ matrix.channel }}
+          nix run --accept-flake-config .#flake-info -- --push --elastic-schema-version=$(nix eval --raw --file ./version.nix import) nixpkgs ${{ matrix.channel }} --repology-counts-file repology-counts.json
 
       - name: Warmup ${{ matrix.channel }} channel
         if: github.repository_owner == 'NixOS'

--- a/.github/workflows/update-repology-counts.yml
+++ b/.github/workflows/update-repology-counts.yml
@@ -1,0 +1,63 @@
+name: "Daily Repology counts refresh"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily, offset from the 2-hourly imports. Repology refreshes its
+    # `nix_unstable` data roughly daily, so this is a generous ceiling.
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  update-repology-counts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checking out the repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Setup
+        uses: ./.github/actions/common-setup
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
+
+      - name: Compute cache date
+        id: date
+        if: github.repository_owner == 'NixOS'
+        shell: sh
+        run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch Repology counts
+        if: github.repository_owner == 'NixOS'
+        shell: sh
+        run: |
+          nix run --accept-flake-config .#flake-info -- repology-counts --output repology-counts.json
+
+      - name: Save Repology counts to cache
+        if: github.repository_owner == 'NixOS'
+        uses: actions/cache/save@v4
+        with:
+          path: repology-counts.json
+          # Actions cache keys are immutable, so a rotating date lets each daily
+          # run publish fresh data. The `v1` prefix allows format bumps.
+          key: repology-counts-v1-${{ steps.date.outputs.date }}
+
+      - name: Create issue if failed
+        if: failure() && github.repository_owner == 'NixOS'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        shell: sh
+        run: |
+          TITLE="Failing daily Repology counts refresh"
+
+          if [ "$(gh issue list --state open --search "in:title $TITLE" -L 1 --json id --jq length)" -eq 0 ]; then
+            gh issue create \
+              --title "$TITLE" \
+              --label "prio:blocker" \
+              --body "This issue was triggered by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi

--- a/flake-info/Cargo.lock
+++ b/flake-info/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "sha2",
  "sqlite",
  "structopt",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",

--- a/flake-info/Cargo.toml
+++ b/flake-info/Cargo.toml
@@ -26,6 +26,7 @@ sha2 = "0.9"
 pandoc = "0.8.10"
 semver = "1.0"
 sqlite = "0.30"
+tempfile = "3"
 
 elasticsearch = {git = "https://github.com/elastic/elasticsearch-rs", features = ["rustls-tls"], optional = true}
 

--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -36,6 +36,11 @@ pkgs.rustPlatform.buildRustPackage rec {
     cp -rt "$out" assets
 
     wrapProgram $out/bin/flake-info \
-      --prefix PATH : ${pkgs.pandoc}/bin
+      --prefix PATH : ${
+        pkgs.lib.makeBinPath [
+          pkgs.pandoc
+          pkgs.nix-eval-jobs
+        ]
+      }
   '';
 }

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -70,6 +70,14 @@ enum Command {
                     Useful for testing a fix against a custom-built file from a nixpkgs branch"
         )]
         packages_json_url: Option<String>,
+
+        #[structopt(
+            long = "repology-counts-file",
+            help = "Read Repology repository counts (JSON object srcname->count) from this \
+                    file instead of crawling repology.org. A missing/unreadable file drops \
+                    the signal."
+        )]
+        repology_counts_file: Option<PathBuf>,
     },
 
     #[structopt(about = "Import nixpkgs channel from archive or local git path")]
@@ -110,6 +118,12 @@ enum Command {
             help = "Run nix garbage collection between every group member evaluation"
         )]
         with_gc: bool,
+    },
+
+    #[structopt(about = "Fetch Repology repository counts and write them as JSON")]
+    RepologyCounts {
+        #[structopt(short, long, help = "Write JSON to this file instead of stdout")]
+        output: Option<PathBuf>,
     },
 }
 
@@ -189,6 +203,23 @@ async fn main() -> Result<()> {
 
     let args = Args::from_args();
 
+    // The producer subcommand only crawls Repology and writes JSON; it must be
+    // handled before the --push/--json assertion, which does not apply to it.
+    if let Command::RepologyCounts { output } = &args.command {
+        // `get_repology_repo_counts` uses `reqwest::blocking`, whose internal
+        // runtime must not be dropped on the `#[tokio::main]` block_on thread.
+        // Run it on a blocking-permitted thread instead.
+        let counts = tokio::task::spawn_blocking(flake_info::commands::get_repology_repo_counts)
+            .await
+            .context("Repology counts task panicked")??;
+        let json = serde_json::to_string(&counts)?;
+        match output {
+            Some(path) => std::fs::write(path, json)?,
+            None => println!("{}", json),
+        }
+        return Ok(());
+    }
+
     anyhow::ensure!(
         args.elastic.enable || args.elastic.json,
         "at least one of --push or --json must be specified"
@@ -240,6 +271,10 @@ async fn run_command(
     flake_info::commands::check_nix_version(env!("MIN_NIX_VERSION"))?;
 
     match command {
+        // Handled in main() before the runtime setup below.
+        Command::RepologyCounts { .. } => {
+            unreachable!("RepologyCounts is handled before run_command")
+        }
         Command::Flake { flake, temp_store } => {
             let source = if flake.starts_with("github:") {
                 let mut s = flake.split(":").skip(1).next().unwrap().split("/");
@@ -268,6 +303,7 @@ async fn run_command(
             channel,
             attribute,
             packages_json_url,
+            repology_counts_file,
         } => {
             let nixpkgs = Source::nixpkgs(channel)
                 .await
@@ -293,6 +329,7 @@ async fn run_command(
                         &kind,
                         &attribute,
                         &packages_json_url,
+                        &repology_counts_file,
                     )
                     .map_err(FlakeInfoError::Nixpkgs)
                 }),
@@ -326,6 +363,7 @@ async fn run_command(
                         &kind,
                         &attribute,
                         &None,
+                        &None,
                     )
                     .map_err(FlakeInfoError::Nixpkgs)
                 }),
@@ -350,7 +388,7 @@ async fn run_command(
                 .iter()
                 .map(|source| match source {
                     Source::Nixpkgs(nixpkgs) => {
-                        flake_info::process_nixpkgs(source, &kind, &None, &None)
+                        flake_info::process_nixpkgs(source, &kind, &None, &None, &None)
                             .with_context(|| {
                                 format!(
                                     "While processing nixpkgs archive {}",

--- a/flake-info/src/commands/dep_count.rs
+++ b/flake-info/src/commands/dep_count.rs
@@ -1,0 +1,150 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result};
+use command_run::{Command, LogTo};
+use log::info;
+use serde::Deserialize;
+
+use crate::data::Nixpkgs;
+
+/// One line of `nix-eval-jobs --show-input-drvs` output. Eval errors have no `drvPath`.
+#[derive(Debug, Deserialize)]
+struct EvalJob {
+    attr: String,
+    #[serde(rename = "drvPath")]
+    drv_path: Option<String>,
+    #[serde(rename = "inputDrvs", default)]
+    input_drvs: HashMap<String, Vec<String>>,
+}
+
+/// Direct reverse-dependency count per top-level nixpkgs attribute, used as
+/// the `package_dep_count` popularity signal.
+///
+/// Evaluates only x86_64-linux since the graph is nearly identical across
+/// systems. Workers and memory are sized for GitHub-hosted runners.
+pub fn get_nixpkgs_dep_counts(nixpkgs: &Nixpkgs) -> Result<HashMap<String, u64>> {
+    let flake_ref = format!(
+        "github:NixOS/nixpkgs/{}#legacyPackages.x86_64-linux",
+        nixpkgs.git_ref
+    );
+    info!("Computing reverse-dependency counts from {}", flake_ref);
+
+    // Instantiation is required for input drvs. Use a throwaway chroot store
+    // so the drvs stay out of the real store and are cleaned up afterwards.
+    let store_dir = tempfile::Builder::new()
+        .prefix("flake-info-dep-count-store")
+        .tempdir()
+        .with_context(|| "Failed to create temporary store directory")?;
+    let gc_roots_dir = store_dir.path().join("gc-roots");
+
+    let mut command = Command::with_args(
+        "nix-eval-jobs",
+        [
+            "--show-input-drvs",
+            "--workers",
+            "2",
+            "--max-memory-size",
+            "3072",
+            "--flake",
+            &flake_ref,
+        ]
+        .iter(),
+    );
+    command.add_arg_pair("--store", store_dir.path());
+    command.add_arg_pair("--gc-roots-dir", gc_roots_dir);
+    command.enable_capture();
+    command.log_to = LogTo::Log;
+    // Output is huge. Don't echo it into the log on failure.
+    command.log_output_on_error = false;
+
+    let output = command
+        .run()
+        .with_context(|| "Failed to run nix-eval-jobs for dependency counts");
+
+    // Nix makes store directories read-only, which breaks TempDir removal.
+    let mut chmod = Command::with_args("chmod", ["-R", "u+w"].iter());
+    chmod.add_arg(store_dir.path());
+    chmod.log_to = LogTo::Log;
+    let _ = chmod.run();
+
+    let jobs = parse_eval_jobs(&output?.stdout_string_lossy())?;
+    Ok(count_direct_reverse_deps(&jobs))
+}
+
+fn parse_eval_jobs(output: &str) -> Result<Vec<EvalJob>> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line)
+                .with_context(|| format!("Could not parse nix-eval-jobs output line: {}", line))
+        })
+        .collect()
+}
+
+/// Count how many other derivations use each attribute's derivation as a
+/// direct input. Inputs without a top-level attribute are ignored. Aliases
+/// sharing a drv get the same count and are only counted once as dependents.
+fn count_direct_reverse_deps(jobs: &[EvalJob]) -> HashMap<String, u64> {
+    let mut drv_to_attrs: HashMap<&str, Vec<&str>> = HashMap::new();
+    for job in jobs {
+        if let Some(drv) = &job.drv_path {
+            drv_to_attrs.entry(drv).or_default().push(&job.attr);
+        }
+    }
+
+    let mut drv_counts: HashMap<&str, u64> = HashMap::new();
+    let mut seen_drvs: HashSet<&str> = HashSet::new();
+    for job in jobs {
+        let Some(drv) = job.drv_path.as_deref() else {
+            continue;
+        };
+        if !seen_drvs.insert(drv) {
+            continue;
+        }
+        for input in job.input_drvs.keys() {
+            if input != drv && drv_to_attrs.contains_key(input.as_str()) {
+                *drv_counts.entry(input.as_str()).or_default() += 1;
+            }
+        }
+    }
+
+    drv_counts
+        .into_iter()
+        .flat_map(|(drv, count)| {
+            drv_to_attrs[drv]
+                .iter()
+                .map(move |attr| ((*attr).to_string(), count))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_count_direct_reverse_deps() {
+        let output = r#"
+            {"attr":"openssl","drvPath":"/nix/store/aaa-openssl.drv","inputDrvs":{"/nix/store/zzz-perl.drv":["out"]}}
+            {"attr":"curl","drvPath":"/nix/store/bbb-curl.drv","inputDrvs":{"/nix/store/aaa-openssl.drv":["out","dev"],"/nix/store/xxx-patch.drv":["out"]}}
+            {"attr":"git","drvPath":"/nix/store/ccc-git.drv","inputDrvs":{"/nix/store/aaa-openssl.drv":["dev"],"/nix/store/bbb-curl.drv":["dev"]}}
+            {"attr":"curlAlias","drvPath":"/nix/store/bbb-curl.drv","inputDrvs":{"/nix/store/aaa-openssl.drv":["out"]}}
+            {"attr":"broken","error":"evaluation failed"}
+        "#;
+        let jobs = parse_eval_jobs(output).unwrap();
+        let counts = count_direct_reverse_deps(&jobs);
+
+        assert_eq!(counts.get("openssl"), Some(&2));
+        assert_eq!(counts.get("curl"), Some(&1));
+        assert_eq!(counts.get("curlAlias"), Some(&1));
+        assert_eq!(counts.get("git"), None);
+        assert_eq!(counts.get("broken"), None);
+        assert_eq!(counts.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_error_is_reported() {
+        assert!(parse_eval_jobs("not json").is_err());
+    }
+}

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -12,7 +12,7 @@ pub use nixpkgs_info::{
     get_darwin_options, get_home_manager_options, get_nixpkgs_info, get_nixpkgs_options,
     get_nixpkgs_package_services, get_nixpkgs_services,
 };
-pub use repology::get_repology_repo_counts;
+pub use repology::{get_repology_repo_counts, load_repology_repo_counts};
 
 use anyhow::{Context, Result};
 use command_run::{Command, LogTo};

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod nix_check_version;
 mod nix_flake_attrs;
 mod nix_flake_info;
 mod nixpkgs_info;
+mod repology;
 pub use dep_count::get_nixpkgs_dep_counts;
 pub use nix_check_version::{NixCheckError, check_nix_version};
 pub use nix_flake_attrs::get_derivation_info;
@@ -11,6 +12,7 @@ pub use nixpkgs_info::{
     get_darwin_options, get_home_manager_options, get_nixpkgs_info, get_nixpkgs_options,
     get_nixpkgs_package_services, get_nixpkgs_services,
 };
+pub use repology::get_repology_repo_counts;
 
 use anyhow::{Context, Result};
 use command_run::{Command, LogTo};

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -1,7 +1,9 @@
+mod dep_count;
 mod nix_check_version;
 mod nix_flake_attrs;
 mod nix_flake_info;
 mod nixpkgs_info;
+pub use dep_count::get_nixpkgs_dep_counts;
 pub use nix_check_version::{NixCheckError, check_nix_version};
 pub use nix_flake_attrs::get_derivation_info;
 pub use nix_flake_info::get_flake_info;

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -64,6 +64,15 @@ pub fn get_nixpkgs_info(
     } else {
         HashMap::new()
     };
+    // Repology is an external service, so a failure only loses the signal.
+    let repology_counts = if attribute.is_none() {
+        super::get_repology_repo_counts().unwrap_or_else(|err| {
+            log::warn!("Skipping Repology repository counts: {:#}", err);
+            HashMap::new()
+        })
+    } else {
+        HashMap::new()
+    };
 
     Ok(attr_set
         .into_iter()
@@ -75,12 +84,14 @@ pub fn get_nixpkgs_info(
                 .collect();
             let modular_services = package_services.remove(&attribute).unwrap_or_default();
             let dep_count = dep_counts.get(&attribute).copied();
+            let repology_repos = repology_counts.get(&attribute).copied();
             NixpkgsEntry::Derivation {
                 attribute,
                 package,
                 programs,
                 modular_services,
                 dep_count,
+                repology_repos,
             }
         })
         .collect())

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 use command_run::{Command, LogTo};
 
@@ -18,6 +19,7 @@ pub fn get_nixpkgs_info(
     nixpkgs: &Source,
     attribute: &Option<String>,
     packages_json_url: &Option<String>,
+    repology_counts_file: &Option<PathBuf>,
 ) -> Result<Vec<NixpkgsEntry>> {
     let nixpkgs = match nixpkgs {
         Source::Nixpkgs(nixpkgs) => nixpkgs,
@@ -64,14 +66,10 @@ pub fn get_nixpkgs_info(
     } else {
         HashMap::new()
     };
-    // Repology is an external service, so a failure only loses the signal.
-    let repology_counts = if attribute.is_none() {
-        super::get_repology_repo_counts().unwrap_or_else(|err| {
-            log::warn!("Skipping Repology repository counts: {:#}", err);
-            HashMap::new()
-        })
-    } else {
+    let repology_counts = if attribute.is_some() {
         HashMap::new()
+    } else {
+        resolve_repology_counts(repology_counts_file)
     };
 
     Ok(attr_set
@@ -95,6 +93,36 @@ pub fn get_nixpkgs_info(
             }
         })
         .collect())
+}
+
+/// Repology counts for a full import: from a pre-fetched file when provided
+/// (missing/unreadable -> warn + empty, per the daily-cache design), otherwise
+/// a live best-effort crawl (local/dev/manual and archive/group paths).
+fn resolve_repology_counts(file: &Option<PathBuf>) -> HashMap<String, u64> {
+    match file {
+        Some(path) => match super::load_repology_repo_counts(path) {
+            Ok(counts) => {
+                log::info!(
+                    "Loaded {} Repology counts from {}",
+                    counts.len(),
+                    path.display()
+                );
+                counts
+            }
+            Err(err) => {
+                log::warn!(
+                    "Skipping Repology counts from {}: {:#}",
+                    path.display(),
+                    err
+                );
+                HashMap::new()
+            }
+        },
+        None => super::get_repology_repo_counts().unwrap_or_else(|err| {
+            log::warn!("Skipping Repology repository counts: {:#}", err);
+            HashMap::new()
+        }),
+    }
 }
 
 pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -58,6 +58,12 @@ pub fn get_nixpkgs_info(
     let mut programs = get_nixpkgs_programs(nixpkgs)?;
     let mut package_services =
         get_nixpkgs_package_services(&Source::Nixpkgs(nixpkgs.clone())).unwrap_or_default();
+    // Skip the slow eval when only importing a single attribute.
+    let dep_counts = if attribute.is_none() {
+        super::get_nixpkgs_dep_counts(nixpkgs)?
+    } else {
+        HashMap::new()
+    };
 
     Ok(attr_set
         .into_iter()
@@ -68,11 +74,13 @@ pub fn get_nixpkgs_info(
                 .into_iter()
                 .collect();
             let modular_services = package_services.remove(&attribute).unwrap_or_default();
+            let dep_count = dep_counts.get(&attribute).copied();
             NixpkgsEntry::Derivation {
                 attribute,
                 package,
                 programs,
                 modular_services,
+                dep_count,
             }
         })
         .collect())

--- a/flake-info/src/commands/repology.rs
+++ b/flake-info/src/commands/repology.rs
@@ -1,0 +1,118 @@
+use std::collections::{HashMap, HashSet};
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use log::info;
+use serde::Deserialize;
+
+const API_BASE: &str = "https://repology.org/api/v1/projects/";
+const REPOLOGY_REPO: &str = "nix_unstable";
+const USER_AGENT: &str = "nixos-search (https://github.com/NixOS/nixos-search)";
+const REQUEST_DELAY: Duration = Duration::from_secs(1);
+
+/// Subset of a Repology package entry.
+#[derive(Debug, Deserialize)]
+struct RepologyPackage {
+    repo: String,
+    srcname: Option<String>,
+}
+
+type RepologyPage = HashMap<String, Vec<RepologyPackage>>;
+
+/// Number of Repology repositories packaging each nixpkgs attribute, used as
+/// the `package_repology_repos` popularity signal. Always queries the
+/// unstable nixpkgs repository, since the signal only reflects overall
+/// popularity, not the exact channel contents.
+pub fn get_repology_repo_counts() -> Result<HashMap<String, u64>> {
+    info!("Fetching Repology repository counts for {}", REPOLOGY_REPO);
+
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()?;
+
+    let mut counts: HashMap<String, u64> = HashMap::new();
+    let mut cursor = String::new();
+    loop {
+        let url = format!("{}{}?inrepo={}", API_BASE, cursor, REPOLOGY_REPO);
+        let page: RepologyPage = client
+            .get(&url)
+            .send()
+            .and_then(reqwest::blocking::Response::error_for_status)
+            .with_context(|| format!("Failed to fetch {}", url))?
+            .json()
+            .with_context(|| format!("Could not parse Repology response from {}", url))?;
+
+        // The last project of a page is repeated as the first of the next,
+        // so a page with a single project is the final one.
+        let next = match page.keys().max() {
+            Some(name) if page.len() > 1 => Some(format!("{}/", name)),
+            _ => None,
+        };
+        merge_page_counts(&mut counts, page);
+        match next {
+            Some(next) => cursor = next,
+            None => break,
+        }
+        sleep(REQUEST_DELAY);
+    }
+
+    info!("Repology counts cover {} attributes", counts.len());
+    Ok(counts)
+}
+
+/// Fold one API page into the attribute counts. A project's score is the
+/// number of distinct repositories packaging it, and it is assigned to every
+/// nixpkgs attribute (srcname) the project maps to. Attributes appearing in
+/// multiple projects keep the highest score.
+fn merge_page_counts(counts: &mut HashMap<String, u64>, page: RepologyPage) {
+    for packages in page.into_values() {
+        let repos: HashSet<&str> = packages.iter().map(|p| p.repo.as_str()).collect();
+        let count = repos.len() as u64;
+        for package in &packages {
+            if package.repo != REPOLOGY_REPO {
+                continue;
+            }
+            let Some(attr) = &package.srcname else {
+                continue;
+            };
+            let entry = counts.entry(attr.clone()).or_default();
+            *entry = (*entry).max(count);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_page_counts() {
+        let page: RepologyPage = serde_json::from_str(
+            r#"{
+                "7zip": [
+                    {"repo": "nix_unstable", "srcname": "_7zz", "visiblename": "7zz"},
+                    {"repo": "nix_unstable", "srcname": "_7zz-rar", "visiblename": "7zz"},
+                    {"repo": "nix_stable_25_05", "srcname": "_7zz", "visiblename": "7zz"},
+                    {"repo": "debian_13", "srcname": "7zip", "visiblename": "7zip"},
+                    {"repo": "freebsd", "srcname": "archivers/7-zip", "visiblename": "7-zip"}
+                ],
+                "no-nix-src": [
+                    {"repo": "nix_unstable"},
+                    {"repo": "debian_13", "srcname": "no-nix-src"}
+                ],
+                "other-distro-only": [
+                    {"repo": "debian_13", "srcname": "other"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let mut counts = HashMap::new();
+        merge_page_counts(&mut counts, page);
+
+        assert_eq!(counts.get("_7zz"), Some(&4));
+        assert_eq!(counts.get("_7zz-rar"), Some(&4));
+        assert_eq!(counts.len(), 2);
+    }
+}

--- a/flake-info/src/commands/repology.rs
+++ b/flake-info/src/commands/repology.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::thread::sleep;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::{info, warn};
 use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
@@ -55,6 +55,15 @@ pub fn get_repology_repo_counts() -> Result<HashMap<String, u64>> {
 
     info!("Repology counts cover {} attributes", counts.len());
     Ok(counts)
+}
+
+/// Load counts previously produced by `get_repology_repo_counts` (a JSON object
+/// mapping srcname -> repository count).
+pub fn load_repology_repo_counts(path: &std::path::Path) -> Result<HashMap<String, u64>> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("Failed to read Repology counts file {}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("Failed to parse Repology counts file {}", path.display()))
 }
 
 /// Maximum fetch attempts per page before giving up. When exhausted, the error
@@ -234,6 +243,23 @@ mod tests {
         assert_eq!(counts.get("_7zz"), Some(&4));
         assert_eq!(counts.get("_7zz-rar"), Some(&4));
         assert_eq!(counts.len(), 2);
+    }
+
+    #[test]
+    fn test_load_repology_repo_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("repology-counts.json");
+        std::fs::write(&path, r#"{"_7zz":4,"firefox":150}"#).unwrap();
+
+        let counts = load_repology_repo_counts(&path).unwrap();
+        assert_eq!(counts.get("_7zz"), Some(&4));
+        assert_eq!(counts.get("firefox"), Some(&150));
+        assert_eq!(counts.len(), 2);
+
+        // A missing file is an error, not a panic; the caller downgrades it to
+        // an empty signal.
+        let missing = dir.path().join("does-not-exist.json");
+        assert!(load_repology_repo_counts(&missing).is_err());
     }
 
     #[test]

--- a/flake-info/src/commands/repology.rs
+++ b/flake-info/src/commands/repology.rs
@@ -2,8 +2,10 @@ use std::collections::{HashMap, HashSet};
 use std::thread::sleep;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
-use log::info;
+use anyhow::Result;
+use log::{info, warn};
+use reqwest::StatusCode;
+use reqwest::header::{HeaderMap, RETRY_AFTER};
 use serde::Deserialize;
 
 const API_BASE: &str = "https://repology.org/api/v1/projects/";
@@ -35,13 +37,7 @@ pub fn get_repology_repo_counts() -> Result<HashMap<String, u64>> {
     let mut cursor = String::new();
     loop {
         let url = format!("{}{}?inrepo={}", API_BASE, cursor, REPOLOGY_REPO);
-        let page: RepologyPage = client
-            .get(&url)
-            .send()
-            .and_then(reqwest::blocking::Response::error_for_status)
-            .with_context(|| format!("Failed to fetch {}", url))?
-            .json()
-            .with_context(|| format!("Could not parse Repology response from {}", url))?;
+        let page = fetch_page(&client, &url)?;
 
         // The last project of a page is repeated as the first of the next,
         // so a page with a single project is the final one.
@@ -59,6 +55,130 @@ pub fn get_repology_repo_counts() -> Result<HashMap<String, u64>> {
 
     info!("Repology counts cover {} attributes", counts.len());
     Ok(counts)
+}
+
+/// Maximum fetch attempts per page before giving up. When exhausted, the error
+/// propagates and the whole Repology signal is dropped (best-effort).
+const MAX_ATTEMPTS: u32 = 5;
+/// Base unit for exponential backoff between retries.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+/// Ceiling on any single backoff wait, including a `Retry-After` value.
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
+
+/// A failed page fetch, tagged with whether a retry might help and any
+/// server-provided delay (from a 429 `Retry-After` header).
+struct FetchError {
+    error: anyhow::Error,
+    retryable: bool,
+    retry_after: Option<Duration>,
+}
+
+/// Fetch and decode one projects page, retrying transient failures (network
+/// errors, HTTP 429, and 5xx) with exponential backoff plus jitter. A 429
+/// `Retry-After` value, when present, replaces the computed delay. Permanent
+/// failures (non-429 4xx) and exhausted retries return `Err`, which drops the
+/// entire Repology signal upstream instead of failing the import.
+fn fetch_page(client: &reqwest::blocking::Client, url: &str) -> Result<RepologyPage> {
+    let mut attempt = 1;
+    loop {
+        match try_fetch_page(client, url) {
+            Ok(page) => return Ok(page),
+            Err(failure) => {
+                if attempt >= MAX_ATTEMPTS || !failure.retryable {
+                    return Err(failure.error);
+                }
+                let delay = failure
+                    .retry_after
+                    .unwrap_or_else(|| backoff_delay(attempt) + jitter())
+                    .min(MAX_RETRY_DELAY);
+                warn!(
+                    "Repology fetch attempt {}/{} for {} failed ({:#}); retrying in {:?}",
+                    attempt, MAX_ATTEMPTS, url, failure.error, delay
+                );
+                sleep(delay);
+                attempt += 1;
+            }
+        }
+    }
+}
+
+/// Perform a single fetch attempt, classifying any failure for the retry loop.
+fn try_fetch_page(
+    client: &reqwest::blocking::Client,
+    url: &str,
+) -> std::result::Result<RepologyPage, FetchError> {
+    // Connection resets, timeouts, and DNS blips carry no status and are transient.
+    let response = match client.get(url).send() {
+        Ok(response) => response,
+        Err(error) => {
+            return Err(FetchError {
+                error: anyhow::Error::new(error).context(format!("Request to {} failed", url)),
+                retryable: true,
+                retry_after: None,
+            });
+        }
+    };
+
+    let status = response.status();
+    if status.is_success() {
+        // A truncated body from a dropped connection surfaces as a decode error,
+        // so treat parse failures as transient as well.
+        return response.json::<RepologyPage>().map_err(|error| FetchError {
+            error: anyhow::Error::new(error)
+                .context(format!("Could not parse Repology response from {}", url)),
+            retryable: true,
+            retry_after: None,
+        });
+    }
+
+    let retry_after = if status == StatusCode::TOO_MANY_REQUESTS {
+        parse_retry_after(response.headers())
+    } else {
+        None
+    };
+    Err(FetchError {
+        error: anyhow::anyhow!("{} returned HTTP {}", url, status),
+        retryable: is_retryable_status(status),
+        retry_after,
+    })
+}
+
+/// An unsuccessful status is worth retrying only for rate limiting (429) and
+/// server errors (5xx); other 4xx responses will not fix themselves.
+fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Parse a `Retry-After` header given as an integer number of seconds. The
+/// HTTP-date form is ignored, falling back to exponential backoff.
+fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    let seconds: u64 = headers
+        .get(RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    Some(Duration::from_secs(seconds))
+}
+
+/// Deterministic exponential backoff for a 1-based attempt number, capped at
+/// `MAX_RETRY_DELAY`. Jitter is added separately at the call site.
+fn backoff_delay(attempt: u32) -> Duration {
+    let factor = 1u64
+        .checked_shl(attempt.saturating_sub(1))
+        .unwrap_or(u64::MAX);
+    Duration::from_secs(RETRY_BASE_DELAY.as_secs().saturating_mul(factor)).min(MAX_RETRY_DELAY)
+}
+
+/// Up to one second of clock-seeded jitter, avoiding a dependency purely for
+/// backoff randomisation. Cryptographic quality is unnecessary here.
+fn jitter() -> Duration {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.subsec_nanos())
+        .unwrap_or(0);
+    Duration::from_millis(u64::from(nanos % 1_000))
 }
 
 /// Fold one API page into the attribute counts. A project's score is the
@@ -114,5 +234,44 @@ mod tests {
         assert_eq!(counts.get("_7zz"), Some(&4));
         assert_eq!(counts.get("_7zz-rar"), Some(&4));
         assert_eq!(counts.len(), 2);
+    }
+
+    #[test]
+    fn test_is_retryable_status() {
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn test_parse_retry_after() {
+        use reqwest::header::HeaderValue;
+
+        let mut headers = HeaderMap::new();
+        assert_eq!(parse_retry_after(&headers), None);
+
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("30"));
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(30)));
+
+        // The HTTP-date form is not parsed and falls back to backoff.
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"),
+        );
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn test_backoff_delay_grows_and_caps() {
+        assert_eq!(backoff_delay(1), Duration::from_secs(1));
+        assert_eq!(backoff_delay(2), Duration::from_secs(2));
+        assert_eq!(backoff_delay(3), Duration::from_secs(4));
+        assert_eq!(backoff_delay(4), Duration::from_secs(8));
+        // Large attempts saturate at the cap rather than overflowing the shift.
+        assert_eq!(backoff_delay(64), MAX_RETRY_DELAY);
+        assert_eq!(backoff_delay(1000), MAX_RETRY_DELAY);
     }
 }

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -207,6 +207,8 @@ pub enum Derivation {
         package_homepage: Vec<String>,
         package_position: Option<String>,
         package_modular_services: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        package_dep_count: Option<u64>,
     },
     #[serde(rename = "app")]
     App {
@@ -342,6 +344,7 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                     package_homepage: Vec::new(),
                     package_position: None,
                     package_modular_services: Vec::new(),
+                    package_dep_count: None,
                 }
             }
             import::FlakeEntry::App {
@@ -370,6 +373,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 package,
                 programs,
                 modular_services,
+                dep_count,
             } => {
                 let package_attr_set: Vec<_> = attribute.split(".").collect();
                 let package_attr_set: String = (if package_attr_set.len() > 1 {
@@ -480,6 +484,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                         .map_or(Default::default(), OneOrMany::into_list),
                     package_position: position,
                     package_modular_services: modular_services,
+                    package_dep_count: dep_count,
                 }
             }
             import::NixpkgsEntry::Option(option) => option.try_into()?,

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -209,6 +209,8 @@ pub enum Derivation {
         package_modular_services: Vec<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         package_dep_count: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        package_repology_repos: Option<u64>,
     },
     #[serde(rename = "app")]
     App {
@@ -345,6 +347,7 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                     package_position: None,
                     package_modular_services: Vec::new(),
                     package_dep_count: None,
+                    package_repology_repos: None,
                 }
             }
             import::FlakeEntry::App {
@@ -374,6 +377,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 programs,
                 modular_services,
                 dep_count,
+                repology_repos,
             } => {
                 let package_attr_set: Vec<_> = attribute.split(".").collect();
                 let package_attr_set: String = (if package_attr_set.len() > 1 {
@@ -485,6 +489,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     package_position: position,
                     package_modular_services: modular_services,
                     package_dep_count: dep_count,
+                    package_repology_repos: repology_repos,
                 }
             }
             import::NixpkgsEntry::Option(option) => option.try_into()?,

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -198,6 +198,7 @@ pub enum NixpkgsEntry {
         package: Package,
         programs: Vec<String>,
         modular_services: Vec<String>,
+        dep_count: Option<u64>,
     },
     Option(NixOption),
     Service(NixOption),
@@ -613,6 +614,7 @@ mod tests {
                 package,
                 programs: Vec::new(),
                 modular_services: Vec::new(),
+                dep_count: None,
             })
             .collect();
     }

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -199,6 +199,7 @@ pub enum NixpkgsEntry {
         programs: Vec<String>,
         modular_services: Vec<String>,
         dep_count: Option<u64>,
+        repology_repos: Option<u64>,
     },
     Option(NixOption),
     Service(NixOption),
@@ -615,6 +616,7 @@ mod tests {
                 programs: Vec::new(),
                 modular_services: Vec::new(),
                 dep_count: None,
+                repology_repos: None,
             })
             .collect();
     }

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -153,6 +153,9 @@ lazy_static! {
                 "package_dep_count": {
                     "type": "rank_feature"
                 },
+                "package_repology_repos": {
+                    "type": "rank_feature"
+                },
                 // Options fields
                 "option_name": {
                     "type": "keyword",

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -150,6 +150,9 @@ lazy_static! {
                 "package_modular_services": {
                     "type": "keyword"
                 },
+                "package_dep_count": {
+                    "type": "rank_feature"
+                },
                 // Options fields
                 "option_name": {
                     "type": "keyword",

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -55,9 +55,10 @@ pub fn process_nixpkgs(
     kind: &Kind,
     attribute: &Option<String>,
     packages_json_url: &Option<String>,
+    repology_counts_file: &Option<PathBuf>,
 ) -> Result<Vec<Export>, anyhow::Error> {
     let drvs = if matches!(kind, Kind::All | Kind::Package) {
-        commands::get_nixpkgs_info(nixpkgs, attribute, packages_json_url)?
+        commands::get_nixpkgs_info(nixpkgs, attribute, packages_json_url, repology_counts_file)?
     } else {
         Vec::new()
     };

--- a/version.nix
+++ b/version.nix
@@ -2,7 +2,7 @@
   /**
     Backend index version used by import jobs when writing data to Elasticsearch
   */
-  import = "48";
+  import = "49";
 
   /**
     Frontend index version used by the UI when querying Elasticsearch

--- a/version.nix
+++ b/version.nix
@@ -2,7 +2,7 @@
   /**
     Backend index version used by import jobs when writing data to Elasticsearch
   */
-  import = "49";
+  import = "50";
 
   /**
     Frontend index version used by the UI when querying Elasticsearch


### PR DESCRIPTION
This allows us to use:

- popularity
- reverse dependency count

For improving search ranking. Note that this requires a second PR to use the ranking once the index is updated.

Used @Mic92 's work and added:

- Retry on failed fetch with exponential back-off. (Network can be flakey; and we fetch information about all repology packages, paginated)
- Run the job once per day; instead of every 2 hrs. This seems still too much; but if it ever breaks, we can name the day.


Assisted-by: opus-4-8