### PR TITLE
feat(flake-info): index the modular-service base/environment split

### DIFF
--- a/.github/workflows/build-flake-info.yml
+++ b/.github/workflows/build-flake-info.yml
@@ -45,4 +45,4 @@ jobs:
 
           nix eval --json --no-write-lock-file \
             -f ./flake-info/assets/commands/flake_info.nix \
-            nixos-package-services >/dev/null
+            nixpkgs-package-services >/dev/null

--- a/.github/workflows/import-to-elasticsearch.yml
+++ b/.github/workflows/import-to-elasticsearch.yml
@@ -93,6 +93,17 @@ jobs:
             curl -sS ${{ secrets.ELASTICSEARCH_URL2 }}/latest-$(nix eval --raw --file ./version.nix import)-nixos-${{ matrix.channel }}/_search | jq -ce '.took // error'
           done
 
+      # Modular service discovery depends on nixpkgs internals that move
+      # underneath us, and an empty result set is not an import error. Assert
+      # the documents are actually there so a silent loss fails the job.
+      - name: Assert ${{ matrix.channel }} channel has modular services
+        if: github.repository_owner == 'NixOS'
+        shell: sh
+        run: |
+          curl -sS "${{ secrets.ELASTICSEARCH_URL2 }}/latest-$(nix eval --raw --file ./version.nix import)-nixos-${{ matrix.channel }}/_count" \
+            -H 'Content-Type: application/json' \
+            -d '{"query":{"term":{"type":"service"}}}' | jq -e '.count > 0'
+
       - name: Create issue if failed
         if: failure()
         env:

