### PR TITLE
fix(frontend): fix label padding

### DIFF
--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -499,7 +499,7 @@ footer {
         display: grid;
         grid-template-columns: auto max-content;
         color: var(--search-sidebar-link-color);
-        padding: 0.5em 0.5em 0.5em 1em;
+        padding: 0.5em 1em;
         border-radius: 4px;
         white-space: nowrap;
         margin-bottom: 0.2em;


### PR DESCRIPTION
fix a very strange padding!

<img width="129" height="145" alt="image" src="https://github.com/user-attachments/assets/87a3a5c3-4a8c-4912-82ea-0518c9aea8c0" />

<img width="140" height="148" alt="image" src="https://github.com/user-attachments/assets/0138a358-6ee9-4b58-b379-f82b135925c1" />
