### PR TITLE
fix(frontend): improve terminal theming

### DIFF
--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -63,7 +63,7 @@ import Search
         , decodeResolvedFlake
         )
 import Search.Query
-import SyntaxHighlight exposing (elm, oneDark, toBlockHtml, useTheme)
+import SyntaxHighlight exposing (nix, toBlockHtml)
 import Task
 import Url
 import Utils
@@ -455,8 +455,7 @@ viewResultItem nixosChannels channel show activeSource item =
 asHighlightPreCode : String -> Html msg
 asHighlightPreCode value =
     div []
-        [ useTheme oneDark
-        , elm value
+        [ nix value
             |> Result.map (toBlockHtml (Just 1))
             |> Result.withDefault
                 (pre [] [ code [ class "code-block" ] [ text value ] ])

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -8,8 +8,8 @@
 :root {
   --text-color: #333;
   --background-color: #fff;
-  --terminal-background: #333;
-  --terminal-color: #fff;
+  --terminal-background: #343748;
+  --terminal-color: #e8effc;
   --result-item-show-more-background: #fff;
   --result-item-show-more-color: #666;
   --search-sidebar-container-border-color: #ccc;
@@ -72,8 +72,7 @@
     --button-hover-background: #454545;
     --button-active-background: #656565;
     --button-active-hover-background: #707070;
-    --terminal-background: #353535;
-    --terminal-color: var(--text-color);
+    --terminal-background: #343748;
     --line-color: #ffffff26; // Color for separating lines
 
     --result-item-show-more-background: var(--background-color);
@@ -315,6 +314,10 @@ body {
 }
 
 .code-block,.sourceCode,.elmsh > code {
+  a {
+    color: var(--light-blue);
+  }
+
   display: block;
   cursor: text;
 }
@@ -992,6 +995,20 @@ a:focus-visible {
   // commands but a nested <pre> for option values, so match either.
   & pre {
     padding-right: 4em;
+  }
+
+  // Custom theming that override the parsed fragments of SyntaxHighlighting
+  // becaues the provided themes dont support light/dark theming
+
+  // see: https://github.com/pablohirafuji/elm-syntax-highlight/blob/3.6.0/src/SyntaxHighlight.elm#L347
+  //  and https://github.com/pablohirafuji/elm-syntax-highlight/blob/3.6.0/src/SyntaxHighlight/Language/Nix.elm#L322
+  .elmsh {
+    &-comm { color: #aeaeae; }
+    &-nix-o { color: #f08d94;}
+    &-nix-p { color: #d991d2; }
+    &-nix-s { color: #6fc488; }
+    &-nix-k { color: #87adfa; }
+    &-nix-n { color: #e99861; }
   }
 }
 


### PR DESCRIPTION
I couldn't make the terminal light theme, so i default to use the branding colors. Cant really tell if this is better.

### before

<img width="821" height="723" alt="image" src="https://github.com/user-attachments/assets/4831c67d-f33c-439f-932f-997c9d4d6ad0" />

### after

<img width="814" height="719" alt="image" src="https://github.com/user-attachments/assets/79170252-7157-48c3-b911-f08ccbbbde26" />
