### PR TITLE
frontend/benchmark: track precision over the returned page

### DIFF
--- a/frontend/benchmark/queries-options.json
+++ b/frontend/benchmark/queries-options.json
@@ -51,18 +51,21 @@
         "id": "g016",
         "q": "services.openssh.enable",
         "category": "exact",
-        "relevant": ["opt:services.openssh.enable"]
+        "exhaustive": true,
+        "relevant": ["opt:services.openssh.enable", "opt:services.sshd.enable"]
     },
     {
         "id": "g017",
         "q": "services.grafana.enable",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:services.grafana.enable"]
     },
     {
         "id": "g018",
         "q": "networking.firewall.enable",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:networking.firewall.enable"]
     },
     {
@@ -75,12 +78,14 @@
         "id": "g020",
         "q": "services.syncthing.enable",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:services.syncthing.enable"]
     },
     {
         "id": "g021",
         "q": "services.printing.enable",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:services.printing.enable"]
     },
     {
@@ -93,18 +98,21 @@
         "id": "g023",
         "q": "networking.firewall.allowedTCPPorts",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:networking.firewall.allowedTCPPorts"]
     },
     {
         "id": "g024",
         "q": "services.nextcloud.hostName",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:services.nextcloud.hostName"]
     },
     {
         "id": "g025",
         "q": "networking.networkmanager.logLevel",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["opt:networking.networkmanager.logLevel"]
     },
     {

--- a/frontend/benchmark/queries-packages.json
+++ b/frontend/benchmark/queries-packages.json
@@ -9,7 +9,8 @@
         "id": "g002",
         "q": "htop",
         "category": "exact",
-        "relevant": ["pkg:htop"]
+        "exhaustive": true,
+        "relevant": ["pkg:htop", "pkg:htop-vim"]
     },
     {
         "id": "g003",
@@ -39,6 +40,7 @@
         "id": "g007",
         "q": "bat",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["pkg:bat"]
     },
     {
@@ -63,13 +65,22 @@
         "id": "g011",
         "q": "postgresql",
         "category": "exact",
+        "exhaustive": true,
         "relevant": [
             "pkg:postgresql",
             "pkg:postgresql_14",
             "pkg:postgresql_15",
             "pkg:postgresql_16",
             "pkg:postgresql_17",
-            "pkg:postgresql_18"
+            "pkg:postgresql_18",
+            "pkg:postgresql_19",
+            "pkg:postgresql_jit",
+            "pkg:postgresql_14_jit",
+            "pkg:postgresql_15_jit",
+            "pkg:postgresql_16_jit",
+            "pkg:postgresql_17_jit",
+            "pkg:postgresql_18_jit",
+            "pkg:postgresql_19_jit"
         ]
     },
     {
@@ -82,6 +93,7 @@
         "id": "g013",
         "q": "caddy",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["pkg:caddy"]
     },
     {
@@ -100,13 +112,22 @@
         "id": "g026",
         "q": "postgres",
         "category": "prefix",
+        "exhaustive": true,
         "relevant": [
             "pkg:postgresql",
             "pkg:postgresql_14",
             "pkg:postgresql_15",
             "pkg:postgresql_16",
             "pkg:postgresql_17",
-            "pkg:postgresql_18"
+            "pkg:postgresql_18",
+            "pkg:postgresql_19",
+            "pkg:postgresql_jit",
+            "pkg:postgresql_14_jit",
+            "pkg:postgresql_15_jit",
+            "pkg:postgresql_16_jit",
+            "pkg:postgresql_17_jit",
+            "pkg:postgresql_18_jit",
+            "pkg:postgresql_19_jit"
         ]
     },
     {
@@ -166,6 +187,7 @@
         "id": "g037",
         "q": "fail2",
         "category": "prefix",
+        "exhaustive": true,
         "relevant": ["pkg:fail2ban"]
     },
     {
@@ -256,6 +278,7 @@
         "id": "g052",
         "q": "postgrsql",
         "category": "typo",
+        "exhaustive": true,
         "relevant": [
             "pkg:postgresql",
             "pkg:postgresql_14",
@@ -268,7 +291,9 @@
             "pkg:postgresql_15_jit",
             "pkg:postgresql_16_jit",
             "pkg:postgresql_17_jit",
-            "pkg:postgresql_18_jit"
+            "pkg:postgresql_18_jit",
+            "pkg:postgresql_19",
+            "pkg:postgresql_19_jit"
         ]
     },
     {
@@ -287,7 +312,13 @@
         "id": "g055",
         "q": "firefx",
         "category": "typo",
-        "relevant": ["pkg:firefox"]
+        "exhaustive": true,
+        "relevant": [
+            "pkg:firefox",
+            "pkg:firefox-unwrapped",
+            "pkg:firefox-esr-140-unwrapped",
+            "pkg:firefox-esr-153-unwrapped"
+        ]
     },
     {
         "id": "g056",
@@ -305,6 +336,7 @@
         "id": "g060",
         "q": "samaba",
         "category": "typo",
+        "exhaustive": true,
         "relevant": [
             "pkg:samba",
             "pkg:samba4",
@@ -316,12 +348,14 @@
         "id": "g061",
         "q": "redsi",
         "category": "typo",
+        "exhaustive": true,
         "relevant": ["pkg:redis"]
     },
     {
         "id": "g062",
         "q": "openssg",
         "category": "typo",
+        "exhaustive": true,
         "relevant": [
             "pkg:openssh",
             "pkg:opensshWithKerberos",
@@ -346,19 +380,39 @@
         "id": "g065",
         "q": "chromiun",
         "category": "typo",
-        "relevant": ["pkg:chromium"]
+        "exhaustive": true,
+        "relevant": ["pkg:chromium", "pkg:ungoogled-chromium"]
     },
     {
         "id": "g066",
         "q": "thunderbrid",
         "category": "typo",
-        "relevant": ["pkg:thunderbird"]
+        "exhaustive": true,
+        "relevant": [
+            "pkg:thunderbird",
+            "pkg:thunderbird-bin",
+            "pkg:thunderbird-esr",
+            "pkg:thunderbird-esr-bin",
+            "pkg:thunderbird-latest",
+            "pkg:thunderbird-latest-bin",
+            "pkg:thunderbird-140",
+            "pkg:thunderbird-153",
+            "pkg:thunderbird-latest-unwrapped",
+            "pkg:thunderbird-140-unwrapped",
+            "pkg:thunderbird-153-unwrapped"
+        ]
     },
     {
         "id": "g067",
         "q": "dcoker",
         "category": "typo",
-        "relevant": ["pkg:docker", "pkg:docker_25", "pkg:docker_29"]
+        "exhaustive": true,
+        "relevant": [
+            "pkg:docker",
+            "pkg:docker_25",
+            "pkg:docker_29",
+            "pkg:docker-client"
+        ]
     },
     {
         "id": "g068",
@@ -376,36 +430,48 @@
         "id": "g070",
         "q": "vaultwardn",
         "category": "typo",
-        "relevant": ["pkg:vaultwarden"]
+        "exhaustive": true,
+        "relevant": [
+            "pkg:vaultwarden",
+            "pkg:vaultwarden-mysql",
+            "pkg:vaultwarden-postgresql",
+            "pkg:vaultwarden-sqlite",
+            "pkg:vaultwarden-webvault"
+        ]
     },
     {
         "id": "g071",
         "q": "tailscle",
         "category": "typo",
+        "exhaustive": true,
         "relevant": ["pkg:tailscale"]
     },
     {
         "id": "g072",
         "q": "fial2ban",
         "category": "typo",
+        "exhaustive": true,
         "relevant": ["pkg:fail2ban"]
     },
     {
         "id": "g073",
         "q": "mosquito",
         "category": "typo",
+        "exhaustive": true,
         "relevant": ["pkg:mosquitto"]
     },
     {
         "id": "g074",
         "q": "syncthign",
         "category": "typo",
+        "exhaustive": true,
         "relevant": ["pkg:syncthing"]
     },
     {
         "id": "g075",
         "q": "cady",
         "category": "typo",
+        "exhaustive": true,
         "relevant": ["pkg:caddy"]
     },
     {
@@ -671,6 +737,7 @@
         "id": "g151",
         "q": "continuwuity",
         "category": "exact",
+        "exhaustive": true,
         "relevant": ["pkg:matrix-continuwuity"]
     }
 ]

--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -5,7 +5,7 @@
  * scores curated queries against our live ES instance.
  *
  * Usage:
- *   node benchmark/run.mjs [--packages <path>] [--options <path>] [--channel <branch>] [--schema <n>] [--k <n>]
+ *   node benchmark/run.mjs [--packages <path>] [--options <path>] [--channel <branch>] [--schema <n>] [--k <n>] [--persistence <f>]
  *
  */
 
@@ -45,12 +45,14 @@ const { values: args } = parseArgs({
         channel: { type: "string", default: "nixos-unstable" },
         schema: { type: "string" },
         k: { type: "string", default: "10" },
+        persistence: { type: "string", default: "0.8" },
     },
     strict: false,
 });
 
 // Settings
 const K = parseInt(args.k, 10);
