### PR TITLE
fix(frontend): truncate maintainer details when necessary

### DIFF
--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -610,7 +610,7 @@ viewResultItem nixosChannels channel showUsageDetails show item =
 
         maintainersTeamsAndPlatforms =
             div []
-                [ div []
+                [ div [ class "package-details-maintainers" ]
                     [ h4 [] [ text "Maintainers" ]
                     , if List.isEmpty item.source.maintainers then
                         p [] [ text "This package has no maintainers. If you find it useful, please consider becoming a maintainer!" ]

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -1178,3 +1178,21 @@ sort-select-wrapper select {
   position-area: bottom span-right;
   margin-block: 4px;
 }
+
+.package-details-maintainers {
+  width: 100%;
+  overflow: hidden;
+
+  li {
+    display: flex;
+    white-space: nowrap;
+  }
+
+  a {
+    display: inline-block;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+    overflow: hidden;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
- fix: #1444 (2nd part)

### Package maintainer details:

#### Before

<img width="1154" height="741" alt="image" src="https://github.com/user-attachments/assets/4912fce7-2ea8-4bf2-a1e4-b5269fedd7bb" />


#### After

<img width="871" height="746" alt="image" src="https://github.com/user-attachments/assets/7b32291b-89dd-4245-896d-64cd195628bc" />