### PR TITLE
Add OutageDeck CLI flake

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -432,6 +432,11 @@ repo = "llm-agents.nix"
 
 [[sources]]
 type = "github"
+owner = "outagedeck"
+repo = "cli"
+
+[[sources]]
+type = "github"
 owner = "PaddiM8"
 repo = "kalker"
 


### PR DESCRIPTION
Adds the OutageDeck CLI flake to the manual index. The flake exposes packages and a runnable app for checking live cloud and SaaS provider status. It is maintained by the OutageDeck project and is not present in nixpkgs.

Validated with the documented indexer command:

```console
nix run github:nixos/nixos-search#flake-info -- --json flake github:outagedeck/cli
```

The indexer resolved revision `f14eb863f894b2f632675f90138d13fb82abc82f`, emitted both package attributes and the default app, recognized the MIT license, and reported support for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`. The flake also passes `nix flake check --all-systems --no-build`, and the package has been built and run on NixOS.