### PR TITLE
frontend/search: restore fuzzy matching, limited to name fields

### DIFF
--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -94,6 +94,7 @@ packagesBody query from size sort selectedBuckets =
         , ( "package_longDescription", 1.0 )
         , ( "flake_name", 0.5 )
         ]
+        [ "package_attr_name", "package_pname", "package_programs" ]
         [ "package_description^3", "package_longDescription^1" ]
         [ { field = "package_repology_repos", pivot = 20.0 }
         , { field = "package_dep_count", pivot = 1000.0 }
@@ -142,6 +143,7 @@ optionsBody types query from size sort =
         , ( "service_package", 3.0 )
         , ( "service_packages", 3.0 )
         ]
+        [ "option_name", "service_package", "service_packages" ]
         [ "option_description^3" ]
         []
         Nothing
@@ -264,12 +266,20 @@ filterByType types =
             ]
 
 
+{-| Scales the field weights of the fuzzy clause down to a fallback.
+-}
+fuzzyFallbackWeight : Float
+fuzzyFallbackWeight =
+    0.05
+
+
 searchFields :
     List String
     -> List String
     -> List ( String, Float )
+    -> List String
     -> List (List ( String, Json.Encode.Value ))
-searchFields positiveWords mainFields fields =
+searchFields positiveWords mainFields fields fuzzyFieldNames =
     let
         allFields : List String
         allFields =
@@ -301,8 +311,39 @@ searchFields positiveWords mainFields fields =
                     ]
               )
             ]
+
+        fuzzyFields : List String
+        fuzzyFields =
+            fields
+                |> List.filter (\( field, _ ) -> List.member field fuzzyFieldNames)
+                |> List.map
+                    (\( field, score ) ->
+                        field ++ "^" ++ String.fromFloat (score * fuzzyFallbackWeight)
+                    )
+
+        fuzzyMatch : List (List ( String, Json.Encode.Value ))
+        fuzzyMatch =
+            if List.isEmpty fuzzyFields then
+                []
+
+            else
+                [ [ ( "multi_match"
+                    , Json.Encode.object
+                        [ ( "type", Json.Encode.string "best_fields" )
+                        , ( "query", Json.Encode.string (String.join " " positiveWords) )
+                        , ( "fuzziness", Json.Encode.string "1" )
+                        , ( "prefix_length", Json.Encode.int 1 )
+                        , ( "operator", Json.Encode.string "and" )
+                        , ( "_name", Json.Encode.string <| "fuzzy_" ++ String.join "_" positiveWords )
+                        , ( "fields", Json.Encode.list Json.Encode.string fuzzyFields )
+                        ]
+                    )
+                  ]
+                ]
     in
-    multiMatch :: List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
+    multiMatch
+        :: fuzzyMatch
+        ++ List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
 
 
 shouldClauses :
@@ -447,10 +488,11 @@ encodeRequestBody :
     -> List String
     -> List ( String, Float )
     -> List String
+    -> List String
     -> List PopularitySignal
     -> Maybe String
     -> Json.Encode.Value
-encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms filterByBuckets mainFields fields phraseFields popularitySignals rescoreField =
+encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms filterByBuckets mainFields fields fuzzyFieldNames phraseFields popularitySignals rescoreField =
     let
         -- you can not request more then 10000 results otherwise it will return 404
         size =
@@ -531,7 +573,7 @@ encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms 
                                         [ ( "tie_breaker", Json.Encode.float 0.7 )
                                         , ( "queries"
                                           , Json.Encode.list Json.Encode.object
-                                                (searchFields positiveWords mainFields fields)
+                                                (searchFields positiveWords mainFields fields fuzzyFieldNames)
                                           )
                                         ]
                                     )


### PR DESCRIPTION
This PR gives package search typo tolerance again. #1422 added it. #1462
reverted it. This is the retry.

## Why it was reverted

The #1422 clause searched the description fields. It allowed two edits.
It accepted a document when one word matched. One fuzzy word inside a
long description was therefore enough to put a package on the page.
Users reported the result in #1438: `continuwuity`, `rusty-v8`,
`structure-test`.

I re-measured that clause on today's main. It scores 0.468 package RBP.
Main without any fuzzy matching scores 0.507. Per query:

| query                     | main  | #1422 clause |
| ------------------------- | ----- | ------------ |
| continuwuity              | 1.000 | 0.000        |
| services.syncthing.enable | 1.000 | 0.556        |
| services.openssh.enable   | 0.672 | 0.512        |

So #1422 cost precision. The revert was right.

## What is different

#1500 added RBP. Precision is measurable now. I used it to narrow the
clause until it stops costing any.

The new clause:

- searches name fields only: `package_attr_name`, `package_pname`,
  `package_programs`, `option_name`, `service_package`,
  `service_packages`. It never searches a description.
- allows one edit. It does not use `AUTO`.
- keeps the first character (`prefix_length: 1`).
- requires every term (`operator: and`).
- carries 5% of the weight its field carries elsewhere.

The last point matters most. The clause exists to find a document no
other clause found. It must not reorder the documents the other clauses
already found. A small weight does exactly that.

## About the weight

#1422 review asked how to pick this number. I tested 0.05, 0.1, 0.2, 0.5
and a constant score.

- At 0.05 the clause only adds hits to a page.
- At 0.1 and above it also reorders a page. The `postgresql` page loses
  precision first, from 0.953 to 0.923.

So 0.05. I also tested `AUTO` in place of `1`. `AUTO` costs precision on
the options track: `services.openssh.enable` falls from 0.672 to 0.556.


Assisted by opus 5