--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -693,14 +693,14 @@ rec {
 
   # Map from package attribute name to the list of modular service names it
   # exposes.
-  nixos-package-services = lib.zipAttrsWith (_: lib.unique) (
+  nixpkgs-package-services = lib.zipAttrsWith (_: lib.unique) (
     map (e: { ${e.package} = e.service; }) serviceRegistry
   );
 
   # Per-package service metadata: import expressions, environment support and
   # each half's maintainers. The package page is where a modular service is
   # described as a whole, so it carries what the option pages link out to.
-  nixos-package-service-imports = lib.zipAttrsWith (_: values: values) (
+  nixpkgs-package-service-imports = lib.zipAttrsWith (_: values: values) (
     map (
       e:
       let

--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -168,37 +168,42 @@ let
   # Filter for user-visible, non-internal options
   filterOptions = opts: lib.filter (x: x.visible && !x.internal && lib.head x.loc != "_module") opts;
 
-  evalOptionsWith =
+  evalModulesWith =
     {
       evalModules ? lib.evalModules,
       modules,
       specialArgs ? { },
       class ? null,
-      extraAttrs ? { },
     }:
-    let
-      declarations =
-        (evalModules (
-          {
-            modules = modules ++ [
-              (
-                { lib, ... }:
-                {
-                  _module.check = lib.mkForce false;
-                }
-              )
-            ];
-            specialArgs = {
-              pkgs = nixpkgs;
+    evalModules (
+      {
+        modules = modules ++ [
+          (
+            { lib, ... }:
+            {
+              _module.check = lib.mkForce false;
             }
-            // specialArgs;
-          }
-          // lib.optionalAttrs (class != null) { inherit class; }
-        )).options;
+          )
+        ];
+        specialArgs = {
+          pkgs = nixpkgs;
+        }
+        // specialArgs;
+      }
+      // lib.optionalAttrs (class != null) { inherit class; }
+    );
 
-      opts = lib.optionAttrSetToDocList declarations;
-    in
-    map (cleanUpOption extraAttrs) (filterOptions opts);
+  # Turn an evaluation's option set into the flat, indexable list of options
+  docListOf =
+    extraAttrs: eval:
+    map (cleanUpOption extraAttrs) (filterOptions (lib.optionAttrSetToDocList eval.options));
+
+  evalOptionsWith =
+    {
+      extraAttrs ? { },
+      ...
+    }@args:
+    docListOf extraAttrs (evalModulesWith (removeAttrs args [ "extraAttrs" ]));
 
   readNixOSOptions =
     {
@@ -218,57 +223,6 @@ let
         flake = modulePath;
       };
     };
-
-  # Parses the angle-bracket prefix from modular service option names to extract
-  # service_package and service_module, strips the prefix, and tags as entry_type = "service".
-  parseServiceOption =
-    opt:
-    let
-      # Match: <imports = [ pkgs.PKG.services.MODULE ]>.OPTNAME
-      # Group 1: package attrname, group 2: module name, group 3: remaining option path
-      m = lib.match ".*imports.*pkgs\\.([^.]+)\\.services\\.([^ ]+).*>\\.(.*)" opt.name;
-    in
-    if m != null then
-      opt
-      // {
-        entry_type = "service";
-        name = lib.elemAt m 2;
-        service_package = lib.elemAt m 0;
-        service_module = lib.elemAt m 1;
-      }
-    else
-      # Fallback: keep as-is but still tag as service
-      opt // { entry_type = "service"; };
-
-  # Deduplicate service options that share the same underlying module. When
-  # several packages re-export the same service module (e.g. php, php82..php85
-  # all point to the same pkgs/development/interpreters/php/service.nix), we
-  # end up with identical option entries differing only by service_package.
-  # Group by (declarations, parsed name) and keep a single entry per group,
-  # with a canonical service_package and the full list in service_packages.
-  deduplicateServices =
-    opts:
-    let
-      keyOf =
-        opt:
-        lib.toJSON [
-          (opt.declarations or [ ])
-          (opt.name or "")
-          (opt.service_module or "")
-        ];
-      grouped = lib.groupBy keyOf opts;
-      mergeGroup =
-        entries:
-        let
-          packages = lib.naturalSort (lib.unique (map (e: e.service_package or "") entries));
-        in
-        (lib.head entries)
-        // {
-          service_package = lib.head packages;
-          service_packages = packages;
-        };
-    in
-    lib.mapAttrsToList (_: mergeGroup) grouped;
 
   # Base schemas from official flake-schemas input extended with custom schemas
   schemas = flake-schemas.exportedSchemas // (resolved.schemas or { });
@@ -397,20 +351,273 @@ let
     { nixpkgs.hostPlatform = "x86_64-linux"; }
   ];
 
-  # Use nixpkgs' hand-maintained modular services list rather than walking all
-  # `pkgs` attributes (which would force shallow evaluation of every package
-  # and is too expensive -- see NixOS/nixpkgs#509117).
-  serviceDocModules =
-    (import "${nixpkgsFlake}/nixos/modules/misc/documentation/modular-services.nix" {
-      inherit lib;
-      pkgs = nixpkgs;
-    }).documentation.nixos.extraModules;
+  # Kept in sync with `undocumented` in nixpkgs'
+  # nixos/modules/misc/documentation/modular-services.nix: a fixture for
+  # nixos/tests/modular-service-etc rather than a service anyone would import.
+  undocumentedServices = [ "python-http-server" ];
 
-  # Evaluate base + service documentation modules together (service modules
-  # depend on base option types). Then partition: options whose name starts
-  # with "<" come from modular services.
-  nixpkgsAllOpts = readNixOSOptions { module = nixpkgsBaseModules ++ serviceDocModules; };
-  isServiceOption = opt: lib.hasPrefix "<" opt.name;
+  serviceRegistryPath = "${nixpkgsFlake}/nixos/modules/system/service/modular/default.nix";
+
+  # Discovery from nixpkgs' modular service registry, which enumerates every
+  # `<environment>.<package>.<service>` variant. `module` is the variant a
+  # NixOS configuration actually gets.
+  registryServices =
+    let
+      modularServices = (import "${nixpkgsFlake}/nixos/lib" { }).modularServices;
+
+      flat = lib.concatLists (
+        lib.mapAttrsToList (
+          environment: packages:
+          lib.concatLists (
+            lib.mapAttrsToList (
+              package: services:
+              lib.mapAttrsToList (service: module: {
+                inherit
+                  environment
+                  package
+                  service
+                  module
+                  ;
+              }) services
+            ) packages
+          )
+        ) modularServices
+      );
+
+      grouped = lib.groupBy (x: "${x.package}.${x.service}") (
+        lib.filter (x: !(lib.elem x.package undocumentedServices)) flat
+      );
+    in
+    lib.mapAttrsToList (
+      _: entries:
+      let
+        environments = map (x: {
+          name = x.environment;
+          inherit (x) module;
+        }) entries;
+      in
+      {
+        inherit (lib.head entries) package service;
+        module = (primaryEnvironment environments).module;
+        inherit environments;
+      }
+    ) grouped;
+
+  # Discovery on nixpkgs revisions that predate the registry: nixpkgs' own
+  # documentation module is hand-maintained there, so harvest the service
+  # names it declares. Before the split the portable module *was* the NixOS
+  # module, so there is no separate environment half -- `module = null` marks
+  # that, and keeps environment-specific maintainers empty rather than
+  # duplicating the base half's.
+  legacyServices =
+    let
+      docModules =
+        (import "${nixpkgsFlake}/nixos/modules/misc/documentation/modular-services.nix" {
+          inherit lib;
+          pkgs = nixpkgs;
+        }).documentation.nixos.extraModules;
+
+      names = lib.concatMap (module: lib.attrNames (module.options or { })) docModules;
+
+      parse =
+        name:
+        let
+          # `\]` is not a valid POSIX ERE escape; an unpaired `]` is literal.
+          m = lib.match "<imports = \\[ pkgs\\.([^.]+)\\.services\\.([^ ]+) ]>" name;
+        in
+        if m == null then
+          null
+        else
+          {
+            package = lib.elemAt m 0;
+            service = lib.elemAt m 1;
+          };
+    in
+    map
+      (
+        entry:
+        entry
+        // {
+          module = nixpkgs.${entry.package}.services.${entry.service};
+          environments = [
+            {
+              name = "system";
+              module = null;
+            }
+          ];
+        }
+      )
+      (
+        lib.filter (entry: entry != null && !(lib.elem entry.package undocumentedServices)) (
+          map parse names
+        )
+      );
+
+  # [ { package; service; module; environments = [ { name; module; } ]; } ]
+  serviceRegistry = if lib.pathExists serviceRegistryPath then registryServices else legacyServices;
+
+  # The environment a NixOS configuration gets, falling back to whichever
+  # environment happens to be registered first.
+  primaryEnvironment =
+    environments: lib.findFirst (env: env.name == "system") (lib.head environments) environments;
+
+  # The portable half, which every environment builds on.
+  baseImportOf = e: "pkgs.${e.package}.services.${e.service}";
+
+  # The registry names environments but does not carry the option that exposes
+  # them, so this is a small lookup. Falls back to the portable module for
+  # environments we do not know an accessor for, and for nixpkgs revisions
+  # that predate the split.
+  environmentAccessors = {
+    system = "config.modularServices";
+  };
+
+  envImportOf =
+    e: env:
+    if env.module != null && environmentAccessors ? ${env.name} then
+      "${environmentAccessors.${env.name}}.${e.package}.${e.service}"
+      # Do not merge these branches: the accessor is per environment, the
+      # portable half is not.
+    else
+      baseImportOf e;
+
+  primaryImportOf = e: envImportOf e (primaryEnvironment e.environments);
+
+  # Option names are keyed by an import expression we generate ourselves, so
+  # the prefix is an exact key rather than something to parse back out.
+  serviceOptionPrefix = e: "<imports = [ ${primaryImportOf e} ]>";
+  serviceByPrefix = lib.listToAttrs (
+    map (e: lib.nameValuePair (serviceOptionPrefix e) e) serviceRegistry
+  );
+  isServiceOption = opt: serviceByPrefix ? ${lib.head opt.loc};
+
+  # Mirrors `fakeSubmodule` in nixpkgs'
+  # nixos/modules/misc/documentation/modular-services.nix. `pkgs` has to be a
+  # special argument: a variant reaches its portable half through
+  # `imports = [ pkgs.<pkg>.services.<svc> ]`, which is evaluated before
+  # `_module.args`.
+  fakeServiceSubmodule =
+    module:
+    lib.mkOption {
+      type = lib.types.submoduleWith {
+        specialArgs = {
+          pkgs = nixpkgs;
+        };
+        modules = [ module ];
+      };
+      description = "This is a [modular service](https://nixos.org/manual/nixos/unstable/#modular-services), which can be imported into a NixOS configuration using the [`system.services`](https://search.nixos.org/options?channel=unstable&show=system.services&query=modular+service) option.";
+    };
+
+  serviceOptionsModule = {
+    options = lib.listToAttrs (
+      map (e: lib.nameValuePair (serviceOptionPrefix e) (fakeServiceSubmodule e.module)) serviceRegistry
+    );
+  };
+
+  serviceKey = e: "${e.package}.${e.service}";
+
+  # Attaching the services as real configuration makes their `meta.maintainers`
+  # readable. It declares no options, and laziness keeps everything but
+  # `meta.maintainers` unevaluated.
+  serviceAttachModule = {
+    system.services = lib.listToAttrs (
+      map (e: lib.nameValuePair (serviceKey e) { imports = [ e.module ]; }) serviceRegistry
+    );
+  };
+
+  # Evaluate base + service modules together (service modules depend on base
+  # option types).
+  nixpkgsEval = evalModulesWith {
+    modules = nixpkgsBaseModules ++ [
+      serviceOptionsModule
+      serviceAttachModule
+    ];
+    specialArgs = {
+      # !!! NixOS-specific, see `readNixOSOptions`.
+      modulesPath = "${nixpkgsFlake}/nixos/modules";
+    };
+  };
+
+  nixpkgsAllOpts = docListOf { } nixpkgsEval;
+
+  # `meta.maintainers` merges to an attrset of defining file -> maintainer list
+  # (nixpkgs' modules/generic/meta-maintainers.nix), so a service's maintainers
+  # arrive already split by the half that declared them.
+  maintainersBySource =
+    e:
+    let
+      result = safeEval (nixpkgsEval.config.system.services.${serviceKey e}.meta.maintainers or { });
+      raw = if result.success && lib.isAttrs result.value then result.value else { };
+    in
+    lib.filterAttrs (
+      file: maintainers:
+      # A lone empty list is the option's `default` attributed to its declaring
+      # file, not a maintainer claim.
+      maintainers != [ ]
+      # A module that lost its `_file` is attributed to wherever the
+      # `deferredModule` was defined, so its provenance is unknown. That is a
+      # nixpkgs bug, guarded upstream by `nixosTests.modularServiceVariants`.
+      && !(lib.hasInfix ", via option " file)
+      # The file that *declares* `meta.maintainers` is imported by every module
+      # system that offers the option, so where it still names maintainers of
+      # its own they belong to that file rather than to any service.
+      && file != maintainerOptionFile
+    ) (lib.mapAttrs' (file: maintainers: lib.nameValuePair (mkDeclaration file) maintainers) raw);
+
+  maintainerOptionFile = "modules/generic/meta-maintainers.nix";
+
+  projectMaintainer =
+    m:
+    lib.optionalAttrs (m ? name) { inherit (m) name; }
+    // lib.optionalAttrs (m ? email) { inherit (m) email; }
+    // lib.optionalAttrs (m ? github) { inherit (m) github; };
+
+  # Per-service indexed fields, derived once per service and shared by all of
+  # its options.
+  serviceInfo =
+    e:
+    let
+      bySource = maintainersBySource e;
+      sourceOf = env: if env.module == null then null else mkDeclaration (toString env.module);
+      environmentSources = lib.filter (x: x != null) (map sourceOf e.environments);
+    in
+    {
+      service_package = e.package;
+      service_module = e.service;
+      service_import = baseImportOf e;
+      service_environments = map (env: {
+        environment = env.name;
+        import = envImportOf e env;
+        maintainers = map projectMaintainer (
+          let
+            source = sourceOf env;
+          in
+          if source == null then [ ] else bySource.${source} or [ ]
+        );
+      }) e.environments;
+      service_maintainers = map projectMaintainer (
+        lib.concatLists (
+          lib.attrValues (lib.filterAttrs (file: _: !(lib.elem file environmentSources)) bySource)
+        )
+      );
+    };
+
+  serviceInfoByPrefix = lib.mapAttrs (_: serviceInfo) serviceByPrefix;
+
+  # Strip the generated prefix and attach the service's metadata. The entry
+  # whose name *is* the prefix is the submodule root rather than an option.
+  parseServiceOption =
+    opt:
+    let
+      prefix = lib.head opt.loc;
+    in
+    opt
+    // {
+      entry_type = "service";
+      name = lib.removePrefix "${prefix}." opt.name;
+    }
+    // serviceInfoByPrefix.${prefix};
+
   readOptionsIf =
     {
       cond,
@@ -451,17 +658,30 @@ rec {
   nixpkgsOptionsPartition = lib.partition isServiceOption nixpkgsAllOpts;
   nixos-options = nixpkgsOptionsPartition.wrong;
 
-  # Parsed service options
-  realServices = lib.filter (opt: opt ? service_package) (
-    map parseServiceOption nixpkgsOptionsPartition.right
+  # A single-element `loc` is the submodule root itself rather than one of the
+  # service's options.
+  nixos-services = map parseServiceOption (
+    lib.filter (opt: lib.length opt.loc > 1) nixpkgsOptionsPartition.right
   );
 
-  nixos-services = deduplicateServices realServices;
+  # Map from package attribute name to the list of modular service names it
+  # exposes.
+  nixos-package-services = lib.zipAttrsWith (_: lib.unique) (
+    map (e: { ${e.package} = e.service; }) serviceRegistry
+  );
 
-  # Map from package attribute name to the list of modular service module
-  # names it exposes. Derived from the parsed service options above so it
-  # stays in sync with nixpkgs' hand-maintained list.
-  nixos-package-services = lib.zipAttrsWith (_: values: lib.unique values) (
-    map (opt: { ${opt.service_package} = opt.service_module; }) realServices
+  # Per-package import expressions for those same services, so the package
+  # page can show a snippet that matches the channel it is looking at.
+  nixos-package-service-imports = lib.zipAttrsWith (_: values: values) (
+    map (e: {
+      ${e.package} = {
+        service = e.service;
+        import = baseImportOf e;
+        environments = map (env: {
+          environment = env.name;
+          import = envImportOf e env;
+        }) e.environments;
+      };
+    }) serviceRegistry
   );
 }

--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -387,14 +387,21 @@ let
       grouped = lib.groupBy (x: "${x.package}.${x.service}") (
         lib.filter (x: !(lib.elem x.package undocumentedServices)) flat
       );
+
+      # Every environment the registry knows about, so a service can report the
+      # ones it does *not* support alongside the ones it does.
+      knownEnvironments = lib.attrNames modularServices;
     in
     lib.mapAttrsToList (
       _: entries:
       let
-        environments = map (x: {
-          name = x.environment;
-          inherit (x) module;
-        }) entries;
+        registered = lib.listToAttrs (map (x: lib.nameValuePair x.environment x.module) entries);
+
+        environments = map (name: {
+          inherit name;
+          supported = registered ? ${name};
+          module = registered.${name} or null;
+        }) knownEnvironments;
       in
       {
         inherit (lib.head entries) package service;
@@ -442,6 +449,7 @@ let
           environments = [
             {
               name = "system";
+              supported = true;
               module = null;
             }
           ];
@@ -453,13 +461,20 @@ let
         )
       );
 
-  # [ { package; service; module; environments = [ { name; module; } ]; } ]
+  # [ { package; service; module; environments = [ { name; supported; module; } ]; } ]
+  #
+  # `environments` lists every environment the registry knows, not just the ones
+  # this service is registered for; `supported` tells them apart.
   serviceRegistry = if lib.pathExists serviceRegistryPath then registryServices else legacyServices;
 
   # The environment a NixOS configuration gets, falling back to whichever
-  # environment happens to be registered first.
+  # supported environment happens to be registered first.
   primaryEnvironment =
-    environments: lib.findFirst (env: env.name == "system") (lib.head environments) environments;
+    environments:
+    let
+      supported = lib.filter (env: env.supported) environments;
+    in
+    lib.findFirst (env: env.name == "system") (lib.head supported) supported;
 
   # The portable half, which every environment builds on.
   baseImportOf = e: "pkgs.${e.package}.services.${e.service}";
@@ -472,9 +487,13 @@ let
     system = "config.modularServices";
   };
 
+  # `null` for an environment the service is not registered for: there is
+  # nothing to import there.
   envImportOf =
     e: env:
-    if env.module != null && environmentAccessors ? ${env.name} then
+    if !env.supported then
+      null
+    else if env.module != null && environmentAccessors ? ${env.name} then
       "${environmentAccessors.${env.name}}.${e.package}.${e.service}"
     # Do not merge these branches: the accessor is per environment, the
     # portable half is not.
@@ -585,16 +604,24 @@ let
       service_package = e.package;
       service_module = e.service;
       service_import = baseImportOf e;
-      service_environments = map (env: {
-        environment = env.name;
-        import = envImportOf e env;
-        maintainers = map projectMaintainer (
-          let
-            source = sourceOf env;
-          in
-          if source == null then [ ] else bySource.${source} or [ ]
-        );
-      }) e.environments;
+      # Every known environment, so the frontend can show which ones a service
+      # does not support. Unsupported ones carry no import and no maintainers.
+      service_environments = map (
+        env:
+        {
+          environment = env.name;
+          inherit (env) supported;
+        }
+        // lib.optionalAttrs env.supported {
+          import = envImportOf e env;
+          maintainers = map projectMaintainer (
+            let
+              source = sourceOf env;
+            in
+            if source == null then [ ] else bySource.${source} or [ ]
+          );
+        }
+      ) e.environments;
       service_maintainers = map projectMaintainer (
         lib.concatLists (
           lib.attrValues (lib.filterAttrs (file: _: !(lib.elem file environmentSources)) bySource)
@@ -670,18 +697,23 @@ rec {
     map (e: { ${e.package} = e.service; }) serviceRegistry
   );
 
-  # Per-package import expressions for those same services, so the package
-  # page can show a snippet that matches the channel it is looking at.
+  # Per-package service metadata: import expressions, environment support and
+  # each half's maintainers. The package page is where a modular service is
+  # described as a whole, so it carries what the option pages link out to.
   nixos-package-service-imports = lib.zipAttrsWith (_: values: values) (
-    map (e: {
-      ${e.package} = {
-        service = e.service;
-        import = baseImportOf e;
-        environments = map (env: {
-          environment = env.name;
-          import = envImportOf e env;
-        }) e.environments;
-      };
-    }) serviceRegistry
+    map (
+      e:
+      let
+        info = serviceInfo e;
+      in
+      {
+        ${e.package} = {
+          service = e.service;
+          import = info.service_import;
+          maintainers = info.service_maintainers;
+          environments = info.service_environments;
+        };
+      }
+    ) serviceRegistry
   );
 }

--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -476,8 +476,8 @@ let
     e: env:
     if env.module != null && environmentAccessors ? ${env.name} then
       "${environmentAccessors.${env.name}}.${e.package}.${e.service}"
-      # Do not merge these branches: the accessor is per environment, the
-      # portable half is not.
+    # Do not merge these branches: the accessor is per environment, the
+    # portable half is not.
     else
       baseImportOf e;
 

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -82,8 +82,9 @@ pub fn get_nixpkgs_info(
                 .into_iter()
                 .collect();
             let modular_services = package_services.remove(&attribute).unwrap_or_default();
-            let modular_service_imports =
-                package_service_imports.remove(&attribute).unwrap_or_default();
+            let modular_service_imports = package_service_imports
+                .remove(&attribute)
+                .unwrap_or_default();
             let dep_count = dep_counts.get(&attribute).copied();
             let repology_repos = repology_counts.get(&attribute).copied();
             NixpkgsEntry::Derivation {

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -152,7 +152,7 @@ fn get_package_map<T: serde::de::DeserializeOwned>(
 }
 
 pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {
-    get_package_map(nixpkgs, "nixos-package-services")
+    get_package_map(nixpkgs, "nixpkgs-package-services")
 }
 
 /// The import expressions for each package's modular services, so the package
@@ -160,7 +160,7 @@ pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, 
 pub fn get_nixpkgs_package_service_imports(
     nixpkgs: &Source,
 ) -> Result<HashMap<String, Vec<PackageService>>> {
-    get_package_map(nixpkgs, "nixos-package-service-imports")
+    get_package_map(nixpkgs, "nixpkgs-package-service-imports")
 }
 
 pub fn get_nixpkgs_programs(nixpkgs: &Nixpkgs) -> Result<HashMap<String, HashSet<String>>> {

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use crate::Source;
 use crate::data::Nixpkgs;
-use crate::data::import::{NixOption, NixpkgsEntry, Package};
+use crate::data::import::{NixOption, NixpkgsEntry, Package, PackageService};
 
 /// Wrapper for the channel `packages.json` format.
 #[derive(Deserialize)]
@@ -59,6 +59,8 @@ pub fn get_nixpkgs_info(
     let mut programs = get_nixpkgs_programs(nixpkgs)?;
     let mut package_services =
         get_nixpkgs_package_services(&Source::Nixpkgs(nixpkgs.clone())).unwrap_or_default();
+    let mut package_service_imports =
+        get_nixpkgs_package_service_imports(&Source::Nixpkgs(nixpkgs.clone())).unwrap_or_default();
     // Skip the slow eval when only importing a single attribute.
     let dep_counts = if attribute.is_none() {
         super::get_nixpkgs_dep_counts(nixpkgs)?
@@ -80,6 +82,8 @@ pub fn get_nixpkgs_info(
                 .into_iter()
                 .collect();
             let modular_services = package_services.remove(&attribute).unwrap_or_default();
+            let modular_service_imports =
+                package_service_imports.remove(&attribute).unwrap_or_default();
             let dep_count = dep_counts.get(&attribute).copied();
             let repology_repos = repology_counts.get(&attribute).copied();
             NixpkgsEntry::Derivation {
@@ -87,6 +91,7 @@ pub fn get_nixpkgs_info(
                 package,
                 programs,
                 modular_services,
+                modular_service_imports,
                 dep_count,
                 repology_repos,
             }
@@ -124,20 +129,37 @@ fn resolve_repology_counts(file: &Option<PathBuf>) -> HashMap<String, u64> {
     }
 }
 
-pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {
+/// Evaluate `attribute` in the flake-info nix script and parse it as a map from
+/// package attribute name to `T`.
+fn get_package_map<T: serde::de::DeserializeOwned>(
+    nixpkgs: &Source,
+    attribute: &str,
+) -> Result<HashMap<String, T>> {
     let mut command = super::nix_eval_command(&["eval", "--json", "--no-write-lock-file"]);
     super::add_flake_arg(&mut command, "nixpkgsFlake", &nixpkgs.to_flake_ref());
-    command.add_arg("nixos-package-services");
+    command.add_arg(attribute);
 
     let cow = command
         .run()
-        .with_context(|| "Failed to gather modular service mapping for packages")?;
+        .with_context(|| format!("Failed to gather {} for packages", attribute))?;
 
     let output = &*cow.stdout_string_lossy();
     let de = &mut serde_json::Deserializer::from_str(output);
-    let map: HashMap<String, Vec<String>> = serde_path_to_error::deserialize(de)
-        .with_context(|| "Could not parse package-services map")?;
+    let map: HashMap<String, T> = serde_path_to_error::deserialize(de)
+        .with_context(|| format!("Could not parse {}", attribute))?;
     Ok(map)
+}
+
+pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, Vec<String>>> {
+    get_package_map(nixpkgs, "nixos-package-services")
+}
+
+/// The import expressions for each package's modular services, so the package
+/// page can show a snippet matching the channel it is looking at.
+pub fn get_nixpkgs_package_service_imports(
+    nixpkgs: &Source,
+) -> Result<HashMap<String, Vec<PackageService>>> {
+    get_package_map(nixpkgs, "nixos-package-service-imports")
 }
 
 pub fn get_nixpkgs_programs(nixpkgs: &Nixpkgs) -> Result<HashMap<String, HashSet<String>>> {

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -207,6 +207,7 @@ pub enum Derivation {
         package_homepage: Vec<String>,
         package_position: Option<String>,
         package_modular_services: Vec<String>,
+        package_modular_service_imports: Vec<PackageService>,
         #[serde(skip_serializing_if = "Option::is_none")]
         package_dep_count: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -247,7 +248,11 @@ pub enum Derivation {
         option_flake: Option<ModulePath>,
         service_package: Option<String>,
         service_module: Option<String>,
-        service_packages: Vec<String>,
+        service_import: Option<String>,
+        service_environments: Vec<ServiceEnvironment>,
+        service_environments_set: Vec<String>,
+        service_maintainers: Vec<Maintainer>,
+        service_maintainers_set: Vec<String>,
     },
     #[serde(rename = "home-manager-option")]
     HomeManagerOption {
@@ -346,6 +351,7 @@ impl TryFrom<(import::FlakeEntry, super::Flake)> for Derivation {
                     package_homepage: Vec::new(),
                     package_position: None,
                     package_modular_services: Vec::new(),
+                    package_modular_service_imports: Vec::new(),
                     package_dep_count: None,
                     package_repology_repos: None,
                 }
@@ -376,6 +382,7 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 package,
                 programs,
                 modular_services,
+                modular_service_imports,
                 dep_count,
                 repology_repos,
             } => {
@@ -488,6 +495,10 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                         .map_or(Default::default(), OneOrMany::into_list),
                     package_position: position,
                     package_modular_services: modular_services,
+                    package_modular_service_imports: modular_service_imports
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
                     package_dep_count: dep_count,
                     package_repology_repos: repology_repos,
                 }
@@ -504,8 +515,27 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     flake,
                     service_package,
                     service_module,
-                    service_packages,
+                    service_import,
+                    service_environments,
+                    service_maintainers,
                 } = option;
+
+                let service_environments: Vec<ServiceEnvironment> =
+                    service_environments.into_iter().map(Into::into).collect();
+
+                let service_environments_set = service_environments
+                    .iter()
+                    .map(|e| e.environment.to_owned())
+                    .collect();
+
+                let service_maintainers: Vec<Maintainer> =
+                    service_maintainers.into_iter().map(Into::into).collect();
+
+                let service_maintainers_set = service_maintainers
+                    .iter()
+                    .flat_map(|m| m.name.to_owned())
+                    .collect();
+
                 Derivation::Service {
                     option_source: declarations.get(0).map(Clone::clone),
                     option_name: name,
@@ -516,7 +546,11 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     option_type,
                     service_package,
                     service_module,
-                    service_packages,
+                    service_import,
+                    service_environments,
+                    service_environments_set,
+                    service_maintainers,
+                    service_maintainers_set,
                 }
             }
             import::NixpkgsEntry::HomeManagerOption(NixOption {
@@ -583,6 +617,46 @@ impl TryFrom<import::NixOption> for Derivation {
             option_flake: flake,
             option_type,
         })
+    }
+}
+
+/// One environment (e.g. "system") a modular service is registered for, with the
+/// import expression that reaches it and the maintainers of that half.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServiceEnvironment {
+    environment: String,
+    #[serde(rename = "import")]
+    import_expr: String,
+    maintainers: Vec<Maintainer>,
+}
+
+impl From<import::ServiceEnvironment> for ServiceEnvironment {
+    fn from(env: import::ServiceEnvironment) -> Self {
+        ServiceEnvironment {
+            environment: env.environment,
+            import_expr: env.import_expr,
+            maintainers: env.maintainers.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// A modular service a package exposes, with the import expressions for its
+/// portable half and for each environment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PackageService {
+    service: String,
+    #[serde(rename = "import")]
+    import_expr: String,
+    environments: Vec<ServiceEnvironment>,
+}
+
+impl From<import::PackageService> for PackageService {
+    fn from(service: import::PackageService) -> Self {
+        PackageService {
+            service: service.service,
+            import_expr: service.import_expr,
+            environments: service.environments.into_iter().map(Into::into).collect(),
+        }
     }
 }
 

--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -523,8 +523,12 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 let service_environments: Vec<ServiceEnvironment> =
                     service_environments.into_iter().map(Into::into).collect();
 
+                // Only environments the service actually supports: this drives
+                // the bucket filter, where picking one must narrow the results
+                // to services usable there.
                 let service_environments_set = service_environments
                     .iter()
+                    .filter(|e| e.supported)
                     .map(|e| e.environment.to_owned())
                     .collect();
 
@@ -620,13 +624,16 @@ impl TryFrom<import::NixOption> for Derivation {
     }
 }
 
-/// One environment (e.g. "system") a modular service is registered for, with the
-/// import expression that reaches it and the maintainers of that half.
+/// One of the environments the registry knows about (e.g. "system"), as it
+/// applies to a given modular service. Environments the service is not
+/// registered for are listed too, with `supported` false and nothing to import.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ServiceEnvironment {
     environment: String,
-    #[serde(rename = "import")]
-    import_expr: String,
+    supported: bool,
+    #[serde(rename = "import", skip_serializing_if = "Option::is_none")]
+    import_expr: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     maintainers: Vec<Maintainer>,
 }
 
@@ -634,6 +641,7 @@ impl From<import::ServiceEnvironment> for ServiceEnvironment {
     fn from(env: import::ServiceEnvironment) -> Self {
         ServiceEnvironment {
             environment: env.environment,
+            supported: env.supported,
             import_expr: env.import_expr,
             maintainers: env.maintainers.into_iter().map(Into::into).collect(),
         }
@@ -647,6 +655,8 @@ pub struct PackageService {
     service: String,
     #[serde(rename = "import")]
     import_expr: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    maintainers: Vec<Maintainer>,
     environments: Vec<ServiceEnvironment>,
 }
 
@@ -655,6 +665,7 @@ impl From<import::PackageService> for PackageService {
         PackageService {
             service: service.service,
             import_expr: service.import_expr,
+            maintainers: service.maintainers.into_iter().map(Into::into).collect(),
             environments: service.environments.into_iter().map(Into::into).collect(),
         }
     }

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -80,10 +80,44 @@ pub struct NixOption {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_module: Option<String>,
 
-    /// For modular service options: all packages that expose this same service
-    /// module (e.g. ["php", "php82", "php83", "php84", "php85"]).
+    /// For modular service options: the import expression of the portable half
+    /// (e.g. "pkgs.php.services.default")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_import: Option<String>,
+
+    /// For modular service options: the environments (e.g. "system") the service
+    /// is registered for, each with its own import expression and maintainers
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub service_packages: Vec<String>,
+    pub service_environments: Vec<ServiceEnvironment>,
+
+    /// For modular service options: maintainers of the portable half
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_maintainers: Vec<Maintainer>,
+}
+
+/// One environment (e.g. "system") a modular service is registered for.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServiceEnvironment {
+    pub environment: String,
+    /// `import` is a Rust keyword, hence the rename.
+    #[serde(rename = "import")]
+    pub import_expr: String,
+    /// Maintainers of this environment's half, empty on nixpkgs revisions that
+    /// predate the base/environment split.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub maintainers: Vec<Maintainer>,
+}
+
+/// A modular service a package exposes, along with the import expressions the
+/// package page shows for it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PackageService {
+    pub service: String,
+    /// `import` is a Rust keyword, hence the rename.
+    #[serde(rename = "import")]
+    pub import_expr: String,
+    #[serde(default)]
+    pub environments: Vec<ServiceEnvironment>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -198,6 +232,7 @@ pub enum NixpkgsEntry {
         package: Package,
         programs: Vec<String>,
         modular_services: Vec<String>,
+        modular_service_imports: Vec<PackageService>,
         dep_count: Option<u64>,
         repology_repos: Option<u64>,
     },
@@ -615,6 +650,7 @@ mod tests {
                 package,
                 programs: Vec::new(),
                 modular_services: Vec::new(),
+                modular_service_imports: Vec::new(),
                 dep_count: None,
                 repology_repos: None,
             })

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -95,13 +95,22 @@ pub struct NixOption {
     pub service_maintainers: Vec<Maintainer>,
 }
 
-/// One environment (e.g. "system") a modular service is registered for.
+fn default_true() -> bool {
+    true
+}
+
+/// One of the environments the registry knows about (e.g. "system"), as it
+/// applies to a given modular service.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ServiceEnvironment {
     pub environment: String,
-    /// `import` is a Rust keyword, hence the rename.
-    #[serde(rename = "import")]
-    pub import_expr: String,
+    /// Whether the service is registered for this environment. Unsupported
+    /// environments are listed too, so the frontend can show the gap.
+    #[serde(default = "default_true")]
+    pub supported: bool,
+    /// `import` is a Rust keyword, hence the rename. `None` when unsupported.
+    #[serde(default, rename = "import")]
+    pub import_expr: Option<String>,
     /// Maintainers of this environment's half, empty on nixpkgs revisions that
     /// predate the base/environment split.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -116,6 +125,9 @@ pub struct PackageService {
     /// `import` is a Rust keyword, hence the rename.
     #[serde(rename = "import")]
     pub import_expr: String,
+    /// Maintainers of the portable half; each environment half carries its own.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub maintainers: Vec<Maintainer>,
     #[serde(default)]
     pub environments: Vec<ServiceEnvironment>,
 }

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -150,6 +150,8 @@ lazy_static! {
                 "package_modular_services": {
                     "type": "keyword"
                 },
+                // Display-only: returned in `_source` without indexing cost.
+                "package_modular_service_imports": {"type": "object", "enabled": false},
                 "package_dep_count": {
                     "type": "rank_feature"
                 },
@@ -182,12 +184,20 @@ lazy_static! {
                     },
                 },
                 "service_module": {"type": "keyword"},
-                "service_packages": {
-                    "type": "keyword",
-                    "fields": {
-                        "edge": {"type": "text", "analyzer": "edge"}
+                "service_import": {"type": "keyword"},
+                // Display-only: returned in `_source` without indexing cost.
+                // Filtering and aggregation go through `service_environments_set`.
+                "service_environments": {"type": "object", "enabled": false},
+                "service_environments_set": {"type": "keyword"},
+                "service_maintainers": {
+                    "type": "nested",
+                    "properties": {
+                        "name": {"type": "text"},
+                        "email": {"type": "text"},
+                        "github": {"type": "text"},
                     },
                 },
+                "service_maintainers_set": {"type": "keyword"},
             }
         },
         "settings": {

--- a/frontend/src/Benchmark.elm
+++ b/frontend/src/Benchmark.elm
@@ -38,7 +38,7 @@ emit { query, k } =
             Search.Query.packagesBody query 0 k Search.Relevance []
 
         optBody =
-            Search.Query.optionsBody [ "option" ] query 0 k Search.Relevance
+            Search.Query.optionsBody [ "option" ] query 0 k Search.Relevance []
     in
     gotBodies
         { packages = Json.Encode.encode 0 pkgBody

--- a/frontend/src/Page/Flakes.elm
+++ b/frontend/src/Page/Flakes.elm
@@ -187,7 +187,7 @@ view nixosChannels model =
     in
     case model of
         OptionModel model_ ->
-            Html.map OptionsMsg <| mkBody "3rd-party flake options" model_ (Page.Options.viewSuccess model_.activeOptionSource) Page.Options.viewBuckets Page.Options.SearchMsg
+            Html.map OptionsMsg <| mkBody "3rd-party flake options" model_ (Page.Options.viewSuccess model_.activeOptionSource) (Page.Options.viewBuckets model_.activeOptionSource) Page.Options.SearchMsg
 
         PackagesModel model_ ->
             Html.map PackagesMsg <| mkBody "3rd-party flake packages" model_ Page.Packages.viewSuccess Page.Packages.viewBuckets Page.Packages.SearchMsg
@@ -241,7 +241,7 @@ makeRequestBody : SearchType -> String -> Int -> Int -> Maybe String -> Search.S
 makeRequestBody searchType query from size maybeBuckets sort =
     case searchType of
         OptionSearch ->
-            Page.Options.makeRequestBody [ "option" ] query from size sort
+            Page.Options.makeRequestBody [ "option" ] query from size maybeBuckets sort
 
         PackageSearch ->
             Page.Packages.makeRequestBody query from size maybeBuckets sort

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -52,6 +52,7 @@ import Html.Events
 import Http exposing (Body)
 import Json.Decode
 import Json.Decode.Pipeline
+import Json.Encode
 import List.Extra
 import Ports
 import RemoteData
@@ -62,6 +63,8 @@ import Search
         , NixOSChannel
         , decodeResolvedFlake
         )
+import Search.Maintainer
+import Search.ModularService
 import Search.Query
 import SyntaxHighlight exposing (elm, oneDark, toBlockHtml, useTheme)
 import Task
@@ -98,18 +101,43 @@ type alias ResultItemSource =
     -- modular service metadata (populated only for `service` docs)
     , servicePackage : Maybe String
     , serviceModule : Maybe String
-    , servicePackages : List String
+    , serviceImport : Maybe String
+    , serviceEnvironments : List Search.ModularService.Environment
+    , serviceMaintainers : List Search.Maintainer.Maintainer
     }
 
 
 type alias ResultAggregations =
     { all : AggregationsAll
+    , service_environments_set : Search.Aggregation
     }
 
 
 type alias AggregationsAll =
     { doc_count : Int
     }
+
+
+{-| Modular services are the only option documents with anything to filter on,
+so this is the whole sidebar for the "Modular services" tab.
+-}
+type alias Buckets =
+    { environments : List String
+    }
+
+
+emptyBuckets : Buckets
+emptyBuckets =
+    { environments = []
+    }
+
+
+initBuckets : Maybe String -> Buckets
+initBuckets bucketsAsString =
+    bucketsAsString
+        |> Maybe.map (Json.Decode.decodeString decodeBuckets)
+        |> Maybe.andThen Result.toMaybe
+        |> Maybe.withDefault emptyBuckets
 
 
 init :
@@ -190,7 +218,7 @@ view nixosChannels model =
         nixosChannels
         model
         (viewSuccess model.activeOptionSource)
-        viewBuckets
+        (viewBuckets model.activeOptionSource)
         SearchMsg
         [ viewSourceTabs model.activeOptionSource model.sourceCounts ]
 
@@ -277,11 +305,39 @@ formatCount n =
 
 
 viewBuckets :
-    Maybe String
+    OptionSource
+    -> Maybe String
     -> Search.SearchResult ResultItemSource ResultAggregations
     -> List (Html Msg)
-viewBuckets _ _ =
-    []
+viewBuckets activeSource bucketsAsString result =
+    let
+        initialBuckets =
+            initBuckets bucketsAsString
+
+        createBucketsMsg getBucket mergeBuckets value =
+            Utils.toggleList (getBucket initialBuckets) value
+                |> mergeBuckets initialBuckets
+                |> encodeBuckets
+                |> Json.Encode.encode 0
+                |> Search.BucketsChange
+                |> SearchMsg
+
+        sortBuckets items =
+            items
+                |> List.sortBy .doc_count
+                |> List.reverse
+    in
+    if activeSource /= Route.ModularServiceOptions then
+        []
+
+    else
+        []
+            |> Search.viewBucket
+                Search.CheckboxInput
+                "Environments"
+                (result.aggregations.service_environments_set.buckets |> sortBuckets)
+                (createBucketsMsg .environments (\s v -> { s | environments = v }))
+                initialBuckets.environments
 
 
 viewSuccess :
@@ -392,31 +448,20 @@ viewResultItem nixosChannels channel show activeSource item =
                                     []
                                )
                             ++ (if isService then
-                                    case item.source.servicePackages of
-                                        [] ->
-                                            item.source.servicePackage
-                                                |> Maybe.map
-                                                    (\pkg ->
-                                                        [ div [] [ text "Provided by package" ]
-                                                        , div [] [ pkgLink pkg ]
-                                                        ]
-                                                    )
-                                                |> Maybe.withDefault []
-
-                                        [ single ] ->
-                                            [ div [] [ text "Provided by package" ]
-                                            , div [] [ pkgLink single ]
-                                            ]
-
-                                        many ->
-                                            [ div [] [ text "Provided by packages" ]
-                                            , div []
-                                                (List.intersperse (text ", ") (List.map pkgLink many))
-                                            ]
+                                    item.source.servicePackage
+                                        |> Maybe.map
+                                            (\pkg ->
+                                                [ div [] [ text "Provided by package" ]
+                                                , div [] [ pkgLink pkg ]
+                                                ]
+                                            )
+                                        |> Maybe.withDefault []
 
                                 else
                                     []
                                )
+                            ++ viewServiceEnvironments item.source
+                            ++ viewServiceMaintainers item.source
                             ++ viewUsageSnippet item.source
                             ++ [ div [] [ text "Declared in" ]
                                , div [] <| findSource nixosChannels channel item.source
@@ -463,6 +508,63 @@ asHighlightPreCode value =
         ]
 
 
+{-| The environments a modular service is registered for. Each environment has
+its own half of the service, reached by its own import expression and looked
+after by its own maintainers.
+-}
+viewServiceEnvironments : ResultItemSource -> List (Html Msg)
+viewServiceEnvironments source =
+    if List.isEmpty source.serviceEnvironments then
+        []
+
+    else
+        [ div [] [ text "Environments" ]
+        , div []
+            [ ul []
+                (List.map
+                    (\env ->
+                        li []
+                            (strong [] [ text env.environment ]
+                                :: text " "
+                                :: code [] [ text env.importExpr ]
+                                :: (if List.isEmpty env.maintainers then
+                                        []
+
+                                    else
+                                        [ ul [] (List.map showMaintainer env.maintainers) ]
+                                   )
+                            )
+                    )
+                    source.serviceEnvironments
+                )
+            ]
+        ]
+
+
+{-| Maintainers of the portable half, which every environment builds on.
+-}
+viewServiceMaintainers : ResultItemSource -> List (Html Msg)
+viewServiceMaintainers source =
+    if List.isEmpty source.serviceMaintainers then
+        []
+
+    else
+        [ div [] [ text "Maintainers" ]
+        , div []
+            [ ul []
+                (List.map showMaintainer source.serviceMaintainers
+                    ++ Search.Maintainer.linkAllMaintainers CopyToClipboard source.serviceMaintainers
+                    ++ Search.Maintainer.mailtoAllMaintainers source.serviceMaintainers
+                )
+            ]
+        ]
+
+
+showMaintainer : Search.Maintainer.Maintainer -> Html Msg
+showMaintainer =
+    Search.Maintainer.showMaintainer CopyToClipboard
+
+
 {-| Render a "Usage" section showing how to use this option.
 -}
 viewUsageSnippet : ResultItemSource -> List (Html Msg)
@@ -506,20 +608,50 @@ viewUsageSnippet source =
     in
     case source.docType of
         "service" ->
-            case ( source.servicePackage, source.serviceModule ) of
-                ( Just pkg, Just mod_ ) ->
+            let
+                -- Indices written before the base/environment split carry
+                -- neither import expression, so compose the portable half's
+                -- from the package and service names.
+                composedImport =
+                    case ( source.servicePackage, source.serviceModule ) of
+                        ( Just pkg, Just mod_ ) ->
+                            Just ("pkgs." ++ pkg ++ ".services." ++ mod_)
+
+                        _ ->
+                            Nothing
+
+                -- A NixOS configuration wants the environment half; importing
+                -- the portable one alone would silently omit the systemd
+                -- integration.
+                importExpr =
+                    case source.serviceEnvironments of
+                        [] ->
+                            case source.serviceImport of
+                                Just base ->
+                                    Just base
+
+                                Nothing ->
+                                    composedImport
+
+                        environments ->
+                            Just
+                                (Search.ModularService.preferredImport
+                                    (Maybe.withDefault "" source.serviceImport)
+                                    environments
+                                )
+            in
+            case importExpr of
+                Just expr ->
                     usage
                         ("system.services.<name> = {\n"
-                            ++ "  imports = [ pkgs."
-                            ++ pkg
-                            ++ ".services."
-                            ++ mod_
+                            ++ "  imports = [ "
+                            ++ expr
                             ++ " ];\n"
                             ++ nestedOption "  "
                             ++ "};"
                         )
 
-                _ ->
+                Nothing ->
                     []
 
         "option" ->
@@ -763,7 +895,7 @@ makeRequest :
     -> Search.Sort
     -> OptionSource
     -> Cmd Msg
-makeRequest options nixosChannels _ channel query from size _ sort activeSource =
+makeRequest options nixosChannels _ channel query from size maybeBuckets sort activeSource =
     let
         activeQuery : Cmd (Search.Msg ResultItemSource ResultAggregations)
         activeQuery =
@@ -773,6 +905,7 @@ makeRequest options nixosChannels _ channel query from size _ sort activeSource 
                     query
                     from
                     size
+                    maybeBuckets
                     sort
                 )
                 nixosChannels
@@ -790,6 +923,10 @@ makeRequest options nixosChannels _ channel query from size _ sort activeSource 
                     query
                     0
                     0
+                    -- Buckets belong to the tab they are shown on: only
+                    -- modular services carry `service_environments_set`, so
+                    -- applying the filter here would empty every other badge.
+                    Nothing
                     sort
                 )
                 nixosChannels
@@ -821,9 +958,20 @@ makeRequest options nixosChannels _ channel query from size _ sort activeSource 
         |> Cmd.map SearchMsg
 
 
-makeRequestBody : List String -> String -> Int -> Int -> Search.Sort -> Body
-makeRequestBody types query from size sort =
-    Http.jsonBody (Search.Query.optionsBody types query from size sort)
+makeRequestBody : List String -> String -> Int -> Int -> Maybe String -> Search.Sort -> Body
+makeRequestBody types query from size maybeBuckets sort =
+    let
+        currentBuckets =
+            initBuckets maybeBuckets
+    in
+    Http.jsonBody
+        (Search.Query.optionsBody types
+            query
+            from
+            size
+            sort
+            [ ( "service_environments_set", currentBuckets.environments ) ]
+        )
 
 
 
@@ -849,16 +997,49 @@ decodeResultItemSource =
         |> Json.Decode.Pipeline.optional "revision" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "service_package" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "service_module" (Json.Decode.map Just Json.Decode.string) Nothing
-        |> Json.Decode.Pipeline.optional "service_packages" (Json.Decode.list Json.Decode.string) []
+        |> Json.Decode.Pipeline.optional "service_import" (Json.Decode.map Just Json.Decode.string) Nothing
+        |> Json.Decode.Pipeline.optional "service_environments"
+            (Json.Decode.list Search.ModularService.decodeEnvironment)
+            []
+        |> Json.Decode.Pipeline.optional "service_maintainers"
+            (Json.Decode.list Search.Maintainer.decode)
+            []
 
 
 decodeResultAggregations : Json.Decode.Decoder ResultAggregations
 decodeResultAggregations =
-    Json.Decode.map ResultAggregations
+    Json.Decode.map2 ResultAggregations
         (Json.Decode.field "all" decodeResultAggregationsAll)
+        -- Absent on index 50, and on any index whose mapping predates the
+        -- field; an empty aggregation just means no bucket is rendered.
+        (Json.Decode.oneOf
+            [ Json.Decode.field "service_environments_set" Search.decodeAggregation
+            , Json.Decode.succeed emptyAggregation
+            ]
+        )
+
+
+emptyAggregation : Search.Aggregation
+emptyAggregation =
+    { doc_count_error_upper_bound = 0
+    , sum_other_doc_count = 0
+    , buckets = []
+    }
 
 
 decodeResultAggregationsAll : Json.Decode.Decoder AggregationsAll
 decodeResultAggregationsAll =
     Json.Decode.map AggregationsAll
         (Json.Decode.field "doc_count" Json.Decode.int)
+
+
+encodeBuckets : Buckets -> Json.Encode.Value
+encodeBuckets buckets =
+    Json.Encode.object
+        [ ( "service_environments_set", Json.Encode.list Json.Encode.string buckets.environments ) ]
+
+
+decodeBuckets : Json.Decode.Decoder Buckets
+decodeBuckets =
+    Json.Decode.map Buckets
+        (Json.Decode.field "service_environments_set" (Json.Decode.list Json.Decode.string))

--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -335,6 +335,7 @@ viewBuckets activeSource bucketsAsString result =
             |> Search.viewBucket
                 Search.CheckboxInput
                 "Environments"
+                Search.ModularService.environmentLabel
                 (result.aggregations.service_environments_set.buckets |> sortBuckets)
                 (createBucketsMsg .environments (\s v -> { s | environments = v }))
                 initialBuckets.environments
@@ -460,8 +461,13 @@ viewResultItem nixosChannels channel show activeSource item =
                                 else
                                     []
                                )
+                            ++ (if isService then
+                                    viewServiceLink channel item.source
+
+                                else
+                                    []
+                               )
                             ++ viewServiceEnvironments item.source
-                            ++ viewServiceMaintainers item.source
                             ++ viewUsageSnippet item.source
                             ++ [ div [] [ text "Declared in" ]
                                , div [] <| findSource nixosChannels channel item.source
@@ -508,56 +514,115 @@ asHighlightPreCode value =
         ]
 
 
-{-| The environments a modular service is registered for. Each environment has
-its own half of the service, reached by its own import expression and looked
-after by its own maintainers.
+{-| Every environment the registry knows about, marked for whether this service
+supports it. A supported environment expands to its import expression, the
+maintainers of that half and a snippet in the block that environment exposes;
+an unsupported one is a leaf, since there is nothing behind it.
+
+Environment-level detail repeats across every option of the same service, so it
+stays collapsed until asked for.
+
 -}
 viewServiceEnvironments : ResultItemSource -> List (Html Msg)
 viewServiceEnvironments source =
-    if List.isEmpty source.serviceEnvironments then
-        []
+    let
+        marker supported =
+            span
+                [ class "service-environment-support"
+                , Html.Attributes.title
+                    (if supported then
+                        "Supported"
 
-    else
-        [ div [] [ text "Environments" ]
-        , div []
-            [ ul []
-                (List.map
-                    (\env ->
-                        li []
-                            (strong [] [ text env.environment ]
-                                :: text " "
-                                :: code [] [ text env.importExpr ]
+                     else
+                        "Not supported"
+                    )
+                ]
+                [ text
+                    (if supported then
+                        "✅"
+
+                     else
+                        "❌"
+                    )
+                ]
+
+        heading env =
+            [ marker env.supported
+            , text " "
+            , strong [] [ text (Search.ModularService.environmentLabel env.environment) ]
+            ]
+
+        viewEnvironment env =
+            case ( env.supported, env.importExpr ) of
+                ( True, Just importExpr ) ->
+                    li []
+                        [ Html.details []
+                            (Html.summary [] (heading env)
+                                :: div [] [ code [] [ text importExpr ] ]
                                 :: (if List.isEmpty env.maintainers then
                                         []
 
                                     else
                                         [ ul [] (List.map showMaintainer env.maintainers) ]
                                    )
+                                ++ viewEnvironmentSnippet source env.environment importExpr
                             )
-                    )
-                    source.serviceEnvironments
-                )
-            ]
-        ]
+                        ]
 
-
-{-| Maintainers of the portable half, which every environment builds on.
--}
-viewServiceMaintainers : ResultItemSource -> List (Html Msg)
-viewServiceMaintainers source =
-    if List.isEmpty source.serviceMaintainers then
+                _ ->
+                    li [] (heading env)
+    in
+    if List.isEmpty source.serviceEnvironments then
         []
 
     else
-        [ div [] [ text "Maintainers" ]
-        , div []
-            [ ul []
-                (List.map showMaintainer source.serviceMaintainers
-                    ++ Search.Maintainer.linkAllMaintainers CopyToClipboard source.serviceMaintainers
-                    ++ Search.Maintainer.mailtoAllMaintainers source.serviceMaintainers
-                )
-            ]
+        [ div [] [ text "Environments" ]
+        , div [] [ ul [ class "service-environments" ] (List.map viewEnvironment source.serviceEnvironments) ]
         ]
+
+
+{-| The import expression for the portable half.
+
+Indices written before the base/environment split carry no import expression,
+so compose it from the package and service names there.
+
+-}
+portableImport : ResultItemSource -> Maybe String
+portableImport source =
+    case source.serviceImport of
+        Just expr ->
+            Just expr
+
+        Nothing ->
+            case ( source.servicePackage, source.serviceModule ) of
+                ( Just pkg, Just service ) ->
+                    Just ("pkgs." ++ pkg ++ ".services." ++ service)
+
+                _ ->
+                    Nothing
+
+
+{-| The service this option belongs to, pointing at the package page where its
+maintainers and environment support are shown once rather than once per option.
+
+Named by its import expression rather than by `<package>.<service>`, since that
+is the string a reader would go on to write.
+
+-}
+viewServiceLink : String -> ResultItemSource -> List (Html Msg)
+viewServiceLink channel source =
+    case ( source.servicePackage, portableImport source ) of
+        ( Just pkg, Just importExpr ) ->
+            [ div [] [ text "Service" ]
+            , div []
+                [ a
+                    [ href ("/packages?channel=" ++ channel ++ "&query=" ++ pkg ++ "#show=" ++ Url.percentEncode pkg) ]
+                    [ code [] [ text importExpr ] ]
+                ]
+            ]
+
+        _ ->
+            []
 
 
 showMaintainer : Search.Maintainer.Maintainer -> Html Msg
@@ -565,14 +630,15 @@ showMaintainer =
     Search.Maintainer.showMaintainer CopyToClipboard
 
 
-{-| Render a "Usage" section showing how to use this option.
+{-| `<option> = <value>;`, indented, with the option's default when that default
+is a plain Nix expression.
 -}
-viewUsageSnippet : ResultItemSource -> List (Html Msg)
-viewUsageSnippet source =
+optionLine : ResultItemSource -> String -> String
+optionLine source indent =
     let
         -- Re-indent a (possibly multi-line) value so every line after the
         -- first aligns with `indent`.
-        indentValue indent val =
+        indentValue val =
             case String.split "\n" val of
                 [] ->
                     val
@@ -586,70 +652,76 @@ viewUsageSnippet source =
         isNixLiteral val =
             not (String.contains "<" val)
 
-        leafValue indent =
+        value =
             source.default
                 |> Maybe.andThen
                     (\val ->
                         if isNixLiteral val then
-                            Just (indentValue indent val)
+                            Just (indentValue val)
 
                         else
                             Nothing
                     )
                 |> Maybe.withDefault "..."
+    in
+    indent ++ source.name ++ " = " ++ value ++ ";\n"
 
-        nestedOption indent =
-            indent ++ source.name ++ " = " ++ leafValue indent ++ ";\n"
 
-        usage snippet =
-            [ div [] [ text "Usage" ]
-            , Utils.copyable CopyToClipboard snippet (asHighlightPreCode snippet)
+{-| What a modular service contributes to whatever service block its environment
+exposes: the import, and the option being looked at.
+-}
+serviceSnippetBody : ResultItemSource -> String -> String -> String
+serviceSnippetBody source indent importExpr =
+    indent ++ "imports = [ " ++ importExpr ++ " ];\n" ++ optionLine source indent
+
+
+usageSection : String -> List (Html Msg)
+usageSection snippet =
+    [ div [] [ text "Usage" ]
+    , Utils.copyable CopyToClipboard snippet (asHighlightPreCode snippet)
+    ]
+
+
+{-| The same body wrapped in the block a specific environment exposes, for
+environments whose shape we know.
+-}
+viewEnvironmentSnippet : ResultItemSource -> String -> String -> List (Html Msg)
+viewEnvironmentSnippet source environment importExpr =
+    case Search.ModularService.environmentUsagePath environment of
+        Just path ->
+            [ div []
+                [ let
+                    snippet =
+                        path ++ " = {\n" ++ serviceSnippetBody source "  " importExpr ++ "};"
+                  in
+                  Utils.copyable CopyToClipboard snippet (asHighlightPreCode snippet)
+                ]
             ]
+
+        Nothing ->
+            []
+
+
+{-| Render a "Usage" section showing how to use this option.
+-}
+viewUsageSnippet : ResultItemSource -> List (Html Msg)
+viewUsageSnippet source =
+    let
+        usage =
+            usageSection
+
+        nestedOption =
+            optionLine source
     in
     case source.docType of
         "service" ->
-            let
-                -- Indices written before the base/environment split carry
-                -- neither import expression, so compose the portable half's
-                -- from the package and service names.
-                composedImport =
-                    case ( source.servicePackage, source.serviceModule ) of
-                        ( Just pkg, Just mod_ ) ->
-                            Just ("pkgs." ++ pkg ++ ".services." ++ mod_)
-
-                        _ ->
-                            Nothing
-
-                -- A NixOS configuration wants the environment half; importing
-                -- the portable one alone would silently omit the systemd
-                -- integration.
-                importExpr =
-                    case source.serviceEnvironments of
-                        [] ->
-                            case source.serviceImport of
-                                Just base ->
-                                    Just base
-
-                                Nothing ->
-                                    composedImport
-
-                        environments ->
-                            Just
-                                (Search.ModularService.preferredImport
-                                    (Maybe.withDefault "" source.serviceImport)
-                                    environments
-                                )
-            in
-            case importExpr of
+            -- The portable half is the one every environment builds on, so it
+            -- is what an environment-agnostic snippet can name. The block these
+            -- lines go in differs per environment -- `system.services.<name>`
+            -- on NixOS -- and is shown under that environment instead.
+            case portableImport source of
                 Just expr ->
-                    usage
-                        ("system.services.<name> = {\n"
-                            ++ "  imports = [ "
-                            ++ expr
-                            ++ " ];\n"
-                            ++ nestedOption "  "
-                            ++ "};"
-                        )
+                    usage (serviceSnippetBody source "" expr)
 
                 Nothing ->
                     []

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -336,30 +336,35 @@ viewBuckets bucketsAsString result =
         |> viewBucket
             Search.RadioInput
             "Package sets"
+            identity
             (result.aggregations.package_attr_set.buckets |> sortBuckets)
             (createBucketsMsg True .packageSets (\s v -> { s | packageSets = v }))
             selectedBucket.packageSets
         |> viewBucket
             Search.CheckboxInput
             "Licenses"
+            identity
             (result.aggregations.package_license_set.buckets |> sortBuckets)
             (createBucketsMsg False .licenses (\s v -> { s | licenses = v }))
             selectedBucket.licenses
         |> viewBucket
             Search.CheckboxInput
             "Maintainers"
+            identity
             (result.aggregations.package_maintainers_set.buckets |> sortBuckets)
             (createBucketsMsg False .maintainers (\s v -> { s | maintainers = v }))
             selectedBucket.maintainers
         |> viewBucket
             Search.CheckboxInput
             "Teams"
+            identity
             (result.aggregations.package_teams_set.buckets |> sortBuckets)
             (createBucketsMsg False .teams (\s v -> { s | teams = v }))
             selectedBucket.teams
         |> viewBucket
             Search.CheckboxInput
             "Platforms"
+            identity
             (result.aggregations.package_platforms.buckets |> sortBuckets)
             (createBucketsMsg False .platforms (\s v -> { s | platforms = v }))
             selectedBucket.platforms
@@ -830,55 +835,7 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                     , programs
                     , maintainersTeamsAndPlatforms
                     , optionsLink
-                    , let
-                        -- The import expressions come from the index, so they
-                        -- match the channel being looked at. Indices written
-                        -- before the base/environment split carry only the
-                        -- service names, from which the portable half's import
-                        -- can be composed.
-                        serviceImports =
-                            case item.source.modularServiceImports of
-                                [] ->
-                                    List.map
-                                        (\mod_ -> "pkgs." ++ item.source.attr_name ++ ".services." ++ mod_)
-                                        item.source.modularServices
-
-                                packageServices ->
-                                    List.map
-                                        (\service ->
-                                            Search.ModularService.preferredImport
-                                                service.importExpr
-                                                service.environments
-                                        )
-                                        packageServices
-                      in
-                      if List.isEmpty serviceImports then
-                        text ""
-
-                      else
-                        div []
-                            [ h4 []
-                                [ text "Modular Services"
-                                , text " "
-                                , a
-                                    [ href "https://nixos.org/manual/nixos/stable/#modular-services"
-                                    , Html.Attributes.target "_blank"
-                                    , Html.Attributes.title "What are modular services?"
-                                    ]
-                                    [ text "(?)" ]
-                                ]
-                            , ul []
-                                (List.map
-                                    (\importExpr ->
-                                        li []
-                                            [ a
-                                                [ href ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name ++ "&include_nixos_options=0") ]
-                                                [ code [] [ text importExpr ] ]
-                                            ]
-                                    )
-                                    serviceImports
-                                )
-                            ]
+                    , viewModularServices channel item.source
                     ]
                 ]
 
@@ -924,6 +881,144 @@ viewResultItem nixosChannels channel showUsageDetails show item =
          ]
             ++ longerPackageDetails
         )
+
+
+{-| The modular services this package exposes, and which environments each of
+them can be used in.
+
+Environments the registry knows but a service is not registered for are listed
+too, so the list answers "is this usable here yet?" rather than only listing
+what happens to work. Indices written before the base/environment split carry
+only the service names, from which the portable half's import can be composed.
+
+Each half carries its own maintainers: the ones next to the service maintain the
+portable module every environment builds on, the ones under an environment
+maintain that environment's integration only.
+
+Environments are stacked rather than laid out side by side, since the registry
+is expected to grow more of them than fit across a page.
+
+-}
+viewModularServices : String -> ResultItemSource -> Html Msg
+viewModularServices channel source =
+    let
+        services =
+            case source.modularServiceImports of
+                [] ->
+                    List.map
+                        (\service ->
+                            { service = service
+                            , importExpr = "pkgs." ++ source.attr_name ++ ".services." ++ service
+                            , maintainers = []
+                            , environments = []
+                            }
+                        )
+                        source.modularServices
+
+                packageServices ->
+                    packageServices
+
+        -- The service's options live on the Modular services tab, so the link
+        -- has to select that source; the options page otherwise opens on NixOS
+        -- options, which carry none of them.
+        serviceRoute =
+            Route.Options
+                { query = Just source.attr_name
+                , channel = Just channel
+                , show = Nothing
+                , from = Nothing
+                , size = Nothing
+                , buckets = Nothing
+                , sort = Nothing
+                , type_ = Just Route.OptionSearch
+                , activeOptionSource = Route.ModularServiceOptions
+                }
+
+        serviceLink service =
+            a [ Route.href serviceRoute ] [ code [] [ text service.importExpr ] ]
+
+        maintainerList maintainers =
+            if List.isEmpty maintainers then
+                []
+
+            else
+                [ ul [ class "modular-service-maintainers" ]
+                    (List.map (Search.Maintainer.showMaintainer CopyToClipboard) maintainers)
+                ]
+
+        marker supported =
+            span
+                [ class "service-environment-support"
+                , title
+                    (if supported then
+                        "Supported"
+
+                     else
+                        "Not supported"
+                    )
+                ]
+                [ text
+                    (if supported then
+                        "✅"
+
+                     else
+                        "❌"
+                    )
+                ]
+
+        heading env =
+            [ marker env.supported
+            , text " "
+            , strong [] [ text (Search.ModularService.environmentLabel env.environment) ]
+            ]
+
+        -- A supported environment expands to the import of its half and the
+        -- maintainers of that half; an unsupported one has nothing behind it.
+        viewEnvironment env =
+            case ( env.supported, env.importExpr ) of
+                ( True, Just importExpr ) ->
+                    li []
+                        [ Html.details []
+                            (Html.summary [] (heading env)
+                                :: div [] [ code [] [ text importExpr ] ]
+                                :: maintainerList env.maintainers
+                            )
+                        ]
+
+                _ ->
+                    li [] (heading env)
+
+        viewService service =
+            li []
+                (serviceLink service
+                    :: maintainerList service.maintainers
+                    ++ (if List.isEmpty service.environments then
+                            []
+
+                        else
+                            [ ul [ class "service-environments" ]
+                                (List.map viewEnvironment service.environments)
+                            ]
+                       )
+                )
+    in
+    if List.isEmpty services then
+        text ""
+
+    else
+        div []
+            [ h4 []
+                [ text "Modular Services"
+                , text " "
+                , a
+                    [ href "https://nixos.org/manual/nixos/stable/#modular-services"
+                    , Html.Attributes.target "_blank"
+                    , Html.Attributes.title "What are modular services?"
+                    ]
+                    [ text "(?)" ]
+                ]
+            , ul [ class "modular-services" ] (List.map viewService services)
+            ]
 
 
 inlineListElementsCopyableCode : (a -> String) -> (a -> String) -> (a -> Html Msg) -> List a -> Html Msg

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -69,6 +69,8 @@ import Search
         , NixOSChannel
         , viewBucket
         )
+import Search.Maintainer
+import Search.ModularService
 import Search.Query
 import Utils
 
@@ -104,6 +106,7 @@ type alias ResultItemSource =
     , flakeDescription : Maybe String
     , flakeUrl : Maybe ( String, String )
     , modularServices : List String
+    , modularServiceImports : List Search.ModularService.PackageService
     }
 
 
@@ -134,10 +137,7 @@ type LicenseExpression
 
 
 type alias ResultPackageMaintainer =
-    { name : Maybe String
-    , email : Maybe String
-    , github : Maybe String
-    }
+    Search.Maintainer.Maintainer
 
 
 type alias ResultPackageTeam =
@@ -493,63 +493,11 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                        )
                 )
 