+const P = parseFloat(args.persistence);
 const SCHEMA = args.schema ?? frontendSchema();
 const INDEX = `latest-${SCHEMA}-${args.channel}`;
 const ES_URL =
@@ -157,6 +159,42 @@ function recallAtK(ranked, relevant, k) {
     return denom > 0 ? hits / denom : 0;
 }
 
+// Rank-biased precision (Moffat & Zobel 2008), conditioned on the user stopping
+// inside the page we returned.
+//
+// The user model: a user reads rank 1, then moves on to the next rank with
+// probability `p`. So rank `i` is examined with weight `p^(i-1)`.
+//
+//   RBP = sum(p^(i-1) over relevant hits) / sum(p^(i-1) over returned hits)
+//
+// Textbook RBP divides by `1 / (1 - p)`, the weight of an unbounded result list.
+// Dividing by the weight of the hits actually returned conditions the same model
+// on the user stopping inside the page, since
+// `sum(p^(i-1), i=1..n) = (1 - p^n) / (1 - p)`.
+//
+// Properties:
+// - Junk anywhere on the page costs something, discounted by rank.
+// - A page holding fewer than `k` hits is scored on what it returned, so a short
+//   clean page reaches 1.000.
+// - `p` sets how far down the user reads: expected examination depth is
+//   `1 / (1 - p)` results.
+//
+// Requires `"exhaustive": true`, meaning `relevant` enumerates every acceptable
+// answer; otherwise a good-but-unlisted hit scores as noise. Returns `null` when
+// there are no hits, which drops the query from the mean.
+function conditionalRBP(ranked, relevant, p) {
+    if (ranked.length === 0) return null;
+    const rel = new Set(relevant);
+    let num = 0,
+        denom = 0;
+    for (let i = 0; i < ranked.length; i++) {
+        const weight = p ** i;
+        denom += weight;
+        if (rel.has(ranked[i])) num += weight;
+    }
+    return num / denom;
+}
+
 function nextBody(query, k) {
     return new Promise((resolve) => {
         const sub = app.ports.gotBodies.subscribe(function handler(bodies) {
@@ -181,9 +219,11 @@ async function scoreTrack(queries, bodyKey, field, prefix) {
             category: q.category,
             relevant: q.relevant,
             ranked,
+            matched: data.hits.total.value,
             mrr: reciprocalRank(ranked, q.relevant),
             success: successAtK(ranked, q.relevant, K),
             recall: recallAtK(ranked, q.relevant, K),
+            rbp: q.exhaustive ? conditionalRBP(ranked, q.relevant, P) : null,
         });
     }
     return results;
@@ -224,10 +264,13 @@ const table = (header, rows) =>
 
 // One `## <label>` section: Overall + By-category tables for a single track.
 function section(label, results) {
+    // RBP only covers the closed-set queries that returned something.
+    const closed = results.filter((r) => r.rbp !== null);
     const overall = {
         success: mean(results.map((r) => r.success)),
         mrr: mean(results.map((r) => r.mrr)),
         recall: mean(results.map((r) => r.recall)),
+        rbp: closed.length ? mean(closed.map((r) => r.rbp)) : null,
     };
     const byCategory = {};
     for (const r of results) {
@@ -241,11 +284,16 @@ function section(label, results) {
         "### Overall",
         "",
         table(
-            ["metric", "value"],
+            ["metric", "value", "n"],
             [
-                ["Success@" + K, overall.success.toFixed(3)],
-                ["MRR", overall.mrr.toFixed(3)],
-                ["Recall@" + K, overall.recall.toFixed(3)],
+                ["Success@" + K, overall.success.toFixed(3), results.length],
+                ["MRR", overall.mrr.toFixed(3), results.length],
+                ["Recall@" + K, overall.recall.toFixed(3), results.length],
+                [
+                    `RBP (p=${P})`,
+                    overall.rbp === null ? "-" : overall.rbp.toFixed(3),
+                    closed.length,
+                ],
             ],
         ),
         "",
@@ -276,15 +324,34 @@ const perQuery = [
 const lines = [
     "# Relevance benchmark: frontend query vs deployed ES",
     "",
-    `> Index: \`${INDEX}\`. metrics: (Success@${K}, MRR, Recall@${K}).`,
+    `> Index: \`${INDEX}\`. metrics: (Success@${K}, MRR, Recall@${K}, RBP(p=${P})).`,
+    "",
+    `> \`RBP\` is rank-biased precision over the page returned. Rank \`i\` is priced at`,
+    `> \`p^(i-1)\`, so junk near the top costs more than junk near the bottom, and a`,
+    `> short page is scored on what it returned. \`p = ${P}\` here; pass \`--persistence\``,
+    `> to change it. Only queries flagged \`"exhaustive": true\` are covered, and a`,
+    "> query that returns nothing drops out of the mean.",
     "",
     ...section("Packages", pkgResults),
     ...section("Options", optResults),
     "<details>",
     "<summary>Per-query results</summary>",
     "",
+    "> `matched` is the size of the whole match set: a diagnostic for reading a",
+    "> single row, not a score, and deliberately absent from the Overall table.",
+    "",
     table(
-        ["id", "track", "q", "category", "success", "mrr", "top-3 ranked"],
+        [
+            "id",
+            "track",
+            "q",
+            "category",
+            "success",
+            "mrr",
+            "RBP",
+            "matched",
+            "top-3 ranked",
+        ],
         perQuery.map((r) => [
             r.id,
             r.track,
@@ -292,6 +359,8 @@ const lines = [
             r.category,
             r.success.toFixed(0),
             r.mrr.toFixed(3),
+            r.rbp === null ? "-" : r.rbp.toFixed(3),
+            r.matched,
             r.ranked.slice(0, 3).join(", "),
         ]),
     ),


### PR DESCRIPTION
Closes #1442.

`Success@10`, `MRR` and `Recall@10` all count only listed positives, so they are blind to whatever else the page contains. `htop` returns `httpie`, `python313Packages.httpie`, `hopenpgp-tools` and five more, and the benchmark reports a flawless 1.000/1.000/1.000. This adds one bounded precision figure that prices junk anywhere on the page the user sees.

## The metric

Rank-biased precision (Moffat & Zobel 2008), conditioned on the user stopping inside the page returned:

```
RBP = sum over returned i where hit_i is relevant of p^(i-1)
      -------------------------------------------------------
      sum over returned i of p^(i-1)
```

`p` is the probability that a user who read one result reads the next. Junk anywhere on the page costs something, discounted by rank -- junk at rank 2 costs more than junk at rank 9. Textbook RBP divides by `1 / (1 - p)`, the weight of an unbounded result list; dividing by the weight of the hits actually returned holds the closed-world claim inside the window that was audited, and means a query with little to return is not charged for the slots it left empty: `syncthign` matches 2 things, one junk, and scores 0.556 rather than the 0.1 a fixed `k` denominator would give.

Computed only for queries flagged `"exhaustive": true`, whose `relevant` enumerates every acceptable answer among the top `k`; 21 package and 8 option queries qualify. Returns `null` on zero hits, which drops the query from the mean while it still counts in `n`.

Plain `Precision@k` expresses none of this: with `|relevant| <= k` it is `Recall@k * |relevant| / k`, a reparametrization of a metric already reported, and it sits at its ceiling for any placement within the top `k`, so it cannot see rank at all.

## Persistence default

Sweep over the closed set. The spread is flat at every `p` (sd 0.27-0.34), so the choice is not about discrimination:

| p | packages (n=21) | options (n=8) | queries at 1.000 | sd (all 29) | `caddy` | `htop` |
| --- | --- | --- | --- | --- | --- | --- |
| 0.3 | 0.689 | 0.870 | 8 | 0.28 | 0.700 | 0.910 |
| 0.5 | 0.616 | 0.804 | 6 | 0.27 | 0.500 | 0.751 |
| 0.7 | 0.521 | 0.752 | 6 | 0.30 | 0.309 | 0.525 |
| **0.8** | **0.468** | **0.731** | **6** | **0.32** | **0.224** | **0.403** |
| 0.9 | 0.417 | 0.714 | 6 | 0.34 | 0.154 | 0.292 |

Default `p = 0.8`, an expected examination depth of 5.0 results. Three things argue for the high end:

- **A low `p` cannot see crowding, which is the whole point.** Ranks 6-10 carry 3.0% of the weight at `p = 0.5`, against 24.7% at 0.8 and 37.1% at 0.9. At 0.5 the bottom half of the page is nearly free, so the metric stops measuring the thing #1438 complains about.
- **A low `p` is jumpy on differences no user perceives.** Of the 178 adjacent score pairs inside the closed-set pages, 37 are exact `_score` ties and 34 more are within 1% -- 40% of the boundaries are coin flips. Swapping ranks 1 and 2 on a two-hit page moves the score by 0.333 at `p = 0.5` and by 0.111 at 0.8.
- **A low `p` makes the figure redundant with `MRR`.** Pearson `r` against `MRR` over the closed set is 0.881 at `p = 0.3`, 0.692 at 0.5, 0.472 at 0.7 and 0.388 at 0.8. Raising `p` is what gives RBP a signal of its own rather than a restatement of one already in the table.

The resulting 0.224 for a single-answer query is not the metric misfiring. `caddy` returns the right answer and then `nvim-treesitter-parsers.caddy`, `caddyfile-mode`, `xcaddy` and `swayfx`; 0.224 is that page being reported. `--persistence` exposes `p` so this can be argued with.

The same 6 pages are at 1.000 at every `p >= 0.5`: a page that is entirely correct scores 1.000 whatever `p` is, which keeps the default a presentational choice rather than a definitional one. The two extra at `p = 0.3` are rounding, not clean pages -- `g011 postgresql` and `g066 thunderbrid` each carry one junk hit late on the page, and `0.3^7` is too small to survive three decimals.

## Measured against #1457's ranking

The package figures include the repology popularity boost #1457 added: a `rank_feature` clause on `package_repology_repos` in the packages `should` list, boost `5.0` at saturation pivot `20.0`. It is worth up to 5 points, which is nothing against a rank-1 exact match but decisive in the tail, so it reorders the low-scoring package pages and pulls in hits that were never previously on them.

Removing the clause and re-measuring puts the net effect at 0.465 -> 0.468. It lifts real answers -- `postgresql_18` entering the `postgresql` page (0.941 -> 0.953), `thunderbird-bin` the `thunderbrid` page (0.932 -> 0.962), `samba4` climbing a rank on `samaba` (0.428 -> 0.443) -- against noise entrants that cost about as much: `picom` and `solvespace` onto `cady`, `headscale` onto `tailscle`, `lua52Packages.http` and `lua55Packages.http` onto `htop`, three `redis` bindings onto `redsi`. `optionsBody` passes an empty `popularityFields`, so `popularityClauses` contributes nothing on the options track and 0.731 is measured without the boost.

Whether the boost is a good idea is a separate question; this PR only makes it measurable.

## Relevance judgments

Under `Precision@cut` (the first attempt on this branch, now superseded) 16 of 29 closed-set queries scored a trivial 1.000 via `|cut| = 1`, so a wrong judgment below rank 1 was masked. RBP prices every slot, so every one of those pages was inspected hit by hit, and re-inspected after #1457 changed which hits are on them.

The rule applied: **a hit is relevant if it is the named software itself or a repackaging of it** (versions, `-bin`, `-unwrapped`, `-jit`, renamed option aliases); **noise if it is different software that merely resembles the query string.**

- Relevant: `postgresql_16_jit` for `postgresql`; `htop-vim` (an htop fork) for `htop`; `thunderbird-153` and `thunderbird-153-unwrapped` for `thunderbrid`, the two versions nixpkgs gained while this branch was open; `services.sshd.enable` for `services.openssh.enable` -- the index states it is literally `Alias of services.openssh.enable`.
- Noise: `xcaddy` ("Build Caddy with plugins"), `bat-extras.batman` (third-party scripts wrapping `bat`), `python313Packages.tailscale` ("Python client for the Tailscale API"), `headscale` ("self-hosted implementation of the Tailscale control server" -- a compatible reimplementation, not a repackaging), `zabbix-agent2-plugin-postgresql` (a Zabbix tool), `reaction` ("an alternative to fail2ban"), `birdtray` ("Mail system tray notification icon for Thunderbird").
- Sibling options are the sharpest call. For `services.openssh.enable` the page also holds `services.openssh.enableRecommendedAlgorithms` and `services.opkssh.enable`. The user typed a complete path, so anything else is something they did not ask for; this is a deliberate call and the reason the options track does not read 1.000 across the board.

Where a page could not be classified confidently the `exhaustive` flag would have been dropped rather than scoring a good hit as noise. No query needed that.

## Results

Packages 0.468 (n=21), Options 0.731 (n=8). Per query, at the default `p = 0.8`:

| id | track | query | RBP | matched |
| --- | --- | --- | --- | --- |
| g151 | pkg | `continuwuity` | 0.000 | 176 |
| g061 | pkg | `redsi` | 0.179 | 159 |
| g062 | pkg | `openssg` | 0.179 | 207 |
| g007 | pkg | `bat` | 0.224 | 1155 |
| g013 | pkg | `caddy` | 0.224 | 28 |
| g023 | opt | `networking.firewall.allowedTCPPorts` | 0.224 | 16 |
| g037 | pkg | `fail2` | 0.224 | 51 |
| g071 | pkg | `tailscle` | 0.224 | 22 |
| g075 | pkg | `cady` | 0.224 | 50 |
| g072 | pkg | `fial2ban` | 0.339 | 4 |
| g073 | pkg | `mosquito` | 0.339 | 4 |
| g002 | pkg | `htop` | 0.403 | 1480 |
| g065 | pkg | `chromiun` | 0.403 | 39 |
| g060 | pkg | `samaba` | 0.443 | 25 |
| g016 | opt | `services.openssh.enable` | 0.512 | 4 |
| g020 | opt | `services.syncthing.enable` | 0.556 | 2 |
| g024 | opt | `services.nextcloud.hostName` | 0.556 | 2 |
| g074 | pkg | `syncthign` | 0.556 | 2 |
| g067 | pkg | `dcoker` | 0.577 | 160 |
| g055 | pkg | `firefx` | 0.661 | 110 |
| g052 | pkg | `postgrsql` | 0.708 | 703 |
| g011 | pkg | `postgresql` | 0.953 | 875 |
| g066 | pkg | `thunderbrid` | 0.962 | 25 |
| g017 | opt | `services.grafana.enable` | 1.000 | 1 |
| g018 | opt | `networking.firewall.enable` | 1.000 | 1 |
| g021 | opt | `services.printing.enable` | 1.000 | 1 |
| g025 | opt | `networking.networkmanager.logLevel` | 1.000 | 1 |
| g026 | pkg | `postgres` | 1.000 | 1127 |
| g070 | pkg | `vaultwardn` | 1.000 | 5 |

1.000 is reached only where it is earned, and is not structural: `g026` has 10 relevant hits in 10 slots and `g070` 5 in 5, while the four options queries at 1.000 return exactly one hit and it is right. Short pages are not automatically at the ceiling -- `g020`/`g024`/`g074` return 2 hits and score 0.556, `g072`/`g073` return 4 and score 0.339.

RBP subsumes what `Precision@cut` could see (it still flags `g055 firefx` at 0.661) and adds the pages the cut scored a trivial 1.000: `htop` 0.403, `bat` 0.224, `caddy` 0.224, `cady` 0.224. It uses no `_score`, so `--tau` and the score plumbing are gone.

## Acid test

Temporarily dropping the fuzzy `best_fields` clause in `frontend/src/Search/Query.elm` (reverted before committing) moves `continuwuity` 0.000 -> 1.000 while the `typo` category collapses:

| category | n | Success with fuzzy | without | MRR with | without |
| --- | --- | --- | --- | --- | --- |
| typo | 41 | 0.805 | 0.049 | 0.571 | 0.027 |

**The aggregate shift is mostly survivorship, and should not be read as fuzzy matching hurting precision.** 13 of the 21 closed-set package queries return nothing at all without fuzzy and leave the mean entirely. On the 8 measurable both ways the mean moves 0.421 -> 0.507, and that is driven by `continuwuity` alone -- whose failure `Success@10` already reports. Read the figure as a quality baseline to improve, not a regression alarm for #1438.

## Out of scope

- **Match-set size as a metric.** Dropping the fuzzy clause takes `htop` from 1480 matches to 22 and `bat` from 1155 to 394, and leaves their RBP at 0.403 and 0.224 -- the top 10 is equally junky either way; only the identity of the junk changes. Any metric sensitive to that would be measuring the invisible tail. Retained per-query as `matched`, explicitly labelled a diagnostic and deliberately absent from the Overall table.
- **Precision over the full match set.** Judging unlisted-as-irrelevant across all 875 matches scores `postgresql` 0.016, because 861 of them are packages plausibly relevant to someone. Scoped to the audited top 10 the same query scores 0.953.
- **Whether the repology boost is the right ranking call.** This PR measures it; changing it is a separate question.
- Negative/`irrelevant` judgment lists; positives-only enumeration plus the `exhaustive` flag was the explicit call.
- Any regression gate. CI stays report-only (`continue-on-error: true`, no baseline diff).

## Verification

- Success/MRR/Recall are inert to the code change: running this branch's `run.mjs` against the parent commit's query files reproduces the parent's overall, by-category and all 217 per-query rows exactly (`rankHits` returning bare ids restores the pre-`Precision@cut` shape). The curation moves four figures on purpose -- `g026` recall 0.833 -> 1.000, `g052` 0.600 -> 0.700, `g066` MRR 0.250 -> 1.000, and recall 1.000 -> 0.900 on `g011` and `g066`, where enumerating every variant raises the capped denominator to 10 while only 9 fit on the page.
- `npm --prefix frontend test` passes; `nix fmt -- --fail-on-change` is clean.
- The benchmark drives the compiled `Search/Query.elm` against `https://search.nixos.org/backend` at `latest-50-nixos-unstable`, which the deployed bundle confirms is the index it queries, so the priced top 10 is the head of the real first page (the site shows 50 per page).
- Figures are a snapshot of a live index. `nixos-unstable` moved twice during this branch: `postgresql_18_jit` entered the `postgresql` page and was already listed, and `thunderbird-153`/`thunderbird-153-unwrapped` entered the `thunderbrid` page and were added to its `relevant` list under the rule above.

Disclaimer: I used a coding agent in the creation of this patch.
