### PR TITLE
fix(frontend): wrap search input options

### DIFF
--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -396,6 +396,8 @@ footer {
 
     .search-input-options {
       display: flex;
+      flex-flow: wrap;
+      gap: 1em;
       justify-content: space-between;
       align-items: center;
       margin-bottom: 1.5em;


### PR DESCRIPTION
- Fix: #736

### Before

<img width="407" height="125" alt="image" src="https://github.com/user-attachments/assets/91362e4c-1365-4f4b-8808-25ab84f16e07" />

### After

<img width="412" height="159" alt="image" src="https://github.com/user-attachments/assets/0e44ec2b-ab3b-4e23-afd4-a673d5723b81" />
