### PR TITLE
frontend: update index schema version to 50

### DIFF
--- a/version.nix
+++ b/version.nix
@@ -8,5 +8,5 @@
     Frontend index version used by the UI when querying Elasticsearch
     Keep this at the old version while 'import' populates a new index, then update to switch traffic
   */
-  frontend = "48";
+  frontend = "50";
 }


### PR DESCRIPTION
Update `frontend` index version in `version.nix` to 50 so the UI queries target `latest-50-*` indices, restoring functionality to the `/flakes` page.

Fixes #1451