### PR TITLE
feat(frontend): reduce topbar height on small width

### DIFF
--- a/frontend/src/scss/fragments/navbar.scss
+++ b/frontend/src/scss/fragments/navbar.scss
@@ -38,6 +38,12 @@
     }
   }
 
+  @media (max-width:979px) {
+    // save a bunch of real-estage be merging
+    .nav { order: 3;  }
+    .theme-toggle { order: 2; }
+  }
+
   .nav {
     margin: unset;
     display: flex;
@@ -110,5 +116,4 @@
   @media(min-width:768px) and (max-width:979px) {
     width: 724px;
   }
-
 }


### PR DESCRIPTION
- Fix: #1424

Save ~26.1% of on the topbar

### Before

<img width="758" height="132" alt="image" src="https://github.com/user-attachments/assets/d3296131-bb1f-4db5-85fb-6157c1b0d4fb" />

### After

<img width="763" height="94" alt="image" src="https://github.com/user-attachments/assets/c9c274a3-ce7d-47d1-9114-949af6f444bc" />
