### PR TITLE
fix(frontend): declare line-color in light theme

### DIFF
--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -26,6 +26,9 @@
   /* When search results are expanded, they show tabbed help for installing the result. This is the border color for that tabbed thing.
        It is only half of the border, the other half is styled by bootstrap. */
   --search-result-expanded-tab-border: #ccc;
+
+  --line-color: #ccc;
+
   /* Color of the animation above the `Loading` text that is shown when searching */
   --loader-color: #000;
   /* Background color of the experimental badge next to the flakes search */


### PR DESCRIPTION
before:
<img width="675" height="226" alt="image" src="https://github.com/user-attachments/assets/57e3fee0-dc5f-4eed-8321-7c88609855ec" />

after:
<img width="656" height="416" alt="image" src="https://github.com/user-attachments/assets/3d24e9f4-a080-4118-8d01-da1a130a1121" />