-        showMaintainer maintainer =
-            let
-                githubHandle =
-                    Maybe.map (String.append "@") maintainer.github
+        showMaintainer =
+            Search.Maintainer.showMaintainer CopyToClipboard
 
-                name =
-                    Maybe.withDefault (Maybe.withDefault "Unknown" maintainer.github) maintainer.name
-
-                nameHtml =
-                    case maintainer.github of
-                        Just github ->
-                            a [ href ("https://github.com/" ++ github) ] [ text name ]
-
-                        Nothing ->
-                            text name
-
-                githubHtml =
-                    case githubHandle of
-                        Just handle ->
-                            [ text " ("
-                            , code [] [ text handle ]
-                            , text ")"
-                            ]
-
-                        Nothing ->
-                            []
-
-                emailHtml =
-                    case maintainer.email of
-                        Just email ->
-                            [ text " <"
-                            , a [ href ("mailto:" ++ email) ] [ text email ]
-                            , text ">"
-                            ]
-
-                        Nothing ->
-                            []
-
-                ( onClickAttr, _ ) =
-                    case githubHandle of
-                        Just handle ->
-                            ( [ onClick (CopyToClipboard handle) ], [] )
-
-                        Nothing ->
-                            ( [], [] )
-            in
-            li (class "maintainer-list-item" :: onClickAttr) (nameHtml :: githubHtml ++ emailHtml)
-
-        linkAllMaintainers maintainers =
-            let
-                ghHandles =
-                    List.filterMap (\m -> Maybe.map (String.append "@") m.github) maintainers
-            in
-            optionals (not (List.isEmpty ghHandles))
-                [ li [ class "maintainer-list-item", onClick (CopyToClipboard (String.join " " ghHandles)) ]
-                    [ text "Copy all maintainers' GitHub handles" ]
-                ]
+        linkAllMaintainers =
+            Search.Maintainer.linkAllMaintainers CopyToClipboard
 
         showTeam team =
             let
