### PR TITLE
flakes: add nix-t3code

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -296,6 +296,11 @@ repo = "bitbucket-runner-nix"
 
 [[sources]]
 type = "github"
+owner = "limwa"
+repo = "nix-t3code"
+
+[[sources]]
+type = "github"
 owner = "linyinfeng"
 repo = "angrr"
 


### PR DESCRIPTION
Adds [limwa/nix-t3code](https://github.com/limwa/nix-t3code) to the flakes index.

`t3code` is already in nixpkgs, and this flake mostly cherry-picks that packaging, but it also provides **_nightly builds_**, which is the main reason to list it here and not rely on nixpkgs alone