### PR TITLE
flake-info: fix the evaluation bugs behind the failing manual group import

### DIFF
--- a/flake-info/assets/commands/flake_info.nix
+++ b/flake-info/assets/commands/flake_info.nix
@@ -87,6 +87,12 @@ let
     lib.concatLists (
       lib.mapAttrsToList (
         system: sysNode:
+        let
+          # Forcing the per-system inventory node evaluates the flake's whole
+          # output set for that system, which throws for e.g. a system nixpkgs
+          # no longer supports. Skip that system rather than the whole flake.
+          childrenResult = safeEval (sysNode.children or { });
+        in
         lib.filter (x: x != null) (
           lib.mapAttrsToList (
             attribute_name: itemNode:
@@ -131,7 +137,7 @@ let
               );
             in
             if res.success then res.value else null
-          ) (sysNode.children or { })
+          ) (if childrenResult.success then childrenResult.value else { })
         )
       ) (getSchemaInventory schemaKey)
     );
@@ -398,9 +404,19 @@ let
             (lib.filter (x: lib.elem x rawPlatforms) targetOrder)
             ++ (lib.filter (x: !(lib.elem x targetOrder)) rawPlatforms);
         in
-        removeAttrs (firstWithMeta // { inherit platforms; }) [ "system" ];
+        # A package that never evaluated on any system carries no `name`, which
+        # `FlakeEntry::Package` requires -- keeping it fails deserialization for
+        # the entire flake. Apps have no `name` by design, so this is restricted
+        # to packages. Dropped by `collectSystemEntries`.
+        if (firstWithMeta.entry_type or null) == "package" && !(firstWithMeta ? name) then
+          null
+        else
+          removeAttrs (firstWithMeta // { inherit platforms; }) [ "system" ];
     in
     lib.mapAttrs mergeEntry grouped;
+
+  collectSystemEntries =
+    outputKey: list: lib.filter (x: x != null) (lib.attrValues (collectSystems outputKey list));
 
   # nixpkgs-specific, doesn't use the flake argument
   nixpkgsBaseModules = import "${nixpkgsFlake}/nixos/modules/module-list.nix" ++ [
@@ -435,9 +451,9 @@ let
 in
 
 rec {
-  legacyPackages = lib.attrValues (collectSystems "legacyPackages" legacyPackages');
-  packages = lib.attrValues (collectSystems "packages" packages');
-  apps = lib.attrValues (collectSystems "apps" apps');
+  legacyPackages = collectSystemEntries "legacyPackages" legacyPackages';
+  packages = collectSystemEntries "packages" packages';
+  apps = collectSystemEntries "apps" apps';
   options = readFlakeOptions;
   darwin-options = readOptionsIf {
     cond =

--- a/flake-info/assets/commands/test/basic-flake/flake.nix
+++ b/flake-info/assets/commands/test/basic-flake/flake.nix
@@ -15,47 +15,59 @@
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
-      packages = forAllSystems (
-        system:
-        let
-          pkgs = import nixpkgs { inherit system; };
-        in
-        {
-          # Package available on all systems
-          hello = pkgs.writeShellScriptBin "hello" ''
-            echo "Hello from all systems"
-          '';
-
-          # Package available on all systems with metadata
-          test-package = pkgs.stdenv.mkDerivation {
-            pname = "test-package";
-            version = "1.2.3";
-            src = pkgs.writeText "test.txt" "test content";
-            dontUnpack = true;
-            installPhase = ''
-              mkdir -p $out
-              cp $src $out/test.txt
+      packages =
+        forAllSystems (
+          system:
+          let
+            pkgs = import nixpkgs { inherit system; };
+          in
+          {
+            # Package available on all systems
+            hello = pkgs.writeShellScriptBin "hello" ''
+              echo "Hello from all systems"
             '';
-            meta = with pkgs.lib; {
-              description = "A test package";
-              longDescription = "This is a longer description for testing";
-              license = licenses.mit;
+
+            # Package available on all systems with metadata
+            test-package = pkgs.stdenv.mkDerivation {
+              pname = "test-package";
+              version = "1.2.3";
+              src = pkgs.writeText "test.txt" "test content";
+              dontUnpack = true;
+              installPhase = ''
+                mkdir -p $out
+                cp $src $out/test.txt
+              '';
+              meta = with pkgs.lib; {
+                description = "A test package";
+                longDescription = "This is a longer description for testing";
+                license = licenses.mit;
+              };
             };
-          };
-        }
-        // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
-          # Darwin-only package
-          darwin-specific = pkgs.writeShellScriptBin "darwin-test" ''
-            echo "Darwin only"
-          '';
-        }
-        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          # Linux-only package
-          linux-specific = pkgs.writeShellScriptBin "linux-test" ''
-            echo "Linux only"
-          '';
-        }
-      );
+
+            # Not a derivation, so it has no `name` -- must be dropped rather
+            # than emitted as a name-less package entry.
+            not-a-derivation = {
+              some = "attrset";
+            };
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+            # Darwin-only package
+            darwin-specific = pkgs.writeShellScriptBin "darwin-test" ''
+              echo "Darwin only"
+            '';
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            # Linux-only package
+            linux-specific = pkgs.writeShellScriptBin "linux-test" ''
+              echo "Linux only"
+            '';
+          }
+        )
+        // {
+          # A system whose entire package set throws -- that system must be
+          # skipped rather than aborting evaluation of the whole flake.
+          riscv64-linux = throw "this system is not supported";
+        };
 
       apps = forAllSystems (
         system:
@@ -66,6 +78,24 @@
           app-hello = {
             type = "app";
             program = pkgs.hello.outPath + "/bin/hello";
+          };
+
+          # Throws on every system: the attribute is dropped rather than
+          # aborting evaluation of the whole flake.
+          throwing-app = {
+            type = "app";
+            program = throw "this app cannot be evaluated";
+          };
+
+          # Throws only on darwin: the attribute survives, listing just the
+          # platforms it evaluated on.
+          partly-throwing-app = {
+            type = "app";
+            program =
+              if pkgs.stdenv.isDarwin then
+                throw "this app is unsupported on darwin"
+              else
+                pkgs.hello.outPath + "/bin/hello";
           };
         }
       );

--- a/flake-info/assets/commands/test/expected-outputs/basic-flake.json
+++ b/flake-info/assets/commands/test/expected-outputs/basic-flake.json
@@ -67,5 +67,12 @@
       "aarch64-darwin"
     ],
     "type": "app"
+  },
+  {
+    "attribute_name": "partly-throwing-app",
+    "bin": "/nix/store/sqw9kyl8zrfnkklb3vp6gji9jw9qfgb5-hello-2.12.2/bin/hello",
+    "entry_type": "app",
+    "platforms": ["x86_64-linux", "aarch64-linux"],
+    "type": "app"
   }
 ]

--- a/flake-info/src/commands/mod.rs
+++ b/flake-info/src/commands/mod.rs
@@ -14,8 +14,8 @@ pub use nixpkgs_info::{
 };
 pub use repology::{get_repology_repo_counts, load_repology_repo_counts};
 
-use anyhow::{Context, Result};
-use command_run::{Command, LogTo};
+use anyhow::{Context, Result, anyhow};
+use command_run::{Command, LogTo, Output};
 use lazy_static::lazy_static;
 use log::info;
 use std::path::PathBuf;
@@ -49,4 +49,50 @@ pub fn nix_eval_command(args: &[&str]) -> Command {
     command.log_to = LogTo::Log;
     command.log_output_on_error = true;
     command
+}
+
+/// How much of a `nix` trace to keep in the returned error. Group imports paste
+/// the aggregated error verbatim into an auto-filed issue, and a full trace can
+/// run to thousands of lines.
+const STDERR_TAIL_LINES: usize = 40;
+
+/// Run `command`, including its stderr in the error when it exits non-zero.
+///
+/// `command_run`'s own failure renders as just `command '...' failed: exit
+/// status: 1` -- the actual `nix` message reaches only the log, so the error
+/// that surfaces to the user carries no diagnostic information at all.
+pub fn run_capturing_stderr(command: &mut Command) -> Result<Output> {
+    let check = command.check;
+    command.disable_check();
+    let output = command.run();
+    command.check = check;
+
+    let output = output?;
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    let stderr = output.stderr_string_lossy();
+    let lines: Vec<&str> = stderr.lines().collect();
+    let truncated = lines.len() > STDERR_TAIL_LINES;
+    let tail = lines[lines.len().saturating_sub(STDERR_TAIL_LINES)..].join("\n");
+
+    Err(anyhow!(
+        "command '{}' failed: {}{}{}",
+        command.command_line_lossy(),
+        output.status,
+        if truncated {
+            format!(
+                "\n[... {} earlier stderr lines omitted]",
+                lines.len() - STDERR_TAIL_LINES
+            )
+        } else {
+            String::new()
+        },
+        if tail.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", tail)
+        },
+    ))
 }

--- a/flake-info/src/commands/nix_flake_attrs.rs
+++ b/flake-info/src/commands/nix_flake_attrs.rs
@@ -37,8 +37,7 @@ pub fn get_derivation_info<T: AsRef<str> + Display>(
     }
     command.add_args(extra);
 
-    let parsed: Result<Vec<FlakeEntry>> = command
-        .run()
+    let parsed: Result<Vec<FlakeEntry>> = super::run_capturing_stderr(&mut command)
         .with_context(|| format!("Failed to gather information about {}", flake_ref))
         .and_then(|o| {
             let output = &*o.stdout_string_lossy();

--- a/flake-info/src/commands/nix_flake_info.rs
+++ b/flake-info/src/commands/nix_flake_info.rs
@@ -28,8 +28,7 @@ pub fn get_flake_info<T: AsRef<str> + Display>(
     command.log_to = LogTo::Log;
     command.log_output_on_error = true;
 
-    command
-        .run()
+    super::run_capturing_stderr(&mut command)
         .with_context(|| format!("Failed to gather information about {}", flake_ref))
         .and_then(|o| {
             let deserialized: Result<Flake, _> =

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -129,8 +129,7 @@ pub fn get_nixpkgs_package_services(nixpkgs: &Source) -> Result<HashMap<String, 
     super::add_flake_arg(&mut command, "nixpkgsFlake", &nixpkgs.to_flake_ref());
     command.add_arg("nixos-package-services");
 
-    let cow = command
-        .run()
+    let cow = super::run_capturing_stderr(&mut command)
         .with_context(|| "Failed to gather modular service mapping for packages")?;
 
     let output = &*cow.stdout_string_lossy();
@@ -155,8 +154,7 @@ pub fn get_nixpkgs_programs(nixpkgs: &Nixpkgs) -> Result<HashMap<String, HashSet
     command.log_to = LogTo::Log;
     command.log_output_on_error = true;
 
-    let cow = command
-        .run()
+    let cow = super::run_capturing_stderr(&mut command)
         .with_context(|| "Failed to gather information about nixpkgs programs")?;
 
     let output = cow.stdout_string_lossy();
@@ -191,8 +189,7 @@ fn get_options_from_script(
     }
     command.add_arg(attribute);
 
-    let cow = command
-        .run()
+    let cow = super::run_capturing_stderr(&mut command)
         .with_context(|| format!("Failed to gather information about {}", attribute))?;
 
     let output = &*cow.stdout_string_lossy();

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -33,10 +33,9 @@ url = "git+https://codeberg.org/wolfangaukang/python-trovo?ref=main"
 type = "git"
 url = "git+https://github.com/hannesgith/rquickshare?ref=flake"
 
-# missing field 'name'
-#[[sources]]
-#type = "git"
-#url = "git+https://github.com/hannesgith/neohtop?ref=nixify"
+[[sources]]
+type = "git"
+url = "git+https://github.com/hannesgith/neohtop?ref=nixify"
 
 [[sources]]
 type = "git"
@@ -345,11 +344,10 @@ type = "github"
 owner = "nix-community"
 repo = "autofirma-nix"
 
-# x86_64-darwin throws deprecated
-# [[sources]]
-# type = "github"
-# owner = "nix-community"
-# repo = "fenix"
+[[sources]]
+type = "github"
+owner = "nix-community"
+repo = "fenix"
 
 [[sources]]
 type = "github"


### PR DESCRIPTION
Closes #1487.

Fixes three bugs in `flake-info` -- not in the flakes -- behind the failing `manual` group imports. They were root-caused from run 30222963951 (#1482), where five of ~120 flakes failed; #1487 is the still-open recurrence, where `codeberg.org/alch_emi/embers-nix-packages` fails the whole group on `missing field 'name'`. That is the first bug below, and the flake imports cleanly here at its current `main`.

A failing attribute now amputates only itself: an attribute that throws is dropped, a system whose output set throws is skipped, and everything else in the flake is still indexed. Recording partial-versus-complete evaluation state in ElasticSearch is #1182 and is not attempted here.

## Name-less package entries reach `serde`

`readSchemaItems` evaluates full metadata only on `referenceSystem`, where `evalDrvMetadata` returns `null` for non-derivations and the entry is dropped. For every other system it emits a name-less stub with no derivation check, and `collectSystems` keeps that stub when the reference system yielded no metadata either. `FlakeEntry::Package` requires `name`, so a single non-derivation under `packages` fails deserialization for the whole flake.

`mergeEntry` now returns `null` for a merged package with no `name`, and `collectSystemEntries` filters those out. `collectSystems` is the only producer of final package entries, so no name-less package can reach `serde` regardless of which branch produced the stub. Apps have no `name` by design, so the check is restricted to `entry_type == "package"`.

Hit by `git+https://codeberg.org/alch_emi/embers-nix-packages.git?ref=main`, whose `generate-caddy-sidecars` is a plain attrset.

## Forcing a per-system inventory node is unguarded

`readSchemaItems` forces `sysNode.children`, which evaluates the flake's entire output set for that system. A system nixpkgs no longer supports therefore aborts evaluation of every other system too. #1485 guards the individual entries but not this. The forcing now goes through `safeEval`, skipping just that system.

Hit by `github:nix-community/fenix`, and by `github:StardustXR/telescope` on `riscv64-linux`.

## `nix` stderr never reaches the error message

`nix_eval_command` sets `log_output_on_error`, so stderr goes only to the log; `command_run`'s error renders as just `command '...' failed: exit status: 1`. That is what `FlakeInfoError::Group` aggregates and what the import workflow pastes into the auto-filed issue, which is why #1318 and #1260 were closed as stale rather than fixed -- four of the five entries in #1482 carry no diagnostic information at all, and #1487 needed the raw 18 MB job log to identify the flake at fault.

`run_capturing_stderr` disables `command_run`'s check, and on a non-zero exit builds the error from the exit status plus the last 40 lines of stderr (traces run to thousands of lines, and the message is pasted verbatim into an issue). All `nix` call sites are routed through it. Logging is unchanged. Progress on #1116.

## Re-enabled flakes

`flakes/manual.toml` had `hannesgith/neohtop` commented out for `missing field 'name'` and `nix-community/fenix` for `x86_64-darwin throws deprecated` -- exactly the two bugs above. Both import cleanly now. The other commented-out entries were disabled for unrelated reasons and are left alone.

## Testing

`nix build .#checks.x86_64-linux.flake-info` passes. The `hydra`, `agenix` and `deploy-rs` fixtures pin flake revisions and are byte-identical, confirming no behaviour changed for flakes that already worked. `basic-flake` gains a non-derivation package (dropped), a throwing system (skipped), an app that throws everywhere (dropped) and an app that throws only on darwin (kept, listing only the platforms it evaluated on).

The five failing flakes from run 30222963951 all evaluate, as do the two re-enabled ones, and no package entry lacks `name`:

| flake | entries | packages | apps |
|---|---|---|---|
| `embers-nix-packages` | 10 | 10 | 0 |
| `deadnix` | 3 | 2 | 1 |
| `lnbits-legend` | 5 | 2 | 3 |
| `telescope` | 7 | 4 | 3 |
| `mcp-nixos` | 5 | 3 | 2 |
| `neohtop` | 3 | 3 | 0 |
| `fenix` | 139 | 139 | 0 |

A full `--json group ./flakes/manual.toml manual --report` run over all ~120 flakes exits 0 and writes no `report.txt`, yielding 38372 documents -- 36405 options, 1920 packages and 47 apps.

## Relationship to #1486

#1486 restructures `flake_info.nix` into a flake with pinned inputs and a `lib`, and rebases the Rust side onto it. The two do not duplicate each other: it keeps the per-entry `tryEval` from #1485 but leaves `sysNode.children` unguarded (and for `legacyPackages` additionally forces `resolved.legacyPackages.<system>` through `walkAttrTree`, widening the exposure), has no name-less-package check, and does not touch the stderr path. Both fixes here apply on top of that restructure. Whichever lands first, the other rebases -- happy to go second, since this one is small and #1486 is still WIP.

## Out of scope

Three things surfaced while investigating that belong in separate issues:

- `mergeEntry` picks the alphabetically-first system's `bin` rather than `referenceSystem`'s, so `deploy-rs` indexes its `aarch64-darwin` program while the fixture records the `x86_64-linux` path. It only still matches because `rmDerivationHash` strips the store hash. Reordering by the `targetOrder` list already in `flake_info.nix` would make it deterministic with no fixture change.
- Apps have never been rendered by the frontend -- the flake page filters to `package` and `option`, and `app_bin` appears only in backend files. Whether to index them at all is worth asking.
- Once a flake can be partially evaluated, the error label wants to say which flake failed and that it was `flake_info.nix` that failed on it, and ElasticSearch wants the pass/fail state alongside the data (#1182).

Disclaimer: I used a coding agent in the creation of this patch.