@@ -583,18 +531,8 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                             :: List.concatMap showTeamEntry githubTeams
                             ++ scope
 
-        mailtoAllMaintainers maintainers =
-            let
-                maintainerMails =
-                    List.filterMap (\m -> m.email) maintainers
-            in
-            optionals (List.length maintainerMails > 1)
-                [ a
-                    [ href ("mailto:" ++ String.join "," maintainerMails) ]
-                    [ li [ class "maintainer-list-item" ]
-                        [ text "✉️ Mail to all maintainers" ]
-                    ]
-                ]
+        mailtoAllMaintainers =
+            Search.Maintainer.mailtoAllMaintainers
 
         showPlatform platform =
             case List.Extra.find (\x -> x.id == channel) nixosChannels of
@@ -892,7 +830,29 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                     , programs
                     , maintainersTeamsAndPlatforms
                     , optionsLink
-                    , if List.isEmpty item.source.modularServices then
+                    , let
+                        -- The import expressions come from the index, so they
+                        -- match the channel being looked at. Indices written
+                        -- before the base/environment split carry only the
+                        -- service names, from which the portable half's import
+                        -- can be composed.
+                        serviceImports =
+                            case item.source.modularServiceImports of
+                                [] ->
+                                    List.map
+                                        (\mod_ -> "pkgs." ++ item.source.attr_name ++ ".services." ++ mod_)
+                                        item.source.modularServices
+
+                                packageServices ->
+                                    List.map
+                                        (\service ->
+                                            Search.ModularService.preferredImport
+                                                service.importExpr
+                                                service.environments
+                                        )
+                                        packageServices
+                      in
+                      if List.isEmpty serviceImports then
                         text ""
 
                       else
