### PR TITLE
fix(ci): set `USER` on container-based GitHub runners

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -13,6 +13,15 @@ runs:
   using: "composite"
 
   steps:
+    - name: Setting `USER` for container-based runners
+      shell: bash
+      run: |
+        # Container-based hosted runners leave `USER` unset, which `cachix use`
+        # rejects. VM-based runners already export it, so this is a no-op there.
+        if [ -z "${USER:-}" ]; then
+          echo "USER=$(id -un 2>/dev/null || echo root)" >> "$GITHUB_ENV"
+        fi
+
     - name: Installing Nix
       uses: cachix/install-nix-action@v30
       with:


### PR DESCRIPTION
Closes #1455.

Since ~08:43 UTC on 2026-07-25, `ubuntu-latest` jobs sometimes land on container-based hosted runners (job log header shows `VM Image / - Source: Docker`) instead of the usual VM image. Those containers leave `USER` unset, and `cachix use` rejects that:

    $USER must be set. If running in a container, try setting USER=root.
    Error: The process '/home/runner/.nix-profile/bin/cachix' failed with exit code 1

Every job going through `.github/actions/common-setup` died ~15 seconds in; https://github.com/NixOS/nixos-search/actions/runs/30148194104/job/89662877594 lost both `import-flakes` and `nixos-channels` this way, and `import-nixpkgs` was skipped as a result.

Populate `USER` from `id -un` when the runner has not set it, so the value is right whether the container runs as `root` or as `runner`. VM runners already export `USER`, so the step is a no-op there.

Assisted-by: Claude:claude-opus-5