### PR TITLE
flake-info: restore argument defaults for `nix eval -f`

### DIFF
--- a/.github/workflows/build-flake-info.yml
+++ b/.github/workflows/build-flake-info.yml
@@ -34,3 +34,16 @@ jobs:
         shell: sh
         run: |
           nix flake check --impure --accept-flake-config
+
+      # Exercises the CLI's argument-passing path, which the Nix-level tests
+      # bypass by importing `flake_info.nix` directly.
+      - name: flake-info CLI smoke test
+        shell: sh
+        run: |
+          nix run --accept-flake-config .#flake-info -- \
+            --json flake github:ryantm/agenix | jq -e 'length > 0'
+
+          nix eval --json --no-write-lock-file \
+            -f ./flake-info/assets/commands/flake_info.nix \
+            --override-flake nixpkgs https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz \
+            nixos-package-services >/dev/null

--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -1,7 +1,12 @@
 {
-  targetFlake,
-  nixpkgsFlake,
-  flake-schemas,
+  # Either an already-resolved flake attrset (when imported from Nix, e.g. via
+  # `self.lib.evalFlake`) or a flake reference string. `flake-info` drives this
+  # file with `nix eval -f` and supplies the flake through the registry
+  # (`--override-flake targetFlake <ref>`), which can only fill the defaults
+  # below -- not function formals.
+  targetFlake ? builtins.getFlake "targetFlake",
+  nixpkgsFlake ? builtins.getFlake "nixpkgs",
+  flake-schemas ? builtins.getFlake "flake-schemas",
   targetFlakeUri ? if nixpkgsFlake.lib.isString targetFlake then targetFlake else null,
 }:
 let
@@ -307,7 +312,7 @@ let
 
   # Extract options from home-manager's module system.
   # Evaluated separately during the nixpkgs channel import (via
-  # `--override-flake input-flake github:nix-community/home-manager`) so that
+  # `--override-flake targetFlake github:nix-community/home-manager`) so that
   # home-manager options land in the channel index alongside NixOS options.
   readHomeManagerOptions =
     let
@@ -338,7 +343,7 @@ let
 
   # Extract options from nix-darwin's module system.
   # Evaluated separately during the nixpkgs channel import (via
-  # `--override-flake input-flake github:nix-darwin/nix-darwin`) so that
+  # `--override-flake targetFlake github:nix-darwin/nix-darwin`) so that
   # nix-darwin options land in the channel index alongside NixOS options.
   readDarwinOptions =
     let