@@ -909,22 +869,14 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                                 ]
                             , ul []
                                 (List.map
-                                    (\mod_ ->
-                                        let
-                                            suffix =
-                                                if mod_ == "default" then
-                                                    ""
-
-                                                else
-                                                    "." ++ mod_
-                                        in
+                                    (\importExpr ->
                                         li []
                                             [ a
                                                 [ href ("/options?channel=" ++ channel ++ "&query=" ++ item.source.attr_name ++ "&include_nixos_options=0") ]
-                                                [ code [] [ text ("pkgs." ++ item.source.attr_name ++ ".services" ++ suffix) ] ]
+                                                [ code [] [ text importExpr ] ]
                                             ]
                                     )
-                                    item.source.modularServices
+                                    serviceImports
                                 )
                             ]
                     ]
@@ -1275,6 +1227,9 @@ decodeResultItemSource =
         |> Json.Decode.Pipeline.optional "flake_description" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "flake_resolved" (Json.Decode.map Just decodeResolvedFlake) Nothing
         |> Json.Decode.Pipeline.optional "package_modular_services" (Json.Decode.list Json.Decode.string) []
+        |> Json.Decode.Pipeline.optional "package_modular_service_imports"
+            (Json.Decode.list Search.ModularService.decodePackageService)
+            []
 
 
 type alias ResolvedFlake =
