### PR TITLE
refactor(frontend): html/css classes

### DIFF
--- a/frontend/src/Page/Options.elm
+++ b/frontend/src/Page/Options.elm
@@ -23,7 +23,10 @@ import Html
         ( Html
         , a
         , code
+        , dd
         , div
+        , dl
+        , dt
         , fieldset
         , input
         , label
@@ -293,7 +296,7 @@ viewSuccess :
     -> List (Search.ResultItem ResultItemSource)
     -> Html Msg
 viewSuccess activeSource nixosChannels channel _ show hits =
-    ul []
+    ul [ class "search-results-list" ]
         (List.map
             (viewResultItem nixosChannels channel show activeSource)
             hits
@@ -336,16 +339,16 @@ viewResultItem nixosChannels channel show activeSource item =
                         item.source.docType == "service"
                 in
                 Just <|
-                    div [ Html.Attributes.map SearchMsg Search.trapClick ] <|
-                        [ div [] [ text "Name" ]
-                        , div [] [ viewOptionNamePath channel activeSource item.source.name nameSegments ]
+                    dl [ class "option-details", Html.Attributes.map SearchMsg Search.trapClick ] <|
+                        [ dt [] [ text "Name" ]
+                        , dd [] [ viewOptionNamePath channel activeSource item.source.name nameSegments ]
                         ]
                             ++ (item.source.description
                                     |> Maybe.andThen Utils.showHtml
                                     |> Maybe.map
                                         (\description ->
-                                            [ div [] [ text "Description" ]
-                                            , div [] description
+                                            [ dt [] [ text "Description" ]
+                                            , dd [] description
                                             ]
                                         )
                                     |> Maybe.withDefault []
@@ -353,8 +356,8 @@ viewResultItem nixosChannels channel show activeSource item =
                             ++ (item.source.type_
                                     |> Maybe.map
                                         (\t ->
-                                            [ div [] [ text "Type" ]
-                                            , div [] [ asPre t ]
+                                            [ dt [] [ text "Type" ]
+                                            , dd [] [ asPre t ]
                                             ]
                                         )
                                     |> Maybe.withDefault []
@@ -362,8 +365,8 @@ viewResultItem nixosChannels channel show activeSource item =
                             ++ (item.source.default
                                     |> Maybe.map
                                         (\default ->
-                                            [ div [] [ text "Default" ]
-                                            , div [] <| Maybe.withDefault [ Utils.copyable CopyToClipboard default (asPreCode default) ] (Utils.showHtml default)
+                                            [ dt [] [ text "Default" ]
+                                            , dd [] <| Maybe.withDefault [ Utils.copyable CopyToClipboard default (asPreCode default) ] (Utils.showHtml default)
                                             ]
                                         )
                                     |> Maybe.withDefault []
@@ -371,15 +374,15 @@ viewResultItem nixosChannels channel show activeSource item =
                             ++ (item.source.example
                                     |> Maybe.map
                                         (\example ->
-                                            [ div [] [ text "Example" ]
-                                            , div [] <| Maybe.withDefault [ Utils.copyable CopyToClipboard example (asHighlightPreCode example) ] (Utils.showHtml example)
+                                            [ dt [] [ text "Example" ]
+                                            , dd [] <| Maybe.withDefault [ Utils.copyable CopyToClipboard example (asHighlightPreCode example) ] (Utils.showHtml example)
                                             ]
                                         )
                                     |> Maybe.withDefault []
                                )
                             ++ (if isService then
-                                    [ div [] [ text "About" ]
-                                    , div []
+                                    [ dt [] [ text "About" ]
+                                    , dd []
                                         [ a
                                             [ href "https://nixos.org/manual/nixos/stable/#modular-services"
                                             , Html.Attributes.target "_blank"
@@ -397,20 +400,20 @@ viewResultItem nixosChannels channel show activeSource item =
                                             item.source.servicePackage
                                                 |> Maybe.map
                                                     (\pkg ->
-                                                        [ div [] [ text "Provided by package" ]
-                                                        , div [] [ pkgLink pkg ]
+                                                        [ dt [] [ text "Provided by package" ]
+                                                        , dd [] [ pkgLink pkg ]
                                                         ]
                                                     )
                                                 |> Maybe.withDefault []
 
                                         [ single ] ->
-                                            [ div [] [ text "Provided by package" ]
-                                            , div [] [ pkgLink single ]
+                                            [ dt [] [ text "Provided by package" ]
+                                            , dd [] [ pkgLink single ]
                                             ]
 
                                         many ->
-                                            [ div [] [ text "Provided by packages" ]
-                                            , div []
+                                            [ dt [] [ text "Provided by packages" ]
+                                            , dd []
                                                 (List.intersperse (text ", ") (List.map pkgLink many))
                                             ]
 
@@ -418,8 +421,8 @@ viewResultItem nixosChannels channel show activeSource item =
                                     []
                                )
                             ++ viewUsageSnippet item.source
-                            ++ [ div [] [ text "Declared in" ]
-                               , div [] <| findSource nixosChannels channel item.source
+                            ++ [ dt [] [ text "Declared in" ]
+                               , dd [] <| findSource nixosChannels channel item.source
                                ]
 
             else
@@ -439,7 +442,7 @@ viewResultItem nixosChannels channel show activeSource item =
     <|
         List.filterMap identity
             [ Just <|
-                ul [ class "search-result-button" ]
+                ul [ class "search-result-title option-title" ]
                     [ li []
                         [ a
                             [ onClick toggle
@@ -500,8 +503,8 @@ viewUsageSnippet source =
             indent ++ source.name ++ " = " ++ leafValue indent ++ ";\n"
 
         usage snippet =
-            [ div [] [ text "Usage" ]
-            , Utils.copyable CopyToClipboard snippet (asHighlightPreCode snippet)
+            [ dt [] [ text "Usage" ]
+            , dd [] [ Utils.copyable CopyToClipboard snippet (asHighlightPreCode snippet) ]
             ]
     in
     case source.docType of

--- a/frontend/src/Page/Packages.elm
+++ b/frontend/src/Page/Packages.elm
@@ -373,7 +373,7 @@ viewSuccess :
     -> List (Search.ResultItem ResultItemSource)
     -> Html Msg
 viewSuccess nixosChannels channel showUsageDetails show hits =
-    ul []
+    ul [ class "search-results-list" ]
         (List.map
             (viewResultItem nixosChannels channel showUsageDetails show)
             hits
@@ -430,7 +430,7 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                 [ text title ]
 
         shortPackageDetails =
-            ul []
+            ul [ class "package-short-details" ]
                 (li []
                     [ text "Name: "
                     , code [ class "package-name" ] [ text item.source.pname ]
@@ -609,7 +609,7 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                     li [] [ text platform ]
 
         maintainersTeamsAndPlatforms =
-            div []
+            div [ class "package-maintainers-platforms" ]
                 [ div [ class "package-details-maintainers" ]
                     [ h4 [] [ text "Maintainers" ]
                     , if List.isEmpty item.source.maintainers then
@@ -655,7 +655,7 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                     else
                         text p
             in
-            div []
+            div [ class "package-programs" ]
                 [ h4 [] [ text "Programs provided" ]
                 , if List.isEmpty sortedPrograms then
                     p [] [ text "This package provides no programs." ]
@@ -728,15 +728,15 @@ viewResultItem nixosChannels channel showUsageDetails show item =
 
         longerPackageDetails =
             optionals (Just item.source.attr_name == show)
-                [ div [ trapClick ]
-                    [ div []
+                [ div [ class "package-details", trapClick ]
+                    [ div [ class "package-long-description" ]
                         (item.source.longDescription
                             |> Maybe.andThen Utils.showHtml
                             |> Maybe.withDefault []
                         )
                     , case item.source.flakeUrl of
                         Just ( flakeUrl, _ ) ->
-                            div []
+                            div [ class "package-usage" ]
                                 [ fieldset
                                     [ class "radio-group-tabs usage-radios" ]
                                     [ legend [ class "usage-title" ]
@@ -782,7 +782,7 @@ viewResultItem nixosChannels channel showUsageDetails show item =
                                     , ( Search.ViaNixEnv, "nix-env", True )
                                     ]
                             in
-                            div []
+                            div [ class "package-usage" ]
                                 [ fieldset
                                     [ class "radio-group-tabs usage-radios" ]
                                     [ legend [ class "usage-title" ]
@@ -965,8 +965,8 @@ viewResultItem nixosChannels channel showUsageDetails show item =
         , classList [ ( "opened", isOpen ) ]
         , Search.elementId item.source.attr_name
         ]
-        ([ span [] flakeOrNixpkgs
-         , div [] [ text <| Maybe.withDefault "" item.source.description ]
+        ([ span [ class "search-result-title" ] flakeOrNixpkgs
+         , div [ class "package-description" ] [ text <| Maybe.withDefault "" item.source.description ]
          , shortPackageDetails
          , Search.showMoreButton toggle isOpen
          ]

--- a/frontend/src/Search.elm
+++ b/frontend/src/Search.elm
@@ -913,7 +913,7 @@ viewResult nixosChannels outMsg categoryName model viewSuccess viewBuckets searc
                     in
                     div [ class "search-results", class "loading-overlay" ]
                         [ aside [ class "search-sidebar" ] (searchBuckets ++ buckets)
-                        , div []
+                        , div [ class "search-results-main" ]
                             (viewResults nixosChannels model prev viewSuccess outMsg categoryName)
                         ]
 
@@ -938,7 +938,7 @@ viewResult nixosChannels outMsg categoryName model viewSuccess viewBuckets searc
             else
                 div [ class "search-results" ]
                     [ aside [ class "search-sidebar" ] (searchBuckets ++ buckets)
-                    , div []
+                    , div [ class "search-results-main" ]
                         (viewResults nixosChannels model result viewSuccess outMsg categoryName)
                     ]
 
@@ -1065,7 +1065,7 @@ crossSearchHint categoryName query channel =
 
 closeButton : Html a
 closeButton =
-    span [] []
+    span [ class "bucket-count" ] []
 
 
 type BucketInputType
@@ -1107,12 +1107,12 @@ viewBucket inputType title buckets searchMsgFor selectedBucket sets =
                             label
                                 [ classList [ ( "selected", isSelected ) ]
                                 ]
-                                [ span [] [ text bucket.key ]
+                                [ span [ class "bucket-label" ] [ text bucket.key ]
                                 , if isSelected || bucket.doc_count <= 0 then
                                     closeButton
 
                                   else
-                                    span [] [ span [ class "badge" ] [ text <| String.fromInt bucket.doc_count ] ]
+                                    span [ class "bucket-count" ] [ span [ class "badge" ] [ text <| String.fromInt bucket.doc_count ] ]
                                 , input
                                     [ type_ inputTypeName
                                     , name title
@@ -1267,8 +1267,8 @@ viewResults nixosChannels model result viewSuccess outMsg categoryName =
                     model.from + model.size
                 )
     in
-    [ div []
-        [ h2 []
+    [ div [ class "search-results-header" ]
+        [ h2 [ class "search-results-count" ]
             (List.append
                 [ text "Showing results "
                 , text from
@@ -1360,7 +1360,7 @@ viewPager :
     -> Int
     -> Html (Msg a b)
 viewPager model total =
-    div []
+    div [ class "search-results-footer" ]
         [ ul [ class "pager" ]
             [ li []
                 [ viewButton

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -307,11 +307,6 @@ body {
   position: relative;
   min-height: 100vh;
   overflow-y: auto;
-
-  & > div:first-child {
-    position: relative;
-    min-height: 100vh;
-  }
 }
 
 .code-block,.sourceCode,.elmsh > code {
@@ -444,7 +439,10 @@ footer {
   }
 
 
-  .search-result-button {
+  // Title row of an option result: a single-item list holding the option
+  // name. Laid out as a flex row by `.search-result-title.option-title`
+  // below.
+  .option-title {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -454,10 +452,8 @@ footer {
         text-decoration: underline;
       }
 
-      // Badge column keeps its fixed width; the name column takes the rest
-      // and lets long unbreakable identifiers wrap instead of pushing onto
-      // the next line beneath the badge. (Display:flex is set on the parent
-      // by the more-specific `:nth-child(1).search-result-button` rule.)
+      // The name column takes all the space the row has left and lets long
+      // unbreakable identifiers wrap inside it instead of overflowing.
       &:last-child {
         flex: 1 1 auto;
         min-width: 0;
@@ -514,33 +510,15 @@ footer {
           background: var(--hovered-item-background);
         }
 
-        & > span:first-child {
+        & > .bucket-label {
           text-overflow: ellipsis;
           overflow: hidden;
-        }
-
-        & > span:last-child {
-          text-align: right;
-          margin-left: 0.3em;
         }
 
         &.selected {
           background: var(--selected-item-background);
           color: var(--selected-item-color);
           position: relative;
-
-          & > span:last-child {
-            display: none;
-          }
-        }
-
-        & .close {
-          opacity: 1;
-          text-shadow: none;
-          color: inherit;
-          font-size: inherit;
-          padding-left: .5em;
-          padding-right: .5em;
         }
       }
     }
@@ -551,26 +529,18 @@ footer {
     display: flex;
     flex-direction: row;
 
-    // Results section
-    & > div {
+    // The results column and the empty-state block each take up whatever
+    // width the sidebar leaves.
+    & > .search-results-main,
+    & > .search-no-results {
       width: 100%;
+    }
 
-      // Search results header
-      & > :nth-child(1) {
-        // Text that displays number of results
-        & > h2:nth-child(2) {
-          font-size: 1.7em;
-          font-weight: normal;
-          line-height: 1.3em;
-
-          & > p {
-            font-size: 0.7em;
-          }
-        }
-      }
+    // Results section
+    & > .search-results-main {
 
       // Search results list
-      & > :nth-child(2) {
+      & > .search-results-list {
         list-style: none;
         margin: 2em 0 0 0;
 
@@ -585,7 +555,7 @@ footer {
           }
 
           // Attribute name or option name
-          & > :nth-child(1) {
+          & > .search-result-title {
             background: inherit;
             border: 0;
             padding: 0;
@@ -601,8 +571,8 @@ footer {
             // For options, the title row is a flex layout so a long option
             // name wraps inside its own column instead of dropping below the
             // category badge. Without this override the surrounding
-            // `:nth-child(1)` rule forces `display: block`.
-            &.search-result-button {
+            // `.search-result-title` rule forces `display: block`.
+            &.option-title {
               display: flex;
               align-items: baseline;
               gap: 0.5em;
@@ -613,14 +583,14 @@ footer {
             @include search-result-item;
 
             // Description
-            & > :nth-child(2) {
+            & > .package-description {
               font-size: 1.2em;
               margin-bottom: 0.5em;
               text-align: left;
             }
 
             // short details of a pacakge
-            & > :nth-child(3) {
+            & > .package-short-details {
               color: var(--search-result-short-details-color);
               list-style: none;
               text-align: left;
@@ -636,12 +606,12 @@ footer {
             }
 
             // longer details of a pacakge
-            & > :nth-child(5) {
+            & > .package-details {
               margin: 2em 0 1em 1em;
               text-align: left;
 
               // long description of a package
-              & > :nth-child(1) {
+              & > .package-long-description {
                 margin-top: 1em;
 
                 pre {
@@ -650,13 +620,7 @@ footer {
               }
 
               // how to install a package
-              & > :nth-child(2) {
-
-                h4 {
-                  font-size: 1.2em;
-                  line-height: 1em;
-                  float: left;
-                }
+              & > .package-usage {
 
                 fieldset.usage-radios {
                   @include radio-tabbed-group;
@@ -676,12 +640,12 @@ footer {
               }
 
               // put border around main program
-              & > :nth-child(3) code.main-program {
+              & > .package-programs code.main-program {
                 border: .1em solid;
               }
 
               // maintainers and platforms
-              & > :nth-child(4) {
+              & > .package-maintainers-platforms {
                 margin-top: 1em;
                 display: grid;
                 grid-template-columns: auto auto;
@@ -701,24 +665,28 @@ footer {
             margin: 0;
             padding: 0;
 
-            & > :nth-child(1) {
+            & > .search-result-title {
               padding: 0.5em 0;
             }
 
-            // short details of a pacakge
-            & > :nth-child(2) {
+            // term/value pairs of an option
+            & > .option-details {
               margin: 2em 0 1em 1em;
               display: grid;
               grid-template-columns: 100px 1fr;
               column-gap: 1em;
               row-gap: 0.5em;
 
-              & > div:nth-child(2n+1) {
+              dt {
                 font-weight: bold;
                 text-align: right;
               }
 
-              & > div:nth-child(2n) {
+              dd {
+                // Reset the user agent's inline-start margin; the grid gap
+                // does the spacing.
+                margin: 0;
+
                 pre {
                   background: transparent;
                   color: var(--text-color);
@@ -742,7 +710,7 @@ footer {
       }
 
       // Search results footer
-      & > :nth-child(3) {
+      & > .search-results-footer {
         margin-top: 1em;
 
         & > ul > li > a {
@@ -869,19 +837,12 @@ a:focus-visible {
 
 // Tab strip in the Options sidebar — one tab per option source. Active
 // tab inherits the `.selected` background/foreground from the sidebar's
-// generic styling; the rules below diverge from the bucket-style sidebar
-// in two ways:
-//
-// 1. The bucket layout uses `display: grid` + `:last-child { text-align:
-//    right }`, which right-aligns the lone label whenever a tab's count
-//    badge is missing (e.g. while a fresh query is loading). Flex with
-//    `margin-left: auto` on the badge keeps the label left-aligned
-//    regardless of whether a badge is present.
-// 2. The bucket pattern hides the *last child* of `.selected` because
-//    the count is duplicated above the result list — that rule hides
-//    both the badge (when present) and the lone label (when not),
-//    which means the active tab disappears entirely while loading.
-//    We re-show last-child for tabs.
+// generic styling, but not its layout: a tab carries a category badge
+// next to its label, so it is a flex row (baseline-aligned, with a gap)
+// instead of the bucket's two-column grid. `margin-left: auto` on the
+// count badge pushes it to the right edge, which keeps the label
+// left-aligned whether or not a count is present (it is missing while a
+// fresh query is loading).
 //
 // Nested inside `.search-page` to match the specificity of the rule
 // being overridden (which is also `.search-page`-prefixed via outer
@@ -923,13 +884,6 @@ a:focus-visible {
 
   & > .badge {
     margin-left: auto;
-  }
-
-  // Counter the bucket-pattern `&.selected > span:last-child {
-  // display: none }` rule — applies to both the badge (when present)
-  // and the lone label (when counts are still loading).
-  &.selected > span:last-child {
-    display: inline-block;
   }
 }
 


### PR DESCRIPTION
Closes #1470.

<details>
<summary>
details
</summary>

`index.scss` styled the search UI through positional selectors -- `& > :nth-child(1)`, `> :nth-child(2n+1)`, `span:last-child`, bare `> div` -- which coupled the stylesheet to the exact shape of the Elm view functions and broke silently whenever the DOM was reordered.

Every such selector is replaced by a class that names what the element is. The classes are added in the Elm views only where the stylesheet needs them; element selectors stay where the element is already meaningful (`li`, `pre`, `code` under a classed parent).

New classes: `search-results-main`, `search-results-header`, `search-results-count`, `search-results-footer`, `search-results-list`, `search-result-title`, `bucket-label`, `bucket-count`, `package-description`, `package-short-details`, `package-details`, `package-long-description`, `package-usage`, `package-programs`, `package-maintainers-platforms`, `option-details`. `ul.search-result-button` becomes `ul.search-result-title.option-title` -- it is the option title row, neither a button nor a list of buttons.

The flat term/value grid in the expanded option view becomes a real `dl`, so the parity selectors (`div:nth-child(2n+1)` / `div:nth-child(2n)`) become `dt` / `dd`. `bootstrap.scss` carries no `dl`/`dt`/`dd` rules, so the user agent's `dd` inline-start margin is reset explicitly.

Seven rules matched nothing and are removed rather than revived:

- `body > div:first-child` -- `body`'s only child is `<shortcut-element>`, not a `div`.
- `... > :nth-child(1) > h2:nth-child(2)` and its nested `> p` -- the sort dropdown left the results header, so the `h2` is now child 1.
- `.search-bucket label > span:last-child` and `.search-bucket label.selected > span:last-child` -- the hidden radio `input` is the label's last child.
- `.search-source-tabs > label.selected > span:last-child` -- a counter-rule for the two above, dead for the same reason.
- `.search-bucket label .close` -- no element carries a `close` class.
- package usage `h4` -- the usage heading is a `legend.usage-title`.

Rendering is otherwise unchanged; verified by comparing screenshots against the previous stylesheet (packages, options and flakes lists, expanded package and option items, narrow viewport, light and dark theme -- all pixel-identical). The one exception is the empty-state cross-search hint: `p.search-cross-hint` happened to be the second child of `div.search-no-results` and so picked up the results-list `margin: 2em 0 0 0`. It now uses normal paragraph spacing. Note that the block meant to style it, `.search-page > .search-no-results`, is itself dead -- `.search-no-results` sits inside `.search-results` -- which is left for a separate change.
</details>

Assisted-by: Claude:claude-opus-5