### PR TITLE
Revert "frontent/search: add fuzzy matching to elastic parameters"

### DIFF
--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -299,25 +299,8 @@ searchFields positiveWords mainFields fields =
                     ]
               )
             ]
-
-        fuzzyMatch : List ( String, Json.Encode.Value )
-        fuzzyMatch =
-            [ ( "multi_match"
-              , Json.Encode.object
-                    [ ( "type", Json.Encode.string "best_fields" )
-                    , ( "query", Json.Encode.string (String.join " " positiveWords) )
-                    , ( "fuzziness", Json.Encode.string "AUTO" )
-                    , ( "prefix_length", Json.Encode.int 1 )
-                    , ( "_name", Json.Encode.string <| "fuzzy_" ++ String.join "_" positiveWords )
-                    , ( "fields"
-                      , Json.Encode.list Json.Encode.string
-                            (List.map (\( field, score ) -> field ++ "^" ++ String.fromFloat (score * 0.5)) fields)
-                      )
-                    ]
-              )
-            ]
     in
-    multiMatch :: fuzzyMatch :: List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
+    multiMatch :: List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
 
 
 shouldClauses :


### PR DESCRIPTION
Revert #1422 over signal-to-noise concerns initially reported at #1438.

We could retry adding functionality like this until we are able to measure such precision, see #1442.

The underlying insight here is that intent-based queries and typos are generally less common than exact (/ partial) matches, and that as such, it might make more sense to only iterate on such edge cases once we are confident this will not have significant adverse effects on the more common case.