@@ -1413,16 +1368,7 @@ decodeLicenseExpression =
 
 decodeResultPackageMaintainer : Json.Decode.Decoder ResultPackageMaintainer
 decodeResultPackageMaintainer =
-    Json.Decode.map3 ResultPackageMaintainer
-        (Json.Decode.oneOf
-            [ Json.Decode.field "name" (Json.Decode.map Just Json.Decode.string)
-            , Json.Decode.field "email" (Json.Decode.map Just Json.Decode.string)
-            , Json.Decode.field "github" (Json.Decode.map Just Json.Decode.string)
-            , Json.Decode.succeed Nothing
-            ]
-        )
-        (Json.Decode.field "email" (Json.Decode.nullable Json.Decode.string))
-        (Json.Decode.field "github" (Json.Decode.nullable Json.Decode.string))
+    Search.Maintainer.decode
 
 
 decodeResultPackageTeam : Json.Decode.Decoder ResultPackageTeam

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -826,6 +826,7 @@ viewFlakes outMsg selectedCategory =
     viewBucket
         RadioInput
         "Category"
+        identity
         (List.map (\cat -> { key = searchTypeToTitle cat, doc_count = 0 }) allTypes)
         (\title ->
             outMsg
@@ -1046,15 +1047,19 @@ type BucketInputType
     | RadioInput
 
 
+{-| `labelFor` renders a bucket key for display; the key itself still drives
+selection, so it must not be folded into the label.
+-}
 viewBucket :
     BucketInputType
     -> String
+    -> (String -> String)
     -> List AggregationsBucketItem
     -> (String -> a)
     -> List String
     -> List (Html a)
     -> List (Html a)
-viewBucket inputType title buckets searchMsgFor selectedBucket sets =
+viewBucket inputType title labelFor buckets searchMsgFor selectedBucket sets =
     List.append
         sets
         (if List.isEmpty buckets then
@@ -1080,7 +1085,7 @@ viewBucket inputType title buckets searchMsgFor selectedBucket sets =
                             label
                                 [ classList [ ( "selected", isSelected ) ]
                                 ]
-                                [ span [] [ text bucket.key ]
+                                [ span [] [ text (labelFor bucket.key) ]
                                 , if isSelected || bucket.doc_count <= 0 then
                                     closeButton
 

--- a/frontend/src/Search/Maintainer.elm
+++ b/frontend/src/Search/Maintainer.elm
@@ -1,0 +1,120 @@
+module Search.Maintainer exposing
+    ( Maintainer
+    , decode
+    , linkAllMaintainers
+    , mailtoAllMaintainers
+    , showMaintainer
+    )
+
+{-| Maintainer rendering shared by package results and modular service results.
+
+Each view passes in its own `copy` message constructor, since the clipboard
+message belongs to the page's own `Msg` type.
+
+-}
+
+import Html exposing (Html, a, code, li, text)
+import Html.Attributes exposing (class, href)
+import Html.Events exposing (onClick)
+import Json.Decode
+
+
+type alias Maintainer =
+    { name : Maybe String
+    , email : Maybe String
+    , github : Maybe String
+    }
+
+
+decode : Json.Decode.Decoder Maintainer
+decode =
+    Json.Decode.map3 Maintainer
+        (Json.Decode.oneOf
+            [ Json.Decode.field "name" (Json.Decode.map Just Json.Decode.string)
+            , Json.Decode.field "email" (Json.Decode.map Just Json.Decode.string)
+            , Json.Decode.field "github" (Json.Decode.map Just Json.Decode.string)
+            , Json.Decode.succeed Nothing
+            ]
+        )
+        (Json.Decode.field "email" (Json.Decode.nullable Json.Decode.string))
+        (Json.Decode.field "github" (Json.Decode.nullable Json.Decode.string))
+
+
+showMaintainer : (String -> msg) -> Maintainer -> Html msg
+showMaintainer copy maintainer =
+    let
+        githubHandle =
+            Maybe.map (String.append "@") maintainer.github
+
+        name =
+            Maybe.withDefault (Maybe.withDefault "Unknown" maintainer.github) maintainer.name
+
+        nameHtml =
+            case maintainer.github of
+                Just github ->
+                    a [ href ("https://github.com/" ++ github) ] [ text name ]
+
+                Nothing ->
+                    text name
+
+        githubHtml =
+            case githubHandle of
+                Just handle ->
+                    [ text " ("
+                    , code [] [ text handle ]
+                    , text ")"
+                    ]
+
+                Nothing ->
+                    []
+
+        emailHtml =
+            case maintainer.email of
+                Just email ->
+                    [ text " <"
+                    , a [ href ("mailto:" ++ email) ] [ text email ]
+                    , text ">"
+                    ]
+
+                Nothing ->
+                    []
+
+        onClickAttr =
+            case githubHandle of
+                Just handle ->
+                    [ onClick (copy handle) ]
+
+                Nothing ->
+                    []
+    in
+    li (class "maintainer-list-item" :: onClickAttr) (nameHtml :: githubHtml ++ emailHtml)
+
+
+linkAllMaintainers : (String -> msg) -> List Maintainer -> List (Html msg)
+linkAllMaintainers copy maintainers =
+    case List.filterMap (\m -> Maybe.map (String.append "@") m.github) maintainers of
+        [] ->
+            []
+
+        ghHandles ->
+            [ li [ class "maintainer-list-item", onClick (copy (String.join " " ghHandles)) ]
+                [ text "Copy all maintainers' GitHub handles" ]
+            ]
+
+
+mailtoAllMaintainers : List Maintainer -> List (Html msg)
+mailtoAllMaintainers maintainers =
+    let
+        maintainerMails =
+            List.filterMap (\m -> m.email) maintainers
+    in
+    if List.length maintainerMails > 1 then
+        [ a
+            [ href ("mailto:" ++ String.join "," maintainerMails) ]
+            [ li [ class "maintainer-list-item" ]
+                [ text "✉️ Mail to all maintainers" ]
+            ]
+        ]
+
+    else
+        []

--- a/frontend/src/Search/ModularService.elm
+++ b/frontend/src/Search/ModularService.elm
@@ -3,13 +3,20 @@ module Search.ModularService exposing
     , PackageService
     , decodeEnvironment
     , decodePackageService
+    , environmentLabel
+    , environmentUsagePath
     , preferredImport
+    , supportedEnvironments
     )
 
 {-| A modular service consists of a portable half, reachable as
 `pkgs.<pkg>.services.<svc>`, and one half per environment it is registered for
 (today only `system`, reachable as `config.modularServices.<pkg>.<svc>`). Each
 half carries its own import expression and its own maintainers.
+
+`service_environments` lists every environment nixpkgs' registry knows about,
+not just the ones a given service is registered for; `supported` tells them
+apart, so the UI can show which environments a service does _not_ work in.
 
 On nixpkgs revisions that predate the split there is no separate environment
 half, and every import expression is the portable one.
@@ -23,7 +30,8 @@ import Search.Maintainer exposing (Maintainer)
 
 type alias Environment =
     { environment : String
-    , importExpr : String
+    , supported : Bool
+    , importExpr : Maybe String
     , maintainers : List Maintainer
     }
 
@@ -31,23 +39,73 @@ type alias Environment =
 type alias PackageService =
     { service : String
     , importExpr : String
+    , maintainers : List Maintainer
     , environments : List Environment
     }
 
 
+{-| The environments a service can actually be used in.
+-}
+supportedEnvironments : List Environment -> List Environment
+supportedEnvironments =
+    List.filter .supported
+
+
+{-| Human-readable name for a registry environment.
+
+These names come from nixpkgs' modular service registry, so they are NixOS's
+environments. Modular services are also consumed from service managers outside
+nixpkgs (nimi, finix, Home Manager); those bring their own registries, and an
+index built from one would need its own qualifier here.
+
+-}
+environmentLabel : String -> String
+environmentLabel environment =
+    case environment of
+        "system" ->
+            "NixOS system"
+
+        "user" ->
+            "NixOS user"
+
+        other ->
+            other
+
+
+{-| The configuration path an environment exposes its services under, used to
+wrap a usage snippet in the block a user would actually write.
+
+Only environments whose shape we know get one; the rest show their import
+expression on its own rather than a snippet that guesses.
+
+-}
+environmentUsagePath : String -> Maybe String
+environmentUsagePath environment =
+    case environment of
+        "system" ->
+            Just "system.services.<name>"
+
+        _ ->
+            Nothing
+
+
 {-| The import expression to show by default: `system` when the service is
-registered for it, otherwise whichever environment comes first, and finally the
-portable half when there is no environment data at all (index 50, or a flake).
+registered for it, otherwise whichever supported environment comes first, and
+finally the portable half when there is no environment data at all (index 50,
+or a flake).
 -}
 preferredImport : String -> List Environment -> String
 preferredImport fallback environments =
     let
+        supported =
+            supportedEnvironments environments
+
         system =
-            List.filter (\env -> env.environment == "system") environments
+            List.filter (\env -> env.environment == "system") supported
     in
-    case system ++ environments of
-        env :: _ ->
-            env.importExpr
+    case List.filterMap .importExpr (system ++ supported) of
+        expr :: _ ->
+            expr
 
         [] ->
             fallback
@@ -57,7 +115,12 @@ decodeEnvironment : Json.Decode.Decoder Environment
 decodeEnvironment =
     Json.Decode.succeed Environment
         |> Json.Decode.Pipeline.required "environment" Json.Decode.string
-        |> Json.Decode.Pipeline.required "import" Json.Decode.string
+        -- Indices written before unsupported environments were listed only ever
+        -- carried supported ones.
+        |> Json.Decode.Pipeline.optional "supported" Json.Decode.bool True
+        |> Json.Decode.Pipeline.optional "import"
+            (Json.Decode.map Just Json.Decode.string)
+            Nothing
         |> Json.Decode.Pipeline.optional "maintainers"
             (Json.Decode.list Search.Maintainer.decode)
             []
@@ -68,6 +131,9 @@ decodePackageService =
     Json.Decode.succeed PackageService
         |> Json.Decode.Pipeline.required "service" Json.Decode.string
         |> Json.Decode.Pipeline.required "import" Json.Decode.string
+        |> Json.Decode.Pipeline.optional "maintainers"
+            (Json.Decode.list Search.Maintainer.decode)
+            []
         |> Json.Decode.Pipeline.optional "environments"
             (Json.Decode.list decodeEnvironment)
             []

--- a/frontend/src/Search/ModularService.elm
+++ b/frontend/src/Search/ModularService.elm
@@ -1,0 +1,73 @@
+module Search.ModularService exposing
+    ( Environment
+    , PackageService
+    , decodeEnvironment
+    , decodePackageService
+    , preferredImport
+    )
+
+{-| A modular service consists of a portable half, reachable as
+`pkgs.<pkg>.services.<svc>`, and one half per environment it is registered for
+(today only `system`, reachable as `config.modularServices.<pkg>.<svc>`). Each
+half carries its own import expression and its own maintainers.
+
+On nixpkgs revisions that predate the split there is no separate environment
+half, and every import expression is the portable one.
+
+-}
+
+import Json.Decode
+import Json.Decode.Pipeline
+import Search.Maintainer exposing (Maintainer)
+
+
+type alias Environment =
+    { environment : String
+    , importExpr : String
+    , maintainers : List Maintainer
+    }
+
+
+type alias PackageService =
+    { service : String
+    , importExpr : String
+    , environments : List Environment
+    }
+
+
+{-| The import expression to show by default: `system` when the service is
+registered for it, otherwise whichever environment comes first, and finally the
+portable half when there is no environment data at all (index 50, or a flake).
+-}
+preferredImport : String -> List Environment -> String
+preferredImport fallback environments =
+    let
+        system =
+            List.filter (\env -> env.environment == "system") environments
+    in
+    case system ++ environments of
+        env :: _ ->
+            env.importExpr
+
+        [] ->
+            fallback
+
+
+decodeEnvironment : Json.Decode.Decoder Environment
+decodeEnvironment =
+    Json.Decode.succeed Environment
+        |> Json.Decode.Pipeline.required "environment" Json.Decode.string
+        |> Json.Decode.Pipeline.required "import" Json.Decode.string
+        |> Json.Decode.Pipeline.optional "maintainers"
+            (Json.Decode.list Search.Maintainer.decode)
+            []
+
+
+decodePackageService : Json.Decode.Decoder PackageService
+decodePackageService =
+    Json.Decode.succeed PackageService
+        |> Json.Decode.Pipeline.required "service" Json.Decode.string
+        |> Json.Decode.Pipeline.required "import" Json.Decode.string
+        |> Json.Decode.Pipeline.optional "environments"
+            (Json.Decode.list decodeEnvironment)
+            []

--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -120,8 +120,51 @@ optionsBody :
     -> Int
     -> Int
     -> Sort
+    -> List ( String, List String )
     -> Json.Encode.Value
-optionsBody types query from size sort =
+optionsBody types query from size sort selectedBuckets =
+    let
+        -- Only modular service documents carry these, so the buckets stay empty
+        -- on the other option tabs.
+        terms : List Terms
+        terms =
+            [ { field = "service_environments_set", size = 20, include = Nothing } ]
+
+        selectionFor : String -> List String
+        selectionFor field =
+            selectedBuckets
+                |> List.filter (\( f, _ ) -> f == field)
+                |> List.head
+                |> Maybe.map Tuple.second
+                |> Maybe.withDefault []
+
+        filterByBuckets : List ( String, Json.Encode.Value )
+        filterByBuckets =
+            [ ( "bool"
+              , Json.Encode.object
+                    [ ( "must"
+                      , Json.Encode.list Json.Encode.object
+                            (List.map
+                                (\term ->
+                                    [ ( "bool"
+                                      , Json.Encode.object
+                                            [ ( "should"
+                                              , Json.Encode.list Json.Encode.object <|
+                                                    List.map
+                                                        (filterByBucket term.field)
+                                                        (selectionFor term.field)
+                                              )
+                                            ]
+                                      )
+                                    ]
+                                )
+                                terms
+                            )
+                      )
+                    ]
+              )
+            ]
+    in
     encodeRequestBody
         (String.trim query)
         from
@@ -130,15 +173,14 @@ optionsBody types query from size sort =
         types
         "option_name"
         []
-        []
-        []
+        terms
+        filterByBuckets
         [ "option_name", "option_name_query" ]
         [ ( "option_name", 6.0 )
         , ( "option_name_query", 6.0 )
         , ( "option_description", 1.0 )
         , ( "flake_name", 0.5 )
         , ( "service_package", 3.0 )
-        , ( "service_packages", 3.0 )
         ]
         [ "option_description^3" ]
         []

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -938,6 +938,71 @@ a:focus-visible {
   }
 }
 
+// Environment support for a modular service, on the expanded option view.
+// Each supported environment is a `<details>` whose body repeats across every
+// option of the same service, so it stays shut until asked for; unsupported
+// ones are plain leaves and get the same indent as a `<summary>`.
+.service-environments {
+  list-style: none;
+  padding-left: 0;
+
+  & > li {
+    margin-bottom: 0.25em;
+  }
+
+  summary {
+    cursor: pointer;
+  }
+
+  // Align leaves with the text of a `<summary>`, past its disclosure marker.
+  & > li:not(:has(details)) {
+    padding-left: 1.1em;
+  }
+
+  details > *:not(summary) {
+    margin: 0.25em 0 0.25em 1.1em;
+  }
+}
+
+.service-environment-support {
+  // Keep the check/cross from resizing the line when a font renders them
+  // wider than a normal glyph.
+  display: inline-block;
+  width: 1.2em;
+}
+
+// Which environments each of a package's modular services supports. Nested
+// lists rather than a matrix: the registry keeps gaining environments, and
+// stacking them keeps the block growing downwards instead of off the page.
+ul.modular-services {
+  list-style: none;
+  padding-left: 0;
+
+  & > li {
+    margin-bottom: 0.5em;
+  }
+
+  .service-environments {
+    margin: 0.25em 0 0 1.1em;
+  }
+}
+
+// A half's maintainers sit directly under that half.
+.modular-service-maintainers {
+  list-style: none;
+  margin: 0.25em 0 0 1.1em;
+  padding: 0;
+  font-size: 0.85em;
+
+  .maintainer-list-item {
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--hovered-item-background);
+    }
+  }
+}
+
 // The Name code block in the expanded option view hosts a floating copy
 // button at its right edge. Keep the block as the positioning context so
 // the button overlays the code without jostling its layout.

--- a/version.nix
+++ b/version.nix
@@ -4,7 +4,7 @@
   # When making backwards-incompatible schema changes,
   # change the code for the import job first, updating this version number.
   # Only after the new index has been populated, update the frontend.
-  import = "50";
+  import = "51";
 
   # Frontend index version used by the UI when querying Elasticsearch
   # Keep this at the old version while 'import' populates a new index, then update to switch traffic


### PR DESCRIPTION
At nixpkgs, I have proposed (NixOS/nixpkgs#540863) splitting each modular service into two halves: a portable package service at `pkgs/**/service.nix`, reachable as `pkgs.<pkg>.services.<svc>`, and environment-specific implementations thereof (so far: a NixOS system-level service) at `nixos/modules/system/service/modular/<pkg>/<svc>/system.nix`.
Both are enumerated in a registry keyed `<environment>.<pkg>.<service>` and exposed as `lib.nixos.modularServices` (all environments) and `config.modularServices` (the `system` slice).

The current change then helps validate that the proposed method may help make discoverable what services would be supported on what environments (NixOS/nixpkgs#545204).

<img width="964" height="1520" alt="image" src="https://github.com/user-attachments/assets/ddc6d872-9914-4497-9315-6b3fb89c8c9b" />

<img width="964" height="1520" alt="image" src="https://github.com/user-attachments/assets/2868548b-3643-45d1-adae-f919b67c59df" />

(Note that, while in the screenshots the maintainers listed for the package service vs its NixOS system implementation are identical, these are separate - one does not need to maintain one just because they volunteered to maintain the other.)

Disclaimer: I used a coding agent in the creation of this patch.