--- a/flake-info/default.nix
+++ b/flake-info/default.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs, flake-schemas }:
 pkgs.rustPlatform.buildRustPackage rec {
   name = "flake-info";
   src = ./.;
@@ -25,6 +25,9 @@ pkgs.rustPlatform.buildRustPackage rec {
 
   ROOTDIR = builtins.placeholder "out";
   LINK_MANPAGES_PANDOC_FILTER = import src/data/link-manpages.nix { inherit pkgs; };
+  # Baked in at build time so `nix eval -f assets/commands/flake_info.nix` can
+  # resolve the `flake-schemas` registry override to a locked ref.
+  FLAKE_SCHEMAS_REF = "github:DeterminateSystems/flake-schemas/${flake-schemas.rev}";
 
   checkFlags = [
     "--skip elastic::tests"

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -40,6 +40,14 @@ pub fn run_garbage_collection() -> Result<()> {
 pub fn nix_eval_command(args: &[&str]) -> Command {
     let mut command = Command::with_args("nix", args.iter());
     command.add_arg_pair("-f", EXTRACT_SCRIPT.clone());
+    command.add_args(
+        [
+            "--override-flake",
+            "flake-schemas",
+            option_env!("FLAKE_SCHEMAS_REF").unwrap_or("github:DeterminateSystems/flake-schemas"),
+        ]
+        .iter(),
+    );
     command.enable_capture();
     command.log_to = LogTo::Log;
     command.log_output_on_error = true;

--- a/flake.nix
+++ b/flake.nix
@@ -155,7 +155,10 @@
         rec {
           packages = {
             default = packages.flake-info;
-            flake-info = import ./flake-info { inherit pkgs; };
+            flake-info = import ./flake-info {
+              inherit pkgs;
+              inherit (inputs) flake-schemas;
+            };
             frontend = pkgs.callPackage ./frontend {
               inherit nixosChannels version;
             };


### PR DESCRIPTION
The 2-hourly `import-to-elasticsearch` workflow fails on `import-flakes (manual)`, with all 124 flakes in `flakes/manual.toml` failing identically:

```
error: cannot evaluate a function that has an argument without a value ('targetFlake')
       at .../assets/commands/flake_info.nix:2:3
```

#1450 rewrote the header of `flake-info/assets/commands/flake_info.nix` to take `targetFlake`, `nixpkgsFlake` and `flake-schemas` as formals without defaults. Every Rust caller invokes that file through `nix eval -f <file> <attr>` and supplies the flakes as *registry overrides* (`--override-flake targetFlake ...`), not as function arguments. `--override-flake` only affects `builtins.getFlake` and flake-input resolution, so it cannot fill a function formal, and the script aborts before doing any work.

Scope is wider than the flakes job. `import-nixpkgs` is green only because the nixpkgs revs have not advanced since the regression landed (`Index "..." already exists, strategy is: Abort push` -- the eval is never reached). `get_nixpkgs_options`, `get_nixpkgs_services` and `get_nixpkgs_package_services` go through the same path and fail the same way the moment a channel moves; `get_nixpkgs_package_services` is `unwrap_or_default()`-wrapped, so it degrades silently rather than failing loudly.

## Changes

**Restore the defaults.** The three formals now default to registry lookups, so `nix eval -f` works again while direct `import` (from `lib.evalFlake` and the test harness) keeps overriding them. The defaults are lazy, so `nixos-options` / `nixos-services` / `nixos-package-services` -- which never force `resolved` -- evaluate without a `targetFlake` override. Two stale comments referencing the old `input-flake` override name are updated to `targetFlake`.

**Pin `flake-schemas` into the binary.** It is new in #1450 and has no caller-side plumbing at all. The locked rev is baked in at build time as `FLAKE_SCHEMAS_REF` and passed from `nix_eval_command`, so every caller gets it. The `option_env!` plus fallback mirrors the existing `ROOTDIR` handling in `flake-info/src/lib.rs`, so a plain `cargo build` in the dev shell still compiles.

**Guard against a repeat.** The existing tests `import` `flake_info.nix` directly with all arguments supplied, so they cannot catch a breakage in the CLI's argument-passing path -- which is why CI stayed green. `build-flake-info.yml` gains a step driving the real CLI, plus a bare `nix eval` of `nixos-package-services` covering the nixpkgs-side attribute that the flake test does not reach.

The smoke test targets `github:ryantm/agenix` rather than a larger flake because the `Command::Flake` parser drops any trailing rev, so the target always tracks HEAD. `github:NixOS/hydra` is unusable for this: its HEAD currently fails to evaluate for an unrelated upstream reason (`callPackageWith: Function called without required argument "flakePackages"` in hydra's own `nixos-modules/default.nix`). A local `path:` fixture would be hermetic but the CLI rejects it (`unknown variant 'path', expected one of git, github, gitlab, sourcehut`).

#1434 is the longer-term direction and is not addressed here.

## Verification

Run from the repo root:

| Check | Result |
| --- | --- |
| `nix build .#flake-info --accept-flake-config` | passes, 32 unit tests ok |
| `flake-info --json flake github:ryantm/agenix` | exit 0, 15 entries |
| `flake-info --json flake gitlab:pinage404/nix-sandboxes` | exit 0, 10 entries |
| `nix eval ... nixos-package-services` against nixpkgs-unstable | exit 0 |
| `nix flake check --impure --accept-flake-config` | all checks passed |
| `nix fmt` | 61 files, 0 changed |

Before the fix the two `flake-info` invocations exit 1 with the `targetFlake` error above.

Disclaimer: I used a coding agent in the creation of this patch.
