### PR TITLE
fix(frontend): hide sidebar during search

### DIFF
--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -468,6 +468,10 @@ footer {
     }
   }
 
+  .loader-wrapper .search-sidebar {
+    visibility: hidden;
+  }
+
   // Buckets
   .search-sidebar {
     margin: 0 1em 0 0;


### PR DESCRIPTION
before:

<img height="240" alt="Peek 2026-07-26 18-43" src="https://github.com/user-attachments/assets/abb2d123-d65a-4d0b-aaca-487b2dee8e42" />

after:

<img height="240" alt="Peek 2026-07-26 18-44" src="https://github.com/user-attachments/assets/a3367063-4e31-438e-b07d-6487fd0ac03a" />

