### PR TITLE
fix: clear maintainer bucket filter when submitting a new search query

### DIFF
--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -552,6 +552,7 @@ update toRoute navKey msg model nixosChannels =
             { model
                 | from = 0
                 , show = Nothing
+                , buckets = Nothing
                 , typeahead = Typeahead.hideModel model.typeahead
             }
                 |> ensureLoading nixosChannels


### PR DESCRIPTION
## Description

When a user clicks on a maintainer in the sidebar, a bucket filter is added to the search query. However, submitting a new search query did not clear this filter, causing the search to only show results from the previously selected maintainer. This made the search appear broken and there was no way to remove the filter.

## Fix

Added `buckets = Nothing` to the `QueryInputSubmit` handler in `Search.elm`. Starting a new search now resets all active filters.

Fixes #1411