### PR TITLE
Benchmark: score the gold set as ranked tiers

### DIFF
--- a/frontend/benchmark/queries-options.json
+++ b/frontend/benchmark/queries-options.json
@@ -4,20 +4,21 @@
         "q": "nginx",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.nginx.enable",
         "relevant": [
-            "opt:services.nginx.enable",
-            "opt:services.nginx.virtualHosts",
-            "opt:services.nginx.user",
-            "opt:services.nginx.group",
-            "opt:services.nginx.package",
-            "opt:services.nginx.config",
-            "opt:services.nginx.httpConfig",
-            "opt:services.nginx.appendHttpConfig",
-            "opt:services.nginx.recommendedProxySettings",
-            "opt:services.nginx.recommendedTlsSettings",
-            "opt:services.nginx.recommendedGzipSettings",
-            "opt:services.nginx.recommendedOptimisation"
+            ["opt:services.nginx.enable"],
+            [
+                "opt:services.nginx.virtualHosts",
+                "opt:services.nginx.user",
+                "opt:services.nginx.group",
+                "opt:services.nginx.package",
+                "opt:services.nginx.config",
+                "opt:services.nginx.httpConfig",
+                "opt:services.nginx.appendHttpConfig",
+                "opt:services.nginx.recommendedProxySettings",
+                "opt:services.nginx.recommendedTlsSettings",
+                "opt:services.nginx.recommendedGzipSettings",
+                "opt:services.nginx.recommendedOptimisation"
+            ]
         ]
     },
     {
@@ -25,16 +26,17 @@
         "q": "grafana",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.grafana.enable",
         "relevant": [
-            "opt:services.grafana.enable",
-            "opt:services.grafana.settings",
-            "opt:services.grafana.settings.server.http_port",
-            "opt:services.grafana.settings.server.http_addr",
-            "opt:services.grafana.settings.server.domain",
-            "opt:services.grafana.provision.enable",
-            "opt:services.grafana.declarativePlugins",
-            "opt:services.grafana.package"
+            ["opt:services.grafana.enable"],
+            [
+                "opt:services.grafana.settings",
+                "opt:services.grafana.settings.server.http_port",
+                "opt:services.grafana.settings.server.http_addr",
+                "opt:services.grafana.settings.server.domain",
+                "opt:services.grafana.provision.enable",
+                "opt:services.grafana.declarativePlugins",
+                "opt:services.grafana.package"
+            ]
         ]
     },
     {
@@ -42,17 +44,18 @@
         "q": "prometheus",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.prometheus.enable",
         "relevant": [
-            "opt:services.prometheus.enable",
-            "opt:services.prometheus.exporters",
-            "opt:services.prometheus.port",
-            "opt:services.prometheus.listenAddress",
-            "opt:services.prometheus.stateDir",
-            "opt:services.prometheus.scrapeConfigs",
-            "opt:services.prometheus.globalConfig",
-            "opt:services.prometheus.alertmanager.enable",
-            "opt:services.prometheus.exporters.node.enable"
+            ["opt:services.prometheus.enable"],
+            [
+                "opt:services.prometheus.exporters",
+                "opt:services.prometheus.port",
+                "opt:services.prometheus.listenAddress",
+                "opt:services.prometheus.stateDir",
+                "opt:services.prometheus.scrapeConfigs",
+                "opt:services.prometheus.globalConfig",
+                "opt:services.prometheus.alertmanager.enable",
+                "opt:services.prometheus.exporters.node.enable"
+            ]
         ]
     },
     {
@@ -60,19 +63,20 @@
         "q": "postgresql",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.postgresql.enable",
         "relevant": [
-            "opt:services.postgresql.enable",
-            "opt:services.postgresql.package",
-            "opt:services.postgresql.dataDir",
-            "opt:services.postgresql.settings",
-            "opt:services.postgresql.ensureDatabases",
-            "opt:services.postgresql.ensureUsers",
-            "opt:services.postgresql.authentication",
-            "opt:services.postgresql.enableTCPIP",
-            "opt:services.postgresql.identMap",
-            "opt:services.postgresql.initialScript",
-            "opt:services.postgresql.extensions"
+            ["opt:services.postgresql.enable"],
+            [
+                "opt:services.postgresql.package",
+                "opt:services.postgresql.dataDir",
+                "opt:services.postgresql.settings",
+                "opt:services.postgresql.ensureDatabases",
+                "opt:services.postgresql.ensureUsers",
+                "opt:services.postgresql.authentication",
+                "opt:services.postgresql.enableTCPIP",
+                "opt:services.postgresql.identMap",
+                "opt:services.postgresql.initialScript",
+                "opt:services.postgresql.extensions"
+            ]
         ]
     },
     {
@@ -80,20 +84,21 @@
         "q": "openssh",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.openssh.enable",
         "relevant": [
-            "opt:services.openssh.enable",
-            "opt:services.openssh.settings",
-            "opt:services.openssh.ports",
-            "opt:services.openssh.extraConfig",
-            "opt:services.openssh.openFirewall",
-            "opt:services.openssh.package",
-            "opt:services.openssh.hostKeys",
-            "opt:services.openssh.authorizedKeysFiles",
-            "opt:services.openssh.listenAddresses",
-            "opt:services.openssh.startWhenNeeded",
-            "opt:services.openssh.settings.PasswordAuthentication",
-            "opt:services.openssh.settings.PermitRootLogin"
+            ["opt:services.openssh.enable"],
+            [
+                "opt:services.openssh.settings",
+                "opt:services.openssh.ports",
+                "opt:services.openssh.extraConfig",
+                "opt:services.openssh.openFirewall",
+                "opt:services.openssh.package",
+                "opt:services.openssh.hostKeys",
+                "opt:services.openssh.authorizedKeysFiles",
+                "opt:services.openssh.listenAddresses",
+                "opt:services.openssh.startWhenNeeded",
+                "opt:services.openssh.settings.PasswordAuthentication",
+                "opt:services.openssh.settings.PermitRootLogin"
+            ]
         ]
     },
     {
@@ -101,17 +106,18 @@
         "q": "caddy",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.caddy.enable",
         "relevant": [
-            "opt:services.caddy.enable",
-            "opt:services.caddy.virtualHosts",
-            "opt:services.caddy.user",
-            "opt:services.caddy.group",
-            "opt:services.caddy.package",
-            "opt:services.caddy.email",
-            "opt:services.caddy.globalConfig",
-            "opt:services.caddy.configFile",
-            "opt:services.caddy.dataDir"
+            ["opt:services.caddy.enable"],
+            [
+                "opt:services.caddy.virtualHosts",
+                "opt:services.caddy.user",
+                "opt:services.caddy.group",
+                "opt:services.caddy.package",
+                "opt:services.caddy.email",
+                "opt:services.caddy.globalConfig",
+                "opt:services.caddy.configFile",
+                "opt:services.caddy.dataDir"
+            ]
         ]
     },
     {
@@ -119,12 +125,13 @@
         "q": "gitea",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.gitea.enable",
         "relevant": [
-            "opt:services.gitea.enable",
-            "opt:services.gitea.settings",
-            "opt:services.gitea.database.type",
-            "opt:services.gitea.stateDir"
+            ["opt:services.gitea.enable"],
+            [
+                "opt:services.gitea.settings",
+                "opt:services.gitea.database.type",
+                "opt:services.gitea.stateDir"
+            ]
         ]
     },
     {
@@ -132,14 +139,15 @@
         "q": "jellyfin",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.jellyfin.enable",
         "relevant": [
-            "opt:services.jellyfin.enable",
-            "opt:services.jellyfin.openFirewall",
-            "opt:services.jellyfin.dataDir",
-            "opt:services.jellyfin.cacheDir",
-            "opt:services.jellyfin.user",
-            "opt:services.jellyfin.group"
+            ["opt:services.jellyfin.enable"],
+            [
+                "opt:services.jellyfin.openFirewall",
+                "opt:services.jellyfin.dataDir",
+                "opt:services.jellyfin.cacheDir",
+                "opt:services.jellyfin.user",
+                "opt:services.jellyfin.group"
+            ]
         ]
     },
     {
@@ -147,88 +155,91 @@
         "q": "services.openssh.enable",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.openssh.enable",
-        "relevant": ["opt:services.openssh.enable", "opt:services.sshd.enable"]
+        "relevant": [
+            ["opt:services.openssh.enable"],
+            ["opt:services.sshd.enable"]
+        ]
     },
     {
         "id": "g017",
         "q": "services.grafana.enable",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:services.grafana.enable"]
+        "relevant": [["opt:services.grafana.enable"]]
     },
     {
         "id": "g018",
         "q": "networking.firewall.enable",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:networking.firewall.enable"]
+        "relevant": [["opt:networking.firewall.enable"]]
     },
     {
         "id": "g019",
         "q": "services.redis.servers",
         "category": "exact",
-        "relevant": ["opt:services.redis.servers"]
+        "relevant": [["opt:services.redis.servers"]]
     },
     {
         "id": "g020",
         "q": "services.syncthing.enable",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:services.syncthing.enable"]
+        "relevant": [["opt:services.syncthing.enable"]]
     },
     {
         "id": "g021",
         "q": "services.printing.enable",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:services.printing.enable"]
+        "relevant": [["opt:services.printing.enable"]]
     },
     {
         "id": "g022",
         "q": "services.nginx.virtualHosts",
         "category": "exact",
-        "relevant": ["opt:services.nginx.virtualHosts"]
+        "relevant": [["opt:services.nginx.virtualHosts"]]
     },
     {
         "id": "g023",
         "q": "networking.firewall.allowedTCPPorts",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:networking.firewall.allowedTCPPorts"]
+        "relevant": [["opt:networking.firewall.allowedTCPPorts"]]
     },
     {
         "id": "g024",
         "q": "services.nextcloud.hostName",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:services.nextcloud.hostName"]
+        "relevant": [["opt:services.nextcloud.hostName"]]
     },
     {
         "id": "g025",
         "q": "networking.networkmanager.logLevel",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:networking.networkmanager.logLevel"]
+        "relevant": [["opt:networking.networkmanager.logLevel"]]
     },
     {
         "id": "g150",
         "q": "docker",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:virtualisation.docker.enable",
         "relevant": [
-            "opt:virtualisation.docker.enable",
-            "opt:virtualisation.docker.rootless.enable",
-            "opt:virtualisation.docker.rootless.setSocketVariable",
-            "opt:virtualisation.docker.storageDriver",
-            "opt:virtualisation.docker.daemon.settings",
-            "opt:virtualisation.docker.enableOnBoot",
-            "opt:virtualisation.docker.autoPrune.enable",
-            "opt:virtualisation.docker.package",
-            "opt:virtualisation.docker.extraOptions",
-            "opt:virtualisation.docker.logDriver",
-            "opt:virtualisation.docker.liveRestore"
+            ["opt:virtualisation.docker.enable"],
+            [
+                "opt:virtualisation.docker.rootless.enable",
+                "opt:virtualisation.docker.rootless.setSocketVariable",
+                "opt:virtualisation.docker.storageDriver",
+                "opt:virtualisation.docker.daemon.settings",
+                "opt:virtualisation.docker.enableOnBoot",
+                "opt:virtualisation.docker.autoPrune.enable",
+                "opt:virtualisation.docker.package",
+                "opt:virtualisation.docker.extraOptions",
+                "opt:virtualisation.docker.logDriver",
+                "opt:virtualisation.docker.liveRestore"
+            ]
         ]
     },
     {
@@ -236,20 +247,21 @@
         "q": "firewall",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:networking.firewall.enable",
         "relevant": [
-            "opt:networking.firewall.enable",
-            "opt:networking.firewall.allowedTCPPorts",
-            "opt:networking.firewall.allowedUDPPorts",
-            "opt:networking.firewall.allowedTCPPortRanges",
-            "opt:networking.firewall.allowedUDPPortRanges",
-            "opt:networking.firewall.extraCommands",
-            "opt:networking.firewall.extraInputRules",
-            "opt:networking.firewall.checkReversePath",
-            "opt:networking.firewall.trustedInterfaces",
-            "opt:networking.firewall.allowPing",
-            "opt:networking.firewall.interfaces",
-            "opt:networking.firewall.logRefusedConnections"
+            ["opt:networking.firewall.enable"],
+            [
+                "opt:networking.firewall.allowedTCPPorts",
+                "opt:networking.firewall.allowedUDPPorts",
+                "opt:networking.firewall.allowedTCPPortRanges",
+                "opt:networking.firewall.allowedUDPPortRanges",
+                "opt:networking.firewall.extraCommands",
+                "opt:networking.firewall.extraInputRules",
+                "opt:networking.firewall.checkReversePath",
+                "opt:networking.firewall.trustedInterfaces",
+                "opt:networking.firewall.allowPing",
+                "opt:networking.firewall.interfaces",
+                "opt:networking.firewall.logRefusedConnections"
+            ]
         ]
     },
     {
@@ -257,17 +269,18 @@
         "q": "printing",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.printing.enable",
         "relevant": [
-            "opt:services.printing.enable",
-            "opt:services.printing.drivers",
-            "opt:services.printing.openFirewall",
-            "opt:services.printing.browsing",
-            "opt:services.printing.browsed.enable",
-            "opt:services.printing.logLevel",
-            "opt:services.printing.listenAddresses",
-            "opt:services.printing.defaultShared",
-            "opt:hardware.printers.ensurePrinters"
+            ["opt:services.printing.enable"],
+            [
+                "opt:services.printing.drivers",
+                "opt:services.printing.openFirewall",
+                "opt:services.printing.browsing",
+                "opt:services.printing.browsed.enable",
+                "opt:services.printing.logLevel",
+                "opt:services.printing.listenAddresses",
+                "opt:services.printing.defaultShared",
+                "opt:hardware.printers.ensurePrinters"
+            ]
         ]
     },
     {
@@ -275,13 +288,14 @@
         "q": "bluetooth",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:hardware.bluetooth.enable",
         "relevant": [
-            "opt:hardware.bluetooth.enable",
-            "opt:hardware.bluetooth.powerOnBoot",
-            "opt:hardware.bluetooth.settings",
-            "opt:hardware.bluetooth.package",
-            "opt:services.blueman.enable"
+            ["opt:hardware.bluetooth.enable"],
+            [
+                "opt:hardware.bluetooth.powerOnBoot",
+                "opt:hardware.bluetooth.settings",
+                "opt:hardware.bluetooth.package",
+                "opt:services.blueman.enable"
+            ]
         ]
     },
     {
@@ -289,17 +303,18 @@
         "q": "systemd-boot",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:boot.loader.systemd-boot.enable",
         "relevant": [
-            "opt:boot.loader.systemd-boot.enable",
-            "opt:boot.loader.systemd-boot.configurationLimit",
-            "opt:boot.loader.systemd-boot.consoleMode",
-            "opt:boot.loader.systemd-boot.editor",
-            "opt:boot.loader.systemd-boot.extraEntries",
-            "opt:boot.loader.systemd-boot.extraFiles",
-            "opt:boot.loader.systemd-boot.memtest86.enable",
-            "opt:boot.loader.systemd-boot.netbootxyz.enable",
-            "opt:boot.loader.efi.canTouchEfiVariables"
+            ["opt:boot.loader.systemd-boot.enable"],
+            [
+                "opt:boot.loader.systemd-boot.configurationLimit",
+                "opt:boot.loader.systemd-boot.consoleMode",
+                "opt:boot.loader.systemd-boot.editor",
+                "opt:boot.loader.systemd-boot.extraEntries",
+                "opt:boot.loader.systemd-boot.extraFiles",
+                "opt:boot.loader.systemd-boot.memtest86.enable",
+                "opt:boot.loader.systemd-boot.netbootxyz.enable",
+                "opt:boot.loader.efi.canTouchEfiVariables"
+            ]
         ]
     },
     {
@@ -307,15 +322,16 @@
         "q": "git",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:programs.git.enable",
         "relevant": [
-            "opt:programs.git.enable",
-            "opt:programs.git.config",
-            "opt:programs.git.settings",
-            "opt:programs.git.package",
-            "opt:programs.git.lfs.enable",
-            "opt:programs.git.prompt.enable",
-            "opt:programs.git.ignores"
+            ["opt:programs.git.enable"],
+            [
+                "opt:programs.git.config",
+                "opt:programs.git.settings",
+                "opt:programs.git.package",
+                "opt:programs.git.lfs.enable",
+                "opt:programs.git.prompt.enable",
+                "opt:programs.git.ignores"
+            ]
         ]
     },
     {
@@ -323,14 +339,15 @@
         "q": "redis",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.redis.servers",
         "relevant": [
-            "opt:services.redis.servers",
-            "opt:services.redis.servers.<name>.enable",
-            "opt:services.redis.servers.<name>.port",
-            "opt:services.redis.servers.<name>.unixSocket",
-            "opt:services.redis.servers.<name>.user",
-            "opt:services.redis.package"
+            ["opt:services.redis.servers"],
+            [
+                "opt:services.redis.servers.<name>.enable",
+                "opt:services.redis.servers.<name>.port",
+                "opt:services.redis.servers.<name>.unixSocket",
+                "opt:services.redis.servers.<name>.user",
+                "opt:services.redis.package"
+            ]
         ]
     },
     {
@@ -338,17 +355,18 @@
         "q": "restic",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.restic.backups",
         "relevant": [
-            "opt:services.restic.backups",
-            "opt:services.restic.backups.<name>.paths",
-            "opt:services.restic.backups.<name>.repository",
-            "opt:services.restic.backups.<name>.passwordFile",
-            "opt:services.restic.backups.<name>.initialize",
-            "opt:services.restic.backups.<name>.pruneOpts",
-            "opt:services.restic.backups.<name>.timerConfig",
-            "opt:services.restic.backups.<name>.user",
-            "opt:services.restic.backups.<name>.environmentFile"
+            ["opt:services.restic.backups"],
+            [
+                "opt:services.restic.backups.<name>.paths",
+                "opt:services.restic.backups.<name>.repository",
+                "opt:services.restic.backups.<name>.passwordFile",
+                "opt:services.restic.backups.<name>.initialize",
+                "opt:services.restic.backups.<name>.pruneOpts",
+                "opt:services.restic.backups.<name>.timerConfig",
+                "opt:services.restic.backups.<name>.user",
+                "opt:services.restic.backups.<name>.environmentFile"
+            ]
         ]
     },
     {
@@ -356,21 +374,22 @@
         "q": "syncthing",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.syncthing.enable",
         "relevant": [
-            "opt:services.syncthing.enable",
-            "opt:services.syncthing.settings",
-            "opt:services.syncthing.dataDir",
-            "opt:services.syncthing.configDir",
-            "opt:services.syncthing.user",
-            "opt:services.syncthing.group",
-            "opt:services.syncthing.guiAddress",
-            "opt:services.syncthing.openDefaultPorts",
-            "opt:services.syncthing.key",
-            "opt:services.syncthing.cert",
-            "opt:services.syncthing.extraFlags",
-            "opt:services.syncthing.settings.folders",
-            "opt:services.syncthing.settings.devices"
+            ["opt:services.syncthing.enable"],
+            [
+                "opt:services.syncthing.settings",
+                "opt:services.syncthing.dataDir",
+                "opt:services.syncthing.configDir",
+                "opt:services.syncthing.user",
+                "opt:services.syncthing.group",
+                "opt:services.syncthing.guiAddress",
+                "opt:services.syncthing.openDefaultPorts",
+                "opt:services.syncthing.key",
+                "opt:services.syncthing.cert",
+                "opt:services.syncthing.extraFlags",
+                "opt:services.syncthing.settings.folders",
+                "opt:services.syncthing.settings.devices"
+            ]
         ]
     },
     {
@@ -378,15 +397,16 @@
         "q": "tailscale",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.tailscale.enable",
         "relevant": [
-            "opt:services.tailscale.enable",
-            "opt:services.tailscale.port",
-            "opt:services.tailscale.useRoutingFeatures",
-            "opt:services.tailscale.authKeyFile",
-            "opt:services.tailscale.permitCertUid",
-            "opt:services.tailscale.interfaceName",
-            "opt:services.tailscale.package"
+            ["opt:services.tailscale.enable"],
+            [
+                "opt:services.tailscale.port",
+                "opt:services.tailscale.useRoutingFeatures",
+                "opt:services.tailscale.authKeyFile",
+                "opt:services.tailscale.permitCertUid",
+                "opt:services.tailscale.interfaceName",
+                "opt:services.tailscale.package"
+            ]
         ]
     },
     {
@@ -394,13 +414,14 @@
         "q": "samba",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.samba.enable",
         "relevant": [
-            "opt:services.samba.enable",
-            "opt:services.samba.settings",
-            "opt:services.samba.openFirewall",
-            "opt:services.samba.package",
-            "opt:services.samba.usershares.enable"
+            ["opt:services.samba.enable"],
+            [
+                "opt:services.samba.settings",
+                "opt:services.samba.openFirewall",
+                "opt:services.samba.package",
+                "opt:services.samba.usershares.enable"
+            ]
         ]
     },
     {
@@ -408,19 +429,20 @@
         "q": "nextcloud",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.nextcloud.enable",
         "relevant": [
-            "opt:services.nextcloud.enable",
-            "opt:services.nextcloud.hostName",
-            "opt:services.nextcloud.package",
-            "opt:services.nextcloud.https",
-            "opt:services.nextcloud.maxUploadSize",
-            "opt:services.nextcloud.extraApps",
-            "opt:services.nextcloud.secretFile",
-            "opt:services.nextcloud.settings",
-            "opt:services.nextcloud.datadir",
-            "opt:services.nextcloud.phpOptions",
-            "opt:services.nextcloud.config.adminpassFile"
+            ["opt:services.nextcloud.enable"],
+            [
+                "opt:services.nextcloud.hostName",
+                "opt:services.nextcloud.package",
+                "opt:services.nextcloud.https",
+                "opt:services.nextcloud.maxUploadSize",
+                "opt:services.nextcloud.extraApps",
+                "opt:services.nextcloud.secretFile",
+                "opt:services.nextcloud.settings",
+                "opt:services.nextcloud.datadir",
+                "opt:services.nextcloud.phpOptions",
+                "opt:services.nextcloud.config.adminpassFile"
+            ]
         ]
     },
     {
@@ -428,14 +450,15 @@
         "q": "mysql",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.mysql.enable",
         "relevant": [
-            "opt:services.mysql.enable",
-            "opt:services.mysql.package",
-            "opt:services.mysql.settings",
-            "opt:services.mysql.dataDir",
-            "opt:services.mysql.ensureDatabases",
-            "opt:services.mysql.ensureUsers"
+            ["opt:services.mysql.enable"],
+            [
+                "opt:services.mysql.package",
+                "opt:services.mysql.settings",
+                "opt:services.mysql.dataDir",
+                "opt:services.mysql.ensureDatabases",
+                "opt:services.mysql.ensureUsers"
+            ]
         ]
     },
     {
@@ -443,14 +466,15 @@
         "q": "xserver",
         "category": "exact",
         "exhaustive": true,
-        "best": "opt:services.xserver.enable",
         "relevant": [
-            "opt:services.xserver.enable",
-            "opt:services.xserver.videoDrivers",
-            "opt:services.xserver.xkb.layout",
-            "opt:services.xserver.xkb.options",
-            "opt:services.xserver.dpi",
-            "opt:services.displayManager.defaultSession"
+            ["opt:services.xserver.enable"],
+            [
+                "opt:services.xserver.videoDrivers",
+                "opt:services.xserver.xkb.layout",
+                "opt:services.xserver.xkb.options",
+                "opt:services.xserver.dpi",
+                "opt:services.displayManager.defaultSession"
+            ]
         ]
     },
     {
@@ -458,256 +482,257 @@
         "q": "boot.loader.efi.canTouchEfiVariables",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:boot.loader.efi.canTouchEfiVariables"]
+        "relevant": [["opt:boot.loader.efi.canTouchEfiVariables"]]
     },
     {
         "id": "g165",
         "q": "canTouchEfiVariables",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["opt:boot.loader.efi.canTouchEfiVariables"]
+        "relevant": [["opt:boot.loader.efi.canTouchEfiVariables"]]
     },
     {
         "id": "g026",
         "q": "postgres",
         "category": "prefix",
-        "relevant": ["opt:services.postgresql.enable"]
+        "relevant": [["opt:services.postgresql.enable"]]
     },
     {
         "id": "g027",
         "q": "graf",
         "category": "prefix",
-        "relevant": ["opt:services.grafana.enable"]
+        "relevant": [["opt:services.grafana.enable"]]
     },
     {
         "id": "g028",
         "q": "prom",
         "category": "prefix",
-        "relevant": ["opt:services.prometheus.enable"]
+        "relevant": [["opt:services.prometheus.enable"]]
     },
     {
         "id": "g030",
         "q": "jelly",
         "category": "prefix",
-        "relevant": ["opt:services.jellyfin.enable"]
+        "relevant": [["opt:services.jellyfin.enable"]]
     },
     {
         "id": "g031",
         "q": "syncth",
         "category": "prefix",
-        "relevant": ["opt:services.syncthing.enable"]
+        "relevant": [["opt:services.syncthing.enable"]]
     },
     {
         "id": "g032",
         "q": "wireg",
         "category": "prefix",
-        "relevant": ["opt:networking.wireguard.enable"]
+        "relevant": [["opt:networking.wireguard.enable"]]
     },
     {
         "id": "g033",
         "q": "nftab",
         "category": "prefix",
-        "relevant": ["opt:networking.nftables.enable"]
+        "relevant": [["opt:networking.nftables.enable"]]
     },
     {
         "id": "g034",
         "q": "hypr",
         "category": "prefix",
-        "relevant": ["opt:programs.hyprland.enable"]
+        "relevant": [["opt:programs.hyprland.enable"]]
     },
     {
         "id": "g035",
         "q": "ngin",
         "category": "prefix",
-        "relevant": ["opt:services.nginx.enable"]
+        "relevant": [["opt:services.nginx.enable"]]
     },
     {
         "id": "g037",
         "q": "fail2",
         "category": "prefix",
-        "relevant": ["opt:services.fail2ban.enable"]
+        "relevant": [["opt:services.fail2ban.enable"]]
     },
     {
         "id": "g038",
         "q": "tailsc",
         "category": "prefix",
-        "relevant": ["opt:services.tailscale.enable"]
+        "relevant": [["opt:services.tailscale.enable"]]
     },
     {
         "id": "g039",
         "q": "nextcl",
         "category": "prefix",
-        "relevant": ["opt:services.nextcloud.enable"]
+        "relevant": [["opt:services.nextcloud.enable"]]
     },
     {
         "id": "g040",
         "q": "traef",
         "category": "prefix",
-        "relevant": ["opt:services.traefik.enable"]
+        "relevant": [["opt:services.traefik.enable"]]
     },
     {
         "id": "g041",
         "q": "cadd",
         "category": "prefix",
-        "relevant": ["opt:services.caddy.enable"]
+        "relevant": [["opt:services.caddy.enable"]]
     },
     {
         "id": "g042",
         "q": "transm",
         "category": "prefix",
-        "relevant": ["opt:services.transmission.enable"]
+        "relevant": [["opt:services.transmission.enable"]]
     },
     {
         "id": "g043",
         "q": "unbou",
         "category": "prefix",
-        "relevant": ["opt:services.unbound.enable"]
+        "relevant": [["opt:services.unbound.enable"]]
     },
     {
         "id": "g044",
         "q": "dnsma",
         "category": "prefix",
-        "relevant": ["opt:services.dnsmasq.enable"]
+        "relevant": [["opt:services.dnsmasq.enable"]]
     },
     {
         "id": "g049",
         "q": "mosqui",
         "category": "prefix",
-        "relevant": ["opt:services.mosquitto.enable"]
+        "relevant": [["opt:services.mosquitto.enable"]]
     },
     {
         "id": "g050",
         "q": "elastic",
         "category": "prefix",
-        "relevant": ["opt:services.elasticsearch.enable"]
+        "relevant": [["opt:services.elasticsearch.enable"]]
     },
     {
         "id": "g051",
         "q": "ngnix",
         "category": "typo",
-        "relevant": ["opt:services.nginx.enable"]
+        "relevant": [["opt:services.nginx.enable"]]
     },
     {
         "id": "g052",
         "q": "postgrsql",
         "category": "typo",
-        "relevant": ["opt:services.postgresql.enable"]
+        "relevant": [["opt:services.postgresql.enable"]]
     },
     {
         "id": "g053",
         "q": "promethues",
         "category": "typo",
-        "relevant": ["opt:services.prometheus.enable"]
+        "relevant": [["opt:services.prometheus.enable"]]
     },
     {
         "id": "g054",
         "q": "grafan",
         "category": "typo",
-        "relevant": ["opt:services.grafana.enable"]
+        "relevant": [["opt:services.grafana.enable"]]
     },
     {
         "id": "g057",
         "q": "jellifin",
         "category": "typo",
-        "relevant": ["opt:services.jellyfin.enable"]
+        "relevant": [["opt:services.jellyfin.enable"]]
     },
     {
         "id": "g058",
         "q": "sytemd-boot",
         "category": "typo",
-        "relevant": ["opt:boot.loader.systemd-boot.enable"]
+        "relevant": [["opt:boot.loader.systemd-boot.enable"]]
     },
     {
         "id": "g059",
         "q": "wireguad",
         "category": "typo",
-        "relevant": ["opt:networking.wireguard.enable"]
+        "relevant": [["opt:networking.wireguard.enable"]]
     },
     {
         "id": "g060",
         "q": "samaba",
         "category": "typo",
-        "relevant": ["opt:services.samba.enable"]
+        "relevant": [["opt:services.samba.enable"]]
     },
     {
         "id": "g062",
         "q": "openssg",
         "category": "typo",
-        "relevant": ["opt:services.openssh.enable"]
+        "relevant": [["opt:services.openssh.enable"]]
     },
     {
         "id": "g067",
         "q": "dcoker",
         "category": "typo",
-        "relevant": ["opt:virtualisation.docker.enable"]
+        "relevant": [["opt:virtualisation.docker.enable"]]
     },
     {
         "id": "g068",
         "q": "nextcoud",
         "category": "typo",
-        "relevant": ["opt:services.nextcloud.enable"]
+        "relevant": [["opt:services.nextcloud.enable"]]
     },
     {
         "id": "g069",
         "q": "gitae",
         "category": "typo",
-        "relevant": ["opt:services.gitea.enable"]
+        "relevant": [["opt:services.gitea.enable"]]
     },
     {
         "id": "g070",
         "q": "vaultwardn",
         "category": "typo",
-        "relevant": ["opt:services.vaultwarden.enable"]
+        "relevant": [["opt:services.vaultwarden.enable"]]
     },
     {
         "id": "g071",
         "q": "tailscle",
         "category": "typo",
-        "relevant": ["opt:services.tailscale.enable"]
+        "relevant": [["opt:services.tailscale.enable"]]
     },
     {
         "id": "g072",
         "q": "fial2ban",
         "category": "typo",
-        "relevant": ["opt:services.fail2ban.enable"]
+        "relevant": [["opt:services.fail2ban.enable"]]
     },
     {
         "id": "g073",
         "q": "mosquito",
         "category": "typo",
-        "relevant": ["opt:services.mosquitto.enable"]
+        "relevant": [["opt:services.mosquitto.enable"]]
     },
     {
         "id": "g074",
         "q": "syncthign",
         "category": "typo",
-        "relevant": ["opt:services.syncthing.enable"]
+        "relevant": [["opt:services.syncthing.enable"]]
     },
     {
         "id": "g075",
         "q": "cady",
         "category": "typo",
-        "relevant": ["opt:services.caddy.enable"]
+        "relevant": [["opt:services.caddy.enable"]]
     },
     {
         "id": "g076",
         "q": "services.nginx",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.nginx.enable",
         "relevant": [
-            "opt:services.nginx.enable",
-            "opt:services.nginx.virtualHosts",
-            "opt:services.nginx.user",
-            "opt:services.nginx.group",
-            "opt:services.nginx.package",
-            "opt:services.nginx.config",
-            "opt:services.nginx.httpConfig",
-            "opt:services.nginx.appendHttpConfig",
-            "opt:services.nginx.recommendedProxySettings",
-            "opt:services.nginx.recommendedTlsSettings",
-            "opt:services.nginx.recommendedGzipSettings",
-            "opt:services.nginx.recommendedOptimisation"
+            ["opt:services.nginx.enable"],
+            [
+                "opt:services.nginx.virtualHosts",
+                "opt:services.nginx.user",
+                "opt:services.nginx.group",
+                "opt:services.nginx.package",
+                "opt:services.nginx.config",
+                "opt:services.nginx.httpConfig",
+                "opt:services.nginx.appendHttpConfig",
+                "opt:services.nginx.recommendedProxySettings",
+                "opt:services.nginx.recommendedTlsSettings",
+                "opt:services.nginx.recommendedGzipSettings",
+                "opt:services.nginx.recommendedOptimisation"
+            ]
         ]
     },
     {
@@ -715,19 +740,20 @@
         "q": "virtualisation.docker",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:virtualisation.docker.enable",
         "relevant": [
-            "opt:virtualisation.docker.enable",
-            "opt:virtualisation.docker.rootless.enable",
-            "opt:virtualisation.docker.rootless.setSocketVariable",
-            "opt:virtualisation.docker.storageDriver",
-            "opt:virtualisation.docker.daemon.settings",
-            "opt:virtualisation.docker.enableOnBoot",
-            "opt:virtualisation.docker.autoPrune.enable",
-            "opt:virtualisation.docker.package",
-            "opt:virtualisation.docker.extraOptions",
-            "opt:virtualisation.docker.logDriver",
-            "opt:virtualisation.docker.liveRestore"
+            ["opt:virtualisation.docker.enable"],
+            [
+                "opt:virtualisation.docker.rootless.enable",
+                "opt:virtualisation.docker.rootless.setSocketVariable",
+                "opt:virtualisation.docker.storageDriver",
+                "opt:virtualisation.docker.daemon.settings",
+                "opt:virtualisation.docker.enableOnBoot",
+                "opt:virtualisation.docker.autoPrune.enable",
+                "opt:virtualisation.docker.package",
+                "opt:virtualisation.docker.extraOptions",
+                "opt:virtualisation.docker.logDriver",
+                "opt:virtualisation.docker.liveRestore"
+            ]
         ]
     },
     {
@@ -735,20 +761,21 @@
         "q": "services.openssh",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.openssh.enable",
         "relevant": [
-            "opt:services.openssh.enable",
-            "opt:services.openssh.settings",
-            "opt:services.openssh.ports",
-            "opt:services.openssh.extraConfig",
-            "opt:services.openssh.openFirewall",
-            "opt:services.openssh.package",
-            "opt:services.openssh.hostKeys",
-            "opt:services.openssh.authorizedKeysFiles",
-            "opt:services.openssh.listenAddresses",
-            "opt:services.openssh.startWhenNeeded",
-            "opt:services.openssh.settings.PasswordAuthentication",
-            "opt:services.openssh.settings.PermitRootLogin"
+            ["opt:services.openssh.enable"],
+            [
+                "opt:services.openssh.settings",
+                "opt:services.openssh.ports",
+                "opt:services.openssh.extraConfig",
+                "opt:services.openssh.openFirewall",
+                "opt:services.openssh.package",
+                "opt:services.openssh.hostKeys",
+                "opt:services.openssh.authorizedKeysFiles",
+                "opt:services.openssh.listenAddresses",
+                "opt:services.openssh.startWhenNeeded",
+                "opt:services.openssh.settings.PasswordAuthentication",
+                "opt:services.openssh.settings.PermitRootLogin"
+            ]
         ]
     },
     {
@@ -756,19 +783,20 @@
         "q": "services.postgresql",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.postgresql.enable",
         "relevant": [
-            "opt:services.postgresql.enable",
-            "opt:services.postgresql.package",
-            "opt:services.postgresql.dataDir",
-            "opt:services.postgresql.settings",
-            "opt:services.postgresql.ensureDatabases",
-            "opt:services.postgresql.ensureUsers",
-            "opt:services.postgresql.authentication",
-            "opt:services.postgresql.enableTCPIP",
-            "opt:services.postgresql.identMap",
-            "opt:services.postgresql.initialScript",
-            "opt:services.postgresql.extensions"
+            ["opt:services.postgresql.enable"],
+            [
+                "opt:services.postgresql.package",
+                "opt:services.postgresql.dataDir",
+                "opt:services.postgresql.settings",
+                "opt:services.postgresql.ensureDatabases",
+                "opt:services.postgresql.ensureUsers",
+                "opt:services.postgresql.authentication",
+                "opt:services.postgresql.enableTCPIP",
+                "opt:services.postgresql.identMap",
+                "opt:services.postgresql.initialScript",
+                "opt:services.postgresql.extensions"
+            ]
         ]
     },
     {
@@ -776,16 +804,17 @@
         "q": "services.grafana",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.grafana.enable",
         "relevant": [
-            "opt:services.grafana.enable",
-            "opt:services.grafana.settings",
-            "opt:services.grafana.settings.server.http_port",
-            "opt:services.grafana.settings.server.http_addr",
-            "opt:services.grafana.settings.server.domain",
-            "opt:services.grafana.provision.enable",
-            "opt:services.grafana.declarativePlugins",
-            "opt:services.grafana.package"
+            ["opt:services.grafana.enable"],
+            [
+                "opt:services.grafana.settings",
+                "opt:services.grafana.settings.server.http_port",
+                "opt:services.grafana.settings.server.http_addr",
+                "opt:services.grafana.settings.server.domain",
+                "opt:services.grafana.provision.enable",
+                "opt:services.grafana.declarativePlugins",
+                "opt:services.grafana.package"
+            ]
         ]
     },
     {
@@ -793,17 +822,18 @@
         "q": "services.prometheus",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.prometheus.enable",
         "relevant": [
-            "opt:services.prometheus.enable",
-            "opt:services.prometheus.exporters",
-            "opt:services.prometheus.port",
-            "opt:services.prometheus.listenAddress",
-            "opt:services.prometheus.stateDir",
-            "opt:services.prometheus.scrapeConfigs",
-            "opt:services.prometheus.globalConfig",
-            "opt:services.prometheus.alertmanager.enable",
-            "opt:services.prometheus.exporters.node.enable"
+            ["opt:services.prometheus.enable"],
+            [
+                "opt:services.prometheus.exporters",
+                "opt:services.prometheus.port",
+                "opt:services.prometheus.listenAddress",
+                "opt:services.prometheus.stateDir",
+                "opt:services.prometheus.scrapeConfigs",
+                "opt:services.prometheus.globalConfig",
+                "opt:services.prometheus.alertmanager.enable",
+                "opt:services.prometheus.exporters.node.enable"
+            ]
         ]
     },
     {
@@ -811,20 +841,21 @@
         "q": "networking.firewall",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:networking.firewall.enable",
         "relevant": [
-            "opt:networking.firewall.enable",
-            "opt:networking.firewall.allowedTCPPorts",
-            "opt:networking.firewall.allowedUDPPorts",
-            "opt:networking.firewall.allowedTCPPortRanges",
-            "opt:networking.firewall.allowedUDPPortRanges",
-            "opt:networking.firewall.extraCommands",
-            "opt:networking.firewall.extraInputRules",
-            "opt:networking.firewall.checkReversePath",
-            "opt:networking.firewall.trustedInterfaces",
-            "opt:networking.firewall.allowPing",
-            "opt:networking.firewall.interfaces",
-            "opt:networking.firewall.logRefusedConnections"
+            ["opt:networking.firewall.enable"],
+            [
+                "opt:networking.firewall.allowedTCPPorts",
+                "opt:networking.firewall.allowedUDPPorts",
+                "opt:networking.firewall.allowedTCPPortRanges",
+                "opt:networking.firewall.allowedUDPPortRanges",
+                "opt:networking.firewall.extraCommands",
+                "opt:networking.firewall.extraInputRules",
+                "opt:networking.firewall.checkReversePath",
+                "opt:networking.firewall.trustedInterfaces",
+                "opt:networking.firewall.allowPing",
+                "opt:networking.firewall.interfaces",
+                "opt:networking.firewall.logRefusedConnections"
+            ]
         ]
     },
     {
@@ -832,14 +863,15 @@
         "q": "networking.wireguard",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:networking.wireguard.enable",
         "relevant": [
-            "opt:networking.wireguard.enable",
-            "opt:networking.wireguard.interfaces",
-            "opt:networking.wireguard.interfaces.<name>.privateKeyFile",
-            "opt:networking.wg-quick.interfaces",
-            "opt:networking.wg-quick.interfaces.<name>.address",
-            "opt:networking.firewall.checkReversePath"
+            ["opt:networking.wireguard.enable"],
+            [
+                "opt:networking.wireguard.interfaces",
+                "opt:networking.wireguard.interfaces.<name>.privateKeyFile",
+                "opt:networking.wg-quick.interfaces",
+                "opt:networking.wg-quick.interfaces.<name>.address",
+                "opt:networking.firewall.checkReversePath"
+            ]
         ]
     },
     {
@@ -847,14 +879,15 @@
         "q": "services.redis",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.redis.servers",
         "relevant": [
-            "opt:services.redis.servers",
-            "opt:services.redis.servers.<name>.enable",
-            "opt:services.redis.servers.<name>.port",
-            "opt:services.redis.servers.<name>.unixSocket",
-            "opt:services.redis.servers.<name>.user",
-            "opt:services.redis.package"
+            ["opt:services.redis.servers"],
+            [
+                "opt:services.redis.servers.<name>.enable",
+                "opt:services.redis.servers.<name>.port",
+                "opt:services.redis.servers.<name>.unixSocket",
+                "opt:services.redis.servers.<name>.user",
+                "opt:services.redis.package"
+            ]
         ]
     },
     {
@@ -862,17 +895,18 @@
         "q": "services.caddy",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.caddy.enable",
         "relevant": [
-            "opt:services.caddy.enable",
-            "opt:services.caddy.virtualHosts",
-            "opt:services.caddy.user",
-            "opt:services.caddy.group",
-            "opt:services.caddy.package",
-            "opt:services.caddy.email",
-            "opt:services.caddy.globalConfig",
-            "opt:services.caddy.configFile",
-            "opt:services.caddy.dataDir"
+            ["opt:services.caddy.enable"],
+            [
+                "opt:services.caddy.virtualHosts",
+                "opt:services.caddy.user",
+                "opt:services.caddy.group",
+                "opt:services.caddy.package",
+                "opt:services.caddy.email",
+                "opt:services.caddy.globalConfig",
+                "opt:services.caddy.configFile",
+                "opt:services.caddy.dataDir"
+            ]
         ]
     },
     {
@@ -880,17 +914,18 @@
         "q": "boot.loader.systemd-boot",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:boot.loader.systemd-boot.enable",
         "relevant": [
-            "opt:boot.loader.systemd-boot.enable",
-            "opt:boot.loader.systemd-boot.configurationLimit",
-            "opt:boot.loader.systemd-boot.consoleMode",
-            "opt:boot.loader.systemd-boot.editor",
-            "opt:boot.loader.systemd-boot.extraEntries",
-            "opt:boot.loader.systemd-boot.extraFiles",
-            "opt:boot.loader.systemd-boot.memtest86.enable",
-            "opt:boot.loader.systemd-boot.netbootxyz.enable",
-            "opt:boot.loader.efi.canTouchEfiVariables"
+            ["opt:boot.loader.systemd-boot.enable"],
+            [
+                "opt:boot.loader.systemd-boot.configurationLimit",
+                "opt:boot.loader.systemd-boot.consoleMode",
+                "opt:boot.loader.systemd-boot.editor",
+                "opt:boot.loader.systemd-boot.extraEntries",
+                "opt:boot.loader.systemd-boot.extraFiles",
+                "opt:boot.loader.systemd-boot.memtest86.enable",
+                "opt:boot.loader.systemd-boot.netbootxyz.enable",
+                "opt:boot.loader.efi.canTouchEfiVariables"
+            ]
         ]
     },
     {
@@ -898,12 +933,13 @@
         "q": "programs.hyprland",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:programs.hyprland.enable",
         "relevant": [
-            "opt:programs.hyprland.enable",
-            "opt:programs.hyprland.xwayland.enable",
-            "opt:programs.hyprland.package",
-            "opt:programs.hyprland.withUWSM"
+            ["opt:programs.hyprland.enable"],
+            [
+                "opt:programs.hyprland.xwayland.enable",
+                "opt:programs.hyprland.package",
+                "opt:programs.hyprland.withUWSM"
+            ]
         ]
     },
     {
@@ -911,14 +947,15 @@
         "q": "services.jellyfin",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.jellyfin.enable",
         "relevant": [
-            "opt:services.jellyfin.enable",
-            "opt:services.jellyfin.openFirewall",
-            "opt:services.jellyfin.dataDir",
-            "opt:services.jellyfin.cacheDir",
-            "opt:services.jellyfin.user",
-            "opt:services.jellyfin.group"
+            ["opt:services.jellyfin.enable"],
+            [
+                "opt:services.jellyfin.openFirewall",
+                "opt:services.jellyfin.dataDir",
+                "opt:services.jellyfin.cacheDir",
+                "opt:services.jellyfin.user",
+                "opt:services.jellyfin.group"
+            ]
         ]
     },
     {
@@ -926,21 +963,22 @@
         "q": "services.syncthing",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.syncthing.enable",
         "relevant": [
-            "opt:services.syncthing.enable",
-            "opt:services.syncthing.settings",
-            "opt:services.syncthing.dataDir",
-            "opt:services.syncthing.configDir",
-            "opt:services.syncthing.user",
-            "opt:services.syncthing.group",
-            "opt:services.syncthing.guiAddress",
-            "opt:services.syncthing.openDefaultPorts",
-            "opt:services.syncthing.key",
-            "opt:services.syncthing.cert",
-            "opt:services.syncthing.extraFlags",
-            "opt:services.syncthing.settings.folders",
-            "opt:services.syncthing.settings.devices"
+            ["opt:services.syncthing.enable"],
+            [
+                "opt:services.syncthing.settings",
+                "opt:services.syncthing.dataDir",
+                "opt:services.syncthing.configDir",
+                "opt:services.syncthing.user",
+                "opt:services.syncthing.group",
+                "opt:services.syncthing.guiAddress",
+                "opt:services.syncthing.openDefaultPorts",
+                "opt:services.syncthing.key",
+                "opt:services.syncthing.cert",
+                "opt:services.syncthing.extraFlags",
+                "opt:services.syncthing.settings.folders",
+                "opt:services.syncthing.settings.devices"
+            ]
         ]
     },
     {
@@ -948,13 +986,14 @@
         "q": "hardware.bluetooth",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:hardware.bluetooth.enable",
         "relevant": [
-            "opt:hardware.bluetooth.enable",
-            "opt:hardware.bluetooth.powerOnBoot",
-            "opt:hardware.bluetooth.settings",
-            "opt:hardware.bluetooth.package",
-            "opt:services.blueman.enable"
+            ["opt:hardware.bluetooth.enable"],
+            [
+                "opt:hardware.bluetooth.powerOnBoot",
+                "opt:hardware.bluetooth.settings",
+                "opt:hardware.bluetooth.package",
+                "opt:services.blueman.enable"
+            ]
         ]
     },
     {
@@ -962,13 +1001,14 @@
         "q": "services.samba",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.samba.enable",
         "relevant": [
-            "opt:services.samba.enable",
-            "opt:services.samba.settings",
-            "opt:services.samba.openFirewall",
-            "opt:services.samba.package",
-            "opt:services.samba.usershares.enable"
+            ["opt:services.samba.enable"],
+            [
+                "opt:services.samba.settings",
+                "opt:services.samba.openFirewall",
+                "opt:services.samba.package",
+                "opt:services.samba.usershares.enable"
+            ]
         ]
     },
     {
@@ -976,15 +1016,16 @@
         "q": "services.tailscale",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.tailscale.enable",
         "relevant": [
-            "opt:services.tailscale.enable",
-            "opt:services.tailscale.port",
-            "opt:services.tailscale.useRoutingFeatures",
-            "opt:services.tailscale.authKeyFile",
-            "opt:services.tailscale.permitCertUid",
-            "opt:services.tailscale.interfaceName",
-            "opt:services.tailscale.package"
+            ["opt:services.tailscale.enable"],
+            [
+                "opt:services.tailscale.port",
+                "opt:services.tailscale.useRoutingFeatures",
+                "opt:services.tailscale.authKeyFile",
+                "opt:services.tailscale.permitCertUid",
+                "opt:services.tailscale.interfaceName",
+                "opt:services.tailscale.package"
+            ]
         ]
     },
     {
@@ -992,62 +1033,64 @@
         "q": "services.restic",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.restic.backups",
         "relevant": [
-            "opt:services.restic.backups",
-            "opt:services.restic.backups.<name>.paths",
-            "opt:services.restic.backups.<name>.repository",
-            "opt:services.restic.backups.<name>.passwordFile",
-            "opt:services.restic.backups.<name>.initialize",
-            "opt:services.restic.backups.<name>.pruneOpts",
-            "opt:services.restic.backups.<name>.timerConfig",
-            "opt:services.restic.backups.<name>.user",
-            "opt:services.restic.backups.<name>.environmentFile"
+            ["opt:services.restic.backups"],
+            [
+                "opt:services.restic.backups.<name>.paths",
+                "opt:services.restic.backups.<name>.repository",
+                "opt:services.restic.backups.<name>.passwordFile",
+                "opt:services.restic.backups.<name>.initialize",
+                "opt:services.restic.backups.<name>.pruneOpts",
+                "opt:services.restic.backups.<name>.timerConfig",
+                "opt:services.restic.backups.<name>.user",
+                "opt:services.restic.backups.<name>.environmentFile"
+            ]
         ]
     },
     {
         "id": "g094",
         "q": "services.openssh.ports",
         "category": "dotted",
-        "relevant": ["opt:services.openssh.ports"]
+        "relevant": [["opt:services.openssh.ports"]]
     },
     {
         "id": "g095",
         "q": "services.nginx.enable",
         "category": "dotted",
-        "relevant": ["opt:services.nginx.enable"]
+        "relevant": [["opt:services.nginx.enable"]]
     },
     {
         "id": "g096",
         "q": "virtualisation.docker.enable",
         "category": "dotted",
-        "relevant": ["opt:virtualisation.docker.enable"]
+        "relevant": [["opt:virtualisation.docker.enable"]]
     },
     {
         "id": "g097",
         "q": "services.grafana.settings",
         "category": "dotted",
-        "relevant": ["opt:services.grafana.settings"]
+        "relevant": [["opt:services.grafana.settings"]]
     },
     {
         "id": "g098",
         "q": "services.postgresql.dataDir",
         "category": "dotted",
-        "relevant": ["opt:services.postgresql.dataDir"]
+        "relevant": [["opt:services.postgresql.dataDir"]]
     },
     {
         "id": "g099",
         "q": "services.mysql",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.mysql.enable",
         "relevant": [
-            "opt:services.mysql.enable",
-            "opt:services.mysql.package",
-            "opt:services.mysql.settings",
-            "opt:services.mysql.dataDir",
-            "opt:services.mysql.ensureDatabases",
-            "opt:services.mysql.ensureUsers"
+            ["opt:services.mysql.enable"],
+            [
+                "opt:services.mysql.package",
+                "opt:services.mysql.settings",
+                "opt:services.mysql.dataDir",
+                "opt:services.mysql.ensureDatabases",
+                "opt:services.mysql.ensureUsers"
+            ]
         ]
     },
     {
@@ -1055,14 +1098,15 @@
         "q": "services.fail2ban",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.fail2ban.enable",
         "relevant": [
-            "opt:services.fail2ban.enable",
-            "opt:services.fail2ban.jails",
-            "opt:services.fail2ban.maxretry",
-            "opt:services.fail2ban.ignoreIP",
-            "opt:services.fail2ban.bantime",
-            "opt:services.fail2ban.package"
+            ["opt:services.fail2ban.enable"],
+            [
+                "opt:services.fail2ban.jails",
+                "opt:services.fail2ban.maxretry",
+                "opt:services.fail2ban.ignoreIP",
+                "opt:services.fail2ban.bantime",
+                "opt:services.fail2ban.package"
+            ]
         ]
     },
     {
@@ -1070,14 +1114,15 @@
         "q": "services.xserver",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:services.xserver.enable",
         "relevant": [
-            "opt:services.xserver.enable",
-            "opt:services.xserver.videoDrivers",
-            "opt:services.xserver.xkb.layout",
-            "opt:services.xserver.xkb.options",
-            "opt:services.xserver.dpi",
-            "opt:services.displayManager.defaultSession"
+            ["opt:services.xserver.enable"],
+            [
+                "opt:services.xserver.videoDrivers",
+                "opt:services.xserver.xkb.layout",
+                "opt:services.xserver.xkb.options",
+                "opt:services.xserver.dpi",
+                "opt:services.displayManager.defaultSession"
+            ]
         ]
     },
     {
@@ -1085,11 +1130,12 @@
         "q": "hardware.graphics",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:hardware.graphics.enable",
         "relevant": [
-            "opt:hardware.graphics.enable",
-            "opt:hardware.graphics.enable32Bit",
-            "opt:hardware.graphics.extraPackages"
+            ["opt:hardware.graphics.enable"],
+            [
+                "opt:hardware.graphics.enable32Bit",
+                "opt:hardware.graphics.extraPackages"
+            ]
         ]
     },
     {
@@ -1097,157 +1143,162 @@
         "q": "boot.initrd",
         "category": "dotted",
         "exhaustive": true,
-        "best": "opt:boot.initrd.enable",
         "relevant": [
-            "opt:boot.initrd.enable",
-            "opt:boot.initrd.kernelModules",
-            "opt:boot.initrd.availableKernelModules",
-            "opt:boot.initrd.luks.devices",
-            "opt:boot.initrd.systemd.enable"
+            ["opt:boot.initrd.enable"],
+            [
+                "opt:boot.initrd.kernelModules",
+                "opt:boot.initrd.availableKernelModules",
+                "opt:boot.initrd.luks.devices",
+                "opt:boot.initrd.systemd.enable"
+            ]
         ]
     },
     {
         "id": "g101",
         "q": "docker container",
         "category": "multiterm",
-        "relevant": ["opt:virtualisation.docker.enable"]
+        "relevant": [["opt:virtualisation.docker.enable"]]
     },
     {
         "id": "g102",
         "q": "ssh daemon",
         "category": "multiterm",
-        "relevant": ["opt:services.openssh.enable"]
+        "relevant": [["opt:services.openssh.enable"]]
     },
     {
         "id": "g103",
         "q": "home assistant",
         "category": "multiterm",
-        "relevant": ["opt:services.home-assistant.enable"]
+        "relevant": [["opt:services.home-assistant.enable"]]
     },
     {
         "id": "g104",
         "q": "matrix synapse",
         "category": "multiterm",
-        "relevant": ["opt:services.matrix-synapse.enable"]
+        "relevant": [["opt:services.matrix-synapse.enable"]]
     },
     {
         "id": "g106",
         "q": "vault warden",
         "category": "multiterm",
-        "relevant": ["opt:services.vaultwarden.enable"]
+        "relevant": [["opt:services.vaultwarden.enable"]]
     },
     {
         "id": "g107",
         "q": "next cloud",
         "category": "multiterm",
-        "relevant": ["opt:services.nextcloud.enable"]
+        "relevant": [["opt:services.nextcloud.enable"]]
     },
     {
         "id": "g109",
         "q": "network manager",
         "category": "multiterm",
-        "relevant": ["opt:networking.networkmanager.enable"]
+        "relevant": [["opt:networking.networkmanager.enable"]]
     },
     {
         "id": "g110",
         "q": "virtual hosts",
         "category": "multiterm",
-        "relevant": ["opt:services.nginx.virtualHosts"]
+        "relevant": [["opt:services.nginx.virtualHosts"]]
     },
     {
         "id": "g111",
         "q": "allowed tcp ports",
         "category": "multiterm",
-        "relevant": ["opt:networking.firewall.allowedTCPPorts"]
+        "relevant": [["opt:networking.firewall.allowedTCPPorts"]]
     },
     {
         "id": "g112",
         "q": "allowed udp ports",
         "category": "multiterm",
-        "relevant": ["opt:networking.firewall.allowedUDPPorts"]
+        "relevant": [["opt:networking.firewall.allowedUDPPorts"]]
     },
     {
         "id": "g113",
         "q": "enable on boot",
         "category": "multiterm",
-        "relevant": ["opt:virtualisation.docker.enableOnBoot"]
+        "relevant": [["opt:virtualisation.docker.enableOnBoot"]]
     },
     {
         "id": "g114",
         "q": "allow ping",
         "category": "multiterm",
-        "relevant": ["opt:networking.firewall.allowPing"]
+        "relevant": [["opt:networking.firewall.allowPing"]]
     },
     {
         "id": "g115",
         "q": "host keys",
         "category": "multiterm",
-        "relevant": ["opt:services.openssh.hostKeys"]
+        "relevant": [["opt:services.openssh.hostKeys"]]
     },
     {
         "id": "g116",
         "q": "listen addresses",
         "category": "multiterm",
-        "relevant": ["opt:services.openssh.listenAddresses"]
+        "relevant": [["opt:services.openssh.listenAddresses"]]
     },
     {
         "id": "g117",
         "q": "enable nvidia",
         "category": "multiterm",
-        "relevant": ["opt:virtualisation.docker.enableNvidia"]
+        "relevant": [["opt:virtualisation.docker.enableNvidia"]]
     },
     {
         "id": "g118",
         "q": "object storage",
         "category": "multiterm",
-        "relevant": ["opt:services.minio.enable"]
+        "relevant": [["opt:services.minio.enable"]]
     },
     {
         "id": "g119",
         "q": "secret management",
         "category": "multiterm",
-        "relevant": ["opt:services.vault.enable"]
+        "relevant": [["opt:services.vault.enable"]]
     },
     {
         "id": "g120",
         "q": "network firewall",
         "category": "multiterm",
-        "relevant": ["opt:networking.firewall.enable"]
+        "relevant": [["opt:networking.firewall.enable"]]
     },
     {
         "id": "g121",
         "q": "wireguard vpn",
         "category": "multiterm",
-        "relevant": ["opt:networking.wireguard.enable"]
+        "relevant": [["opt:networking.wireguard.enable"]]
     },
     {
         "id": "g122",
         "q": "container runtime",
         "category": "multiterm",
         "relevant": [
-            "opt:virtualisation.docker.enable",
-            "opt:virtualisation.podman.enable"
+            [
+                "opt:virtualisation.docker.enable",
+                "opt:virtualisation.podman.enable"
+            ]
         ]
     },
     {
         "id": "g123",
         "q": "mesh vpn",
         "category": "multiterm",
-        "relevant": ["opt:services.tailscale.enable"]
+        "relevant": [["opt:services.tailscale.enable"]]
     },
     {
         "id": "g124",
         "q": "password manager",
         "category": "multiterm",
-        "relevant": ["opt:services.vaultwarden.enable"]
+        "relevant": [["opt:services.vaultwarden.enable"]]
     },
     {
         "id": "g125",
         "q": "boot loader",
         "category": "multiterm",
         "relevant": [
-            "opt:boot.loader.systemd-boot.enable",
-            "opt:boot.loader.grub.enable"
+            [
+                "opt:boot.loader.systemd-boot.enable",
+                "opt:boot.loader.grub.enable"
+            ]
         ]
     },
     {
@@ -1255,16 +1306,17 @@
         "q": "nginx config",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.nginx.config",
         "relevant": [
-            "opt:services.nginx.config",
-            "opt:services.nginx.httpConfig",
-            "opt:services.nginx.appendHttpConfig",
-            "opt:services.nginx.commonHttpConfig",
-            "opt:services.nginx.appendConfig",
-            "opt:services.nginx.prependConfig",
-            "opt:services.nginx.streamConfig",
-            "opt:services.nginx.eventsConfig"
+            ["opt:services.nginx.config"],
+            [
+                "opt:services.nginx.httpConfig",
+                "opt:services.nginx.appendHttpConfig",
+                "opt:services.nginx.commonHttpConfig",
+                "opt:services.nginx.appendConfig",
+                "opt:services.nginx.prependConfig",
+                "opt:services.nginx.streamConfig",
+                "opt:services.nginx.eventsConfig"
+            ]
         ]
     },
     {
@@ -1272,14 +1324,15 @@
         "q": "nginx virtual hosts",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.nginx.virtualHosts",
         "relevant": [
-            "opt:services.nginx.virtualHosts",
-            "opt:services.nginx.virtualHosts.<name>.locations.<name>.proxyPass",
-            "opt:services.nginx.virtualHosts.<name>.forceSSL",
-            "opt:services.nginx.virtualHosts.<name>.enableACME",
-            "opt:services.nginx.virtualHosts.<name>.root",
-            "opt:services.nginx.virtualHosts.<name>.extraConfig"
+            ["opt:services.nginx.virtualHosts"],
+            [
+                "opt:services.nginx.virtualHosts.<name>.locations.<name>.proxyPass",
+                "opt:services.nginx.virtualHosts.<name>.forceSSL",
+                "opt:services.nginx.virtualHosts.<name>.enableACME",
+                "opt:services.nginx.virtualHosts.<name>.root",
+                "opt:services.nginx.virtualHosts.<name>.extraConfig"
+            ]
         ]
     },
     {
@@ -1288,13 +1341,15 @@
         "category": "scoped",
         "exhaustive": true,
         "relevant": [
-            "opt:services.nginx.appendHttpConfig",
-            "opt:services.nginx.commonHttpConfig",
-            "opt:services.nginx.appendConfig",
-            "opt:services.nginx.prependConfig",
-            "opt:services.nginx.httpConfig",
-            "opt:services.nginx.config",
-            "opt:services.nginx.virtualHosts.<name>.extraConfig"
+            [
+                "opt:services.nginx.appendHttpConfig",
+                "opt:services.nginx.commonHttpConfig",
+                "opt:services.nginx.appendConfig",
+                "opt:services.nginx.prependConfig",
+                "opt:services.nginx.httpConfig",
+                "opt:services.nginx.config",
+                "opt:services.nginx.virtualHosts.<name>.extraConfig"
+            ]
         ]
     },
     {
@@ -1302,8 +1357,7 @@
         "q": "nginx user",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.nginx.user",
-        "relevant": ["opt:services.nginx.user", "opt:services.nginx.group"]
+        "relevant": [["opt:services.nginx.user"], ["opt:services.nginx.group"]]
     },
     {
         "id": "g173",
@@ -1311,11 +1365,13 @@
         "category": "scoped",
         "exhaustive": true,
         "relevant": [
-            "opt:services.nginx.recommendedProxySettings",
-            "opt:services.nginx.recommendedTlsSettings",
-            "opt:services.nginx.virtualHosts",
-            "opt:services.nginx.virtualHosts.<name>.locations.<name>.proxyPass",
-            "opt:services.nginx.proxyTimeout"
+            [
+                "opt:services.nginx.recommendedProxySettings",
+                "opt:services.nginx.recommendedTlsSettings",
+                "opt:services.nginx.virtualHosts",
+                "opt:services.nginx.virtualHosts.<name>.locations.<name>.proxyPass",
+                "opt:services.nginx.proxyTimeout"
+            ]
         ]
     },
     {
@@ -1323,10 +1379,9 @@
         "q": "openssh port",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.openssh.ports",
         "relevant": [
-            "opt:services.openssh.ports",
-            "opt:services.openssh.openFirewall"
+            ["opt:services.openssh.ports"],
+            ["opt:services.openssh.openFirewall"]
         ]
     },
     {
@@ -1334,12 +1389,13 @@
         "q": "openssh settings",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.openssh.settings",
         "relevant": [
-            "opt:services.openssh.settings",
-            "opt:services.openssh.settings.PasswordAuthentication",
-            "opt:services.openssh.settings.PermitRootLogin",
-            "opt:services.openssh.settings.Ciphers"
+            ["opt:services.openssh.settings"],
+            [
+                "opt:services.openssh.settings.PasswordAuthentication",
+                "opt:services.openssh.settings.PermitRootLogin",
+                "opt:services.openssh.settings.Ciphers"
+            ]
         ]
     },
     {
@@ -1347,7 +1403,7 @@
         "q": "openssh extra config",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.openssh.extraConfig"]
+        "relevant": [["opt:services.openssh.extraConfig"]]
     },
     {
         "id": "g177",
@@ -1355,9 +1411,11 @@
         "category": "scoped",
         "exhaustive": true,
         "relevant": [
-            "opt:services.openssh.authorizedKeysFiles",
-            "opt:services.openssh.authorizedKeysCommand",
-            "opt:users.users.<name>.openssh.authorizedKeys.keys"
+            [
+                "opt:services.openssh.authorizedKeysFiles",
+                "opt:services.openssh.authorizedKeysCommand",
+                "opt:users.users.<name>.openssh.authorizedKeys.keys"
+            ]
         ]
     },
     {
@@ -1365,25 +1423,26 @@
         "q": "postgresql package",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.postgresql.package"]
+        "relevant": [["opt:services.postgresql.package"]]
     },
     {
         "id": "g179",
         "q": "postgresql data dir",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.postgresql.dataDir"]
+        "relevant": [["opt:services.postgresql.dataDir"]]
     },
     {
         "id": "g180",
         "q": "postgresql authentication",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.postgresql.authentication",
         "relevant": [
-            "opt:services.postgresql.authentication",
-            "opt:services.postgresql.identMap",
-            "opt:services.postgresql.enableTCPIP"
+            ["opt:services.postgresql.authentication"],
+            [
+                "opt:services.postgresql.identMap",
+                "opt:services.postgresql.enableTCPIP"
+            ]
         ]
     },
     {
@@ -1391,10 +1450,9 @@
         "q": "postgresql ensure databases",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.postgresql.ensureDatabases",
         "relevant": [
-            "opt:services.postgresql.ensureDatabases",
-            "opt:services.postgresql.ensureUsers"
+            ["opt:services.postgresql.ensureDatabases"],
+            ["opt:services.postgresql.ensureUsers"]
         ]
     },
     {
@@ -1402,28 +1460,28 @@
         "q": "postgres settings",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.postgresql.settings"]
+        "relevant": [["opt:services.postgresql.settings"]]
     },
     {
         "id": "g183",
         "q": "git config",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:programs.git.config",
-        "relevant": ["opt:programs.git.config", "opt:programs.git.settings"]
+        "relevant": [["opt:programs.git.config"], ["opt:programs.git.settings"]]
     },
     {
         "id": "g184",
         "q": "docker rootless",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:virtualisation.docker.rootless.enable",
         "relevant": [
-            "opt:virtualisation.docker.rootless.enable",
-            "opt:virtualisation.docker.rootless.setSocketVariable",
-            "opt:virtualisation.docker.rootless.daemon.settings",
-            "opt:virtualisation.docker.rootless.package",
-            "opt:virtualisation.docker.rootless.extraPackages"
+            ["opt:virtualisation.docker.rootless.enable"],
+            [
+                "opt:virtualisation.docker.rootless.setSocketVariable",
+                "opt:virtualisation.docker.rootless.daemon.settings",
+                "opt:virtualisation.docker.rootless.package",
+                "opt:virtualisation.docker.rootless.extraPackages"
+            ]
         ]
     },
     {
@@ -1431,24 +1489,23 @@
         "q": "docker storage driver",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:virtualisation.docker.storageDriver"]
+        "relevant": [["opt:virtualisation.docker.storageDriver"]]
     },
     {
         "id": "g186",
         "q": "docker enable on boot",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:virtualisation.docker.enableOnBoot"]
+        "relevant": [["opt:virtualisation.docker.enableOnBoot"]]
     },
     {
         "id": "g187",
         "q": "firewall allowed tcp ports",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:networking.firewall.allowedTCPPorts",
         "relevant": [
-            "opt:networking.firewall.allowedTCPPorts",
-            "opt:networking.firewall.allowedTCPPortRanges"
+            ["opt:networking.firewall.allowedTCPPorts"],
+            ["opt:networking.firewall.allowedTCPPortRanges"]
         ]
     },
     {
@@ -1456,38 +1513,39 @@
         "q": "bluetooth power on boot",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:hardware.bluetooth.powerOnBoot"]
+        "relevant": [["opt:hardware.bluetooth.powerOnBoot"]]
     },
     {
         "id": "g189",
         "q": "printing drivers",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.printing.drivers"]
+        "relevant": [["opt:services.printing.drivers"]]
     },
     {
         "id": "g190",
         "q": "systemd-boot configuration limit",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:boot.loader.systemd-boot.configurationLimit"]
+        "relevant": [["opt:boot.loader.systemd-boot.configurationLimit"]]
     },
     {
         "id": "g191",
         "q": "restic backups",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.restic.backups",
         "relevant": [
-            "opt:services.restic.backups",
-            "opt:services.restic.backups.<name>.paths",
-            "opt:services.restic.backups.<name>.repository",
-            "opt:services.restic.backups.<name>.passwordFile",
-            "opt:services.restic.backups.<name>.initialize",
-            "opt:services.restic.backups.<name>.pruneOpts",
-            "opt:services.restic.backups.<name>.timerConfig",
-            "opt:services.restic.backups.<name>.user",
-            "opt:services.restic.backups.<name>.environmentFile"
+            ["opt:services.restic.backups"],
+            [
+                "opt:services.restic.backups.<name>.paths",
+                "opt:services.restic.backups.<name>.repository",
+                "opt:services.restic.backups.<name>.passwordFile",
+                "opt:services.restic.backups.<name>.initialize",
+                "opt:services.restic.backups.<name>.pruneOpts",
+                "opt:services.restic.backups.<name>.timerConfig",
+                "opt:services.restic.backups.<name>.user",
+                "opt:services.restic.backups.<name>.environmentFile"
+            ]
         ]
     },
     {
@@ -1495,10 +1553,9 @@
         "q": "prometheus exporters",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.prometheus.exporters",
         "relevant": [
-            "opt:services.prometheus.exporters",
-            "opt:services.prometheus.exporters.node.enable"
+            ["opt:services.prometheus.exporters"],
+            ["opt:services.prometheus.exporters.node.enable"]
         ]
     },
     {
@@ -1506,14 +1563,15 @@
         "q": "redis servers",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.redis.servers",
         "relevant": [
-            "opt:services.redis.servers",
-            "opt:services.redis.servers.<name>.enable",
-            "opt:services.redis.servers.<name>.port",
-            "opt:services.redis.servers.<name>.unixSocket",
-            "opt:services.redis.servers.<name>.user",
-            "opt:services.redis.package"
+            ["opt:services.redis.servers"],
+            [
+                "opt:services.redis.servers.<name>.enable",
+                "opt:services.redis.servers.<name>.port",
+                "opt:services.redis.servers.<name>.unixSocket",
+                "opt:services.redis.servers.<name>.user",
+                "opt:services.redis.package"
+            ]
         ]
     },
     {
@@ -1521,12 +1579,13 @@
         "q": "grafana settings",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.grafana.settings",
         "relevant": [
-            "opt:services.grafana.settings",
-            "opt:services.grafana.settings.server.http_port",
-            "opt:services.grafana.settings.server.http_addr",
-            "opt:services.grafana.settings.server.domain"
+            ["opt:services.grafana.settings"],
+            [
+                "opt:services.grafana.settings.server.http_port",
+                "opt:services.grafana.settings.server.http_addr",
+                "opt:services.grafana.settings.server.domain"
+            ]
         ]
     },
     {
@@ -1534,24 +1593,23 @@
         "q": "nextcloud hostname",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.nextcloud.hostName"]
+        "relevant": [["opt:services.nextcloud.hostName"]]
     },
     {
         "id": "g196",
         "q": "nextcloud max upload size",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.nextcloud.maxUploadSize"]
+        "relevant": [["opt:services.nextcloud.maxUploadSize"]]
     },
     {
         "id": "g197",
         "q": "syncthing data dir",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.syncthing.dataDir",
         "relevant": [
-            "opt:services.syncthing.dataDir",
-            "opt:services.syncthing.configDir"
+            ["opt:services.syncthing.dataDir"],
+            ["opt:services.syncthing.configDir"]
         ]
     },
     {
@@ -1559,52 +1617,51 @@
         "q": "tailscale routing features",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.tailscale.useRoutingFeatures"]
+        "relevant": [["opt:services.tailscale.useRoutingFeatures"]]
     },
     {
         "id": "g199",
         "q": "samba open firewall",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.samba.openFirewall"]
+        "relevant": [["opt:services.samba.openFirewall"]]
     },
     {
         "id": "g200",
         "q": "jellyfin open firewall",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.jellyfin.openFirewall"]
+        "relevant": [["opt:services.jellyfin.openFirewall"]]
     },
     {
         "id": "g201",
         "q": "home assistant extra components",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.home-assistant.extraComponents"]
+        "relevant": [["opt:services.home-assistant.extraComponents"]]
     },
     {
         "id": "g202",
         "q": "fail2ban jails",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.fail2ban.jails"]
+        "relevant": [["opt:services.fail2ban.jails"]]
     },
     {
         "id": "g203",
         "q": "mysql package",
         "category": "scoped",
         "exhaustive": true,
-        "relevant": ["opt:services.mysql.package"]
+        "relevant": [["opt:services.mysql.package"]]
     },
     {
         "id": "g204",
         "q": "nginx recommended proxy settings",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.nginx.recommendedProxySettings",
         "relevant": [
-            "opt:services.nginx.recommendedProxySettings",
-            "opt:services.nginx.recommendedTlsSettings"
+            ["opt:services.nginx.recommendedProxySettings"],
+            ["opt:services.nginx.recommendedTlsSettings"]
         ]
     },
     {
@@ -1612,26 +1669,27 @@
         "q": "transmission download dir",
         "category": "scoped",
         "exhaustive": true,
-        "best": "opt:services.transmission.settings.download-dir",
         "relevant": [
-            "opt:services.transmission.settings.download-dir",
-            "opt:services.transmission.home"
+            ["opt:services.transmission.settings.download-dir"],
+            ["opt:services.transmission.home"]
         ]
     },
     {
         "id": "g126",
         "q": "web server",
         "category": "intent",
-        "relevant": ["opt:services.nginx.enable", "opt:services.caddy.enable"]
+        "relevant": [["opt:services.nginx.enable", "opt:services.caddy.enable"]]
     },
     {
         "id": "g127",
         "q": "reverse proxy",
         "category": "intent",
         "relevant": [
-            "opt:services.nginx.enable",
-            "opt:services.caddy.enable",
-            "opt:services.traefik.enable"
+            [
+                "opt:services.nginx.enable",
+                "opt:services.caddy.enable",
+                "opt:services.traefik.enable"
+            ]
         ]
     },
     {
@@ -1639,95 +1697,91 @@
         "q": "virtual private network",
         "category": "intent",
         "relevant": [
-            "opt:networking.wireguard.enable",
-            "opt:services.tailscale.enable"
+            ["opt:networking.wireguard.enable", "opt:services.tailscale.enable"]
         ]
     },
     {
         "id": "g131",
         "q": "self hosted password manager",
         "category": "intent",
-        "relevant": ["opt:services.vaultwarden.enable"]
+        "relevant": [["opt:services.vaultwarden.enable"]]
     },
     {
         "id": "g132",
         "q": "media streaming server",
         "category": "intent",
-        "relevant": ["opt:services.jellyfin.enable"]
+        "relevant": [["opt:services.jellyfin.enable"]]
     },
     {
         "id": "g134",
         "q": "file synchronization",
         "category": "intent",
-        "relevant": ["opt:services.syncthing.enable"]
+        "relevant": [["opt:services.syncthing.enable"]]
     },
     {
         "id": "g135",
         "q": "relational database server",
         "category": "intent",
         "relevant": [
-            "opt:services.postgresql.enable",
-            "opt:services.mysql.enable"
+            ["opt:services.postgresql.enable", "opt:services.mysql.enable"]
         ]
     },
     {
         "id": "g136",
         "q": "in memory key value store",
         "category": "intent",
-        "relevant": ["opt:services.redis.servers"]
+        "relevant": [["opt:services.redis.servers"]]
     },
     {
         "id": "g137",
         "q": "secret storage",
         "category": "intent",
-        "relevant": ["opt:services.vault.enable"]
+        "relevant": [["opt:services.vault.enable"]]
     },
     {
         "id": "g138",
         "q": "s3 compatible object storage",
         "category": "intent",
-        "relevant": ["opt:services.minio.enable"]
+        "relevant": [["opt:services.minio.enable"]]
     },
     {
         "id": "g139",
         "q": "metrics monitoring stack",
         "category": "intent",
         "relevant": [
-            "opt:services.prometheus.enable",
-            "opt:services.grafana.enable"
+            ["opt:services.prometheus.enable", "opt:services.grafana.enable"]
         ]
     },
     {
         "id": "g140",
         "q": "document management",
         "category": "intent",
-        "relevant": ["opt:services.paperless.enable"]
+        "relevant": [["opt:services.paperless.enable"]]
     },
     {
         "id": "g141",
         "q": "printing support",
         "category": "intent",
-        "relevant": ["opt:services.printing.enable"]
+        "relevant": [["opt:services.printing.enable"]]
     },
     {
         "id": "g142",
         "q": "wireless bluetooth support",
         "category": "intent",
-        "relevant": ["opt:hardware.bluetooth.enable"]
+        "relevant": [["opt:hardware.bluetooth.enable"]]
     },
     {
         "id": "g143",
         "q": "caching dns resolver",
         "category": "intent",
         "relevant": [
-            "opt:services.unbound.enable",
-            "opt:services.dnsmasq.enable"
+            ["opt:services.unbound.enable", "opt:services.dnsmasq.enable"]
         ]
     },
     {
         "id": "g149",
         "q": "bittorrent client",
         "category": "intent",
-        "relevant": ["opt:services.transmission.enable"]
+        "relevant": [["opt:services.transmission.enable"]]
     }
 ]

--- a/frontend/benchmark/queries-options.json
+++ b/frontend/benchmark/queries-options.json
@@ -4,6 +4,7 @@
         "q": "nginx",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.nginx.enable",
         "relevant": [
             "opt:services.nginx.enable",
             "opt:services.nginx.virtualHosts",
@@ -24,6 +25,7 @@
         "q": "grafana",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.grafana.enable",
         "relevant": [
             "opt:services.grafana.enable",
             "opt:services.grafana.settings",
@@ -40,6 +42,7 @@
         "q": "prometheus",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.prometheus.enable",
         "relevant": [
             "opt:services.prometheus.enable",
             "opt:services.prometheus.exporters",
@@ -57,6 +60,7 @@
         "q": "postgresql",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.postgresql.enable",
         "relevant": [
             "opt:services.postgresql.enable",
             "opt:services.postgresql.package",
@@ -76,6 +80,7 @@
         "q": "openssh",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.openssh.enable",
         "relevant": [
             "opt:services.openssh.enable",
             "opt:services.openssh.settings",
@@ -96,6 +101,7 @@
         "q": "caddy",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.caddy.enable",
         "relevant": [
             "opt:services.caddy.enable",
             "opt:services.caddy.virtualHosts",
@@ -113,6 +119,7 @@
         "q": "gitea",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.gitea.enable",
         "relevant": [
             "opt:services.gitea.enable",
             "opt:services.gitea.settings",
@@ -125,6 +132,7 @@
         "q": "jellyfin",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.jellyfin.enable",
         "relevant": [
             "opt:services.jellyfin.enable",
             "opt:services.jellyfin.openFirewall",
@@ -139,6 +147,7 @@
         "q": "services.openssh.enable",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.openssh.enable",
         "relevant": ["opt:services.openssh.enable", "opt:services.sshd.enable"]
     },
     {
@@ -207,6 +216,7 @@
         "q": "docker",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:virtualisation.docker.enable",
         "relevant": [
             "opt:virtualisation.docker.enable",
             "opt:virtualisation.docker.rootless.enable",
@@ -226,6 +236,7 @@
         "q": "firewall",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:networking.firewall.enable",
         "relevant": [
             "opt:networking.firewall.enable",
             "opt:networking.firewall.allowedTCPPorts",
@@ -246,6 +257,7 @@
         "q": "printing",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.printing.enable",
         "relevant": [
             "opt:services.printing.enable",
             "opt:services.printing.drivers",
@@ -263,6 +275,7 @@
         "q": "bluetooth",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:hardware.bluetooth.enable",
         "relevant": [
             "opt:hardware.bluetooth.enable",
             "opt:hardware.bluetooth.powerOnBoot",
@@ -276,6 +289,7 @@
         "q": "systemd-boot",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:boot.loader.systemd-boot.enable",
         "relevant": [
             "opt:boot.loader.systemd-boot.enable",
             "opt:boot.loader.systemd-boot.configurationLimit",
@@ -293,6 +307,7 @@
         "q": "git",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:programs.git.enable",
         "relevant": [
             "opt:programs.git.enable",
             "opt:programs.git.config",
@@ -308,6 +323,7 @@
         "q": "redis",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.redis.servers",
         "relevant": [
             "opt:services.redis.servers",
             "opt:services.redis.servers.<name>.enable",
@@ -322,6 +338,7 @@
         "q": "restic",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.restic.backups",
         "relevant": [
             "opt:services.restic.backups",
             "opt:services.restic.backups.<name>.paths",
@@ -339,6 +356,7 @@
         "q": "syncthing",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.syncthing.enable",
         "relevant": [
             "opt:services.syncthing.enable",
             "opt:services.syncthing.settings",
@@ -360,6 +378,7 @@
         "q": "tailscale",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.tailscale.enable",
         "relevant": [
             "opt:services.tailscale.enable",
             "opt:services.tailscale.port",
@@ -375,6 +394,7 @@
         "q": "samba",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.samba.enable",
         "relevant": [
             "opt:services.samba.enable",
             "opt:services.samba.settings",
@@ -388,6 +408,7 @@
         "q": "nextcloud",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.nextcloud.enable",
         "relevant": [
             "opt:services.nextcloud.enable",
             "opt:services.nextcloud.hostName",
@@ -407,6 +428,7 @@
         "q": "mysql",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.mysql.enable",
         "relevant": [
             "opt:services.mysql.enable",
             "opt:services.mysql.package",
@@ -421,6 +443,7 @@
         "q": "xserver",
         "category": "exact",
         "exhaustive": true,
+        "best": "opt:services.xserver.enable",
         "relevant": [
             "opt:services.xserver.enable",
             "opt:services.xserver.videoDrivers",
@@ -671,6 +694,7 @@
         "q": "services.nginx",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.nginx.enable",
         "relevant": [
             "opt:services.nginx.enable",
             "opt:services.nginx.virtualHosts",
@@ -691,6 +715,7 @@
         "q": "virtualisation.docker",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:virtualisation.docker.enable",
         "relevant": [
             "opt:virtualisation.docker.enable",
             "opt:virtualisation.docker.rootless.enable",
@@ -710,6 +735,7 @@
         "q": "services.openssh",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.openssh.enable",
         "relevant": [
             "opt:services.openssh.enable",
             "opt:services.openssh.settings",
@@ -730,6 +756,7 @@
         "q": "services.postgresql",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.postgresql.enable",
         "relevant": [
             "opt:services.postgresql.enable",
             "opt:services.postgresql.package",
@@ -749,6 +776,7 @@
         "q": "services.grafana",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.grafana.enable",
         "relevant": [
             "opt:services.grafana.enable",
             "opt:services.grafana.settings",
@@ -765,6 +793,7 @@
         "q": "services.prometheus",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.prometheus.enable",
         "relevant": [
             "opt:services.prometheus.enable",
             "opt:services.prometheus.exporters",
@@ -782,6 +811,7 @@
         "q": "networking.firewall",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:networking.firewall.enable",
         "relevant": [
             "opt:networking.firewall.enable",
             "opt:networking.firewall.allowedTCPPorts",
@@ -802,6 +832,7 @@
         "q": "networking.wireguard",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:networking.wireguard.enable",
         "relevant": [
             "opt:networking.wireguard.enable",
             "opt:networking.wireguard.interfaces",
@@ -816,6 +847,7 @@
         "q": "services.redis",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.redis.servers",
         "relevant": [
             "opt:services.redis.servers",
             "opt:services.redis.servers.<name>.enable",
@@ -830,6 +862,7 @@
         "q": "services.caddy",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.caddy.enable",
         "relevant": [
             "opt:services.caddy.enable",
             "opt:services.caddy.virtualHosts",
@@ -847,6 +880,7 @@
         "q": "boot.loader.systemd-boot",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:boot.loader.systemd-boot.enable",
         "relevant": [
             "opt:boot.loader.systemd-boot.enable",
             "opt:boot.loader.systemd-boot.configurationLimit",
@@ -864,6 +898,7 @@
         "q": "programs.hyprland",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:programs.hyprland.enable",
         "relevant": [
             "opt:programs.hyprland.enable",
             "opt:programs.hyprland.xwayland.enable",
@@ -876,6 +911,7 @@
         "q": "services.jellyfin",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.jellyfin.enable",
         "relevant": [
             "opt:services.jellyfin.enable",
             "opt:services.jellyfin.openFirewall",
@@ -890,6 +926,7 @@
         "q": "services.syncthing",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.syncthing.enable",
         "relevant": [
             "opt:services.syncthing.enable",
             "opt:services.syncthing.settings",
@@ -911,6 +948,7 @@
         "q": "hardware.bluetooth",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:hardware.bluetooth.enable",
         "relevant": [
             "opt:hardware.bluetooth.enable",
             "opt:hardware.bluetooth.powerOnBoot",
@@ -924,6 +962,7 @@
         "q": "services.samba",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.samba.enable",
         "relevant": [
             "opt:services.samba.enable",
             "opt:services.samba.settings",
@@ -937,6 +976,7 @@
         "q": "services.tailscale",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.tailscale.enable",
         "relevant": [
             "opt:services.tailscale.enable",
             "opt:services.tailscale.port",
@@ -952,6 +992,7 @@
         "q": "services.restic",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.restic.backups",
         "relevant": [
             "opt:services.restic.backups",
             "opt:services.restic.backups.<name>.paths",
@@ -999,6 +1040,7 @@
         "q": "services.mysql",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.mysql.enable",
         "relevant": [
             "opt:services.mysql.enable",
             "opt:services.mysql.package",
@@ -1013,6 +1055,7 @@
         "q": "services.fail2ban",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.fail2ban.enable",
         "relevant": [
             "opt:services.fail2ban.enable",
             "opt:services.fail2ban.jails",
@@ -1027,6 +1070,7 @@
         "q": "services.xserver",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:services.xserver.enable",
         "relevant": [
             "opt:services.xserver.enable",
             "opt:services.xserver.videoDrivers",
@@ -1041,6 +1085,7 @@
         "q": "hardware.graphics",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:hardware.graphics.enable",
         "relevant": [
             "opt:hardware.graphics.enable",
             "opt:hardware.graphics.enable32Bit",
@@ -1052,6 +1097,7 @@
         "q": "boot.initrd",
         "category": "dotted",
         "exhaustive": true,
+        "best": "opt:boot.initrd.enable",
         "relevant": [
             "opt:boot.initrd.enable",
             "opt:boot.initrd.kernelModules",
@@ -1209,6 +1255,7 @@
         "q": "nginx config",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.nginx.config",
         "relevant": [
             "opt:services.nginx.config",
             "opt:services.nginx.httpConfig",
@@ -1225,6 +1272,7 @@
         "q": "nginx virtual hosts",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.nginx.virtualHosts",
         "relevant": [
             "opt:services.nginx.virtualHosts",
             "opt:services.nginx.virtualHosts.<name>.locations.<name>.proxyPass",
@@ -1254,6 +1302,7 @@
         "q": "nginx user",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.nginx.user",
         "relevant": ["opt:services.nginx.user", "opt:services.nginx.group"]
     },
     {
@@ -1274,6 +1323,7 @@
         "q": "openssh port",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.openssh.ports",
         "relevant": [
             "opt:services.openssh.ports",
             "opt:services.openssh.openFirewall"
@@ -1284,6 +1334,7 @@
         "q": "openssh settings",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.openssh.settings",
         "relevant": [
             "opt:services.openssh.settings",
             "opt:services.openssh.settings.PasswordAuthentication",
@@ -1328,6 +1379,7 @@
         "q": "postgresql authentication",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.postgresql.authentication",
         "relevant": [
             "opt:services.postgresql.authentication",
             "opt:services.postgresql.identMap",
@@ -1339,6 +1391,7 @@
         "q": "postgresql ensure databases",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.postgresql.ensureDatabases",
         "relevant": [
             "opt:services.postgresql.ensureDatabases",
             "opt:services.postgresql.ensureUsers"
@@ -1356,6 +1409,7 @@
         "q": "git config",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:programs.git.config",
         "relevant": ["opt:programs.git.config", "opt:programs.git.settings"]
     },
     {
@@ -1363,6 +1417,7 @@
         "q": "docker rootless",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:virtualisation.docker.rootless.enable",
         "relevant": [
             "opt:virtualisation.docker.rootless.enable",
             "opt:virtualisation.docker.rootless.setSocketVariable",
@@ -1390,6 +1445,7 @@
         "q": "firewall allowed tcp ports",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:networking.firewall.allowedTCPPorts",
         "relevant": [
             "opt:networking.firewall.allowedTCPPorts",
             "opt:networking.firewall.allowedTCPPortRanges"
@@ -1421,6 +1477,7 @@
         "q": "restic backups",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.restic.backups",
         "relevant": [
             "opt:services.restic.backups",
             "opt:services.restic.backups.<name>.paths",
@@ -1438,6 +1495,7 @@
         "q": "prometheus exporters",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.prometheus.exporters",
         "relevant": [
             "opt:services.prometheus.exporters",
             "opt:services.prometheus.exporters.node.enable"
@@ -1448,6 +1506,7 @@
         "q": "redis servers",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.redis.servers",
         "relevant": [
             "opt:services.redis.servers",
             "opt:services.redis.servers.<name>.enable",
@@ -1462,6 +1521,7 @@
         "q": "grafana settings",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.grafana.settings",
         "relevant": [
             "opt:services.grafana.settings",
             "opt:services.grafana.settings.server.http_port",
@@ -1488,6 +1548,7 @@
         "q": "syncthing data dir",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.syncthing.dataDir",
         "relevant": [
             "opt:services.syncthing.dataDir",
             "opt:services.syncthing.configDir"
@@ -1540,6 +1601,7 @@
         "q": "nginx recommended proxy settings",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.nginx.recommendedProxySettings",
         "relevant": [
             "opt:services.nginx.recommendedProxySettings",
             "opt:services.nginx.recommendedTlsSettings"
@@ -1550,6 +1612,7 @@
         "q": "transmission download dir",
         "category": "scoped",
         "exhaustive": true,
+        "best": "opt:services.transmission.settings.download-dir",
         "relevant": [
             "opt:services.transmission.settings.download-dir",
             "opt:services.transmission.home"

--- a/frontend/benchmark/queries-packages.json
+++ b/frontend/benchmark/queries-packages.json
@@ -3,190 +3,188 @@
         "id": "g001",
         "q": "ripgrep",
         "category": "exact",
-        "relevant": ["pkg:ripgrep"]
+        "relevant": [["pkg:ripgrep"]]
     },
     {
         "id": "g002",
         "q": "htop",
         "category": "exact",
         "exhaustive": true,
-        "best": "pkg:htop",
-        "relevant": ["pkg:htop", "pkg:htop-vim"]
+        "relevant": [["pkg:htop"], ["pkg:htop-vim"]]
     },
     {
         "id": "g003",
         "q": "jq",
         "category": "exact",
-        "relevant": ["pkg:jq"]
+        "relevant": [["pkg:jq"]]
     },
     {
         "id": "g004",
         "q": "tmux",
         "category": "exact",
-        "relevant": ["pkg:tmux"]
+        "relevant": [["pkg:tmux"]]
     },
     {
         "id": "g005",
         "q": "neovim",
         "category": "exact",
-        "relevant": ["pkg:neovim"]
+        "relevant": [["pkg:neovim"]]
     },
     {
         "id": "g006",
         "q": "fzf",
         "category": "exact",
-        "relevant": ["pkg:fzf"]
+        "relevant": [["pkg:fzf"]]
     },
     {
         "id": "g007",
         "q": "bat",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["pkg:bat"]
+        "relevant": [["pkg:bat"]]
     },
     {
         "id": "g008",
         "q": "nginx",
         "category": "exact",
-        "best": "pkg:nginx",
-        "relevant": ["pkg:nginx", "pkg:nginxMainline", "pkg:nginxStable"]
+        "relevant": [["pkg:nginx"], ["pkg:nginxMainline", "pkg:nginxStable"]]
     },
     {
         "id": "g009",
         "q": "grafana",
         "category": "exact",
-        "relevant": ["pkg:grafana"]
+        "relevant": [["pkg:grafana"]]
     },
     {
         "id": "g010",
         "q": "prometheus",
         "category": "exact",
-        "relevant": ["pkg:prometheus"]
+        "relevant": [["pkg:prometheus"]]
     },
     {
         "id": "g011",
         "q": "postgresql",
         "category": "exact",
         "exhaustive": true,
-        "best": "pkg:postgresql",
         "relevant": [
-            "pkg:postgresql",
-            "pkg:postgresql_14",
-            "pkg:postgresql_15",
-            "pkg:postgresql_16",
-            "pkg:postgresql_17",
-            "pkg:postgresql_18",
-            "pkg:postgresql_19",
-            "pkg:postgresql_jit",
-            "pkg:postgresql_14_jit",
-            "pkg:postgresql_15_jit",
-            "pkg:postgresql_16_jit",
-            "pkg:postgresql_17_jit",
-            "pkg:postgresql_18_jit",
-            "pkg:postgresql_19_jit"
+            ["pkg:postgresql"],
+            [
+                "pkg:postgresql_14",
+                "pkg:postgresql_15",
+                "pkg:postgresql_16",
+                "pkg:postgresql_17",
+                "pkg:postgresql_18",
+                "pkg:postgresql_19",
+                "pkg:postgresql_jit",
+                "pkg:postgresql_14_jit",
+                "pkg:postgresql_15_jit",
+                "pkg:postgresql_16_jit",
+                "pkg:postgresql_17_jit",
+                "pkg:postgresql_18_jit",
+                "pkg:postgresql_19_jit"
+            ]
         ]
     },
     {
         "id": "g012",
         "q": "openssh",
         "category": "exact",
-        "relevant": ["pkg:openssh"]
+        "relevant": [["pkg:openssh"]]
     },
     {
         "id": "g013",
         "q": "caddy",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["pkg:caddy"]
+        "relevant": [["pkg:caddy"]]
     },
     {
         "id": "g014",
         "q": "gitea",
         "category": "exact",
-        "relevant": ["pkg:gitea"]
+        "relevant": [["pkg:gitea"]]
     },
     {
         "id": "g015",
         "q": "jellyfin",
         "category": "exact",
-        "relevant": ["pkg:jellyfin"]
+        "relevant": [["pkg:jellyfin"]]
     },
     {
         "id": "g026",
         "q": "postgres",
         "category": "prefix",
         "exhaustive": true,
-        "best": "pkg:postgresql",
         "relevant": [
-            "pkg:postgresql",
-            "pkg:postgresql_14",
-            "pkg:postgresql_15",
-            "pkg:postgresql_16",
-            "pkg:postgresql_17",
-            "pkg:postgresql_18",
-            "pkg:postgresql_19",
-            "pkg:postgresql_jit",
-            "pkg:postgresql_14_jit",
-            "pkg:postgresql_15_jit",
-            "pkg:postgresql_16_jit",
-            "pkg:postgresql_17_jit",
-            "pkg:postgresql_18_jit",
-            "pkg:postgresql_19_jit"
+            ["pkg:postgresql"],
+            [
+                "pkg:postgresql_14",
+                "pkg:postgresql_15",
+                "pkg:postgresql_16",
+                "pkg:postgresql_17",
+                "pkg:postgresql_18",
+                "pkg:postgresql_19",
+                "pkg:postgresql_jit",
+                "pkg:postgresql_14_jit",
+                "pkg:postgresql_15_jit",
+                "pkg:postgresql_16_jit",
+                "pkg:postgresql_17_jit",
+                "pkg:postgresql_18_jit",
+                "pkg:postgresql_19_jit"
+            ]
         ]
     },
     {
         "id": "g027",
         "q": "graf",
         "category": "prefix",
-        "relevant": ["pkg:grafana"]
+        "relevant": [["pkg:grafana"]]
     },
     {
         "id": "g028",
         "q": "prom",
         "category": "prefix",
-        "relevant": ["pkg:prometheus"]
+        "relevant": [["pkg:prometheus"]]
     },
     {
         "id": "g029",
         "q": "ripgr",
         "category": "prefix",
-        "relevant": ["pkg:ripgrep"]
+        "relevant": [["pkg:ripgrep"]]
     },
     {
         "id": "g030",
         "q": "jelly",
         "category": "prefix",
-        "relevant": ["pkg:jellyfin"]
+        "relevant": [["pkg:jellyfin"]]
     },
     {
         "id": "g031",
         "q": "syncth",
         "category": "prefix",
-        "relevant": ["pkg:syncthing"]
+        "relevant": [["pkg:syncthing"]]
     },
     {
         "id": "g035",
         "q": "ngin",
         "category": "prefix",
-        "best": "pkg:nginx",
         "relevant": [
-            "pkg:nginx",
-            "pkg:nginxMainline",
-            "pkg:nginxStable",
-            "pkg:nginxShibboleth"
+            ["pkg:nginx"],
+            ["pkg:nginxMainline", "pkg:nginxStable", "pkg:nginxShibboleth"]
         ]
     },
     {
         "id": "g036",
         "q": "mariad",
         "category": "prefix",
-        "best": "pkg:mariadb",
         "relevant": [
-            "pkg:mariadb",
-            "pkg:mariadb_1011",
-            "pkg:mariadb_106",
-            "pkg:mariadb_114",
-            "pkg:mariadb_118"
+            ["pkg:mariadb"],
+            [
+                "pkg:mariadb_1011",
+                "pkg:mariadb_106",
+                "pkg:mariadb_114",
+                "pkg:mariadb_118"
+            ]
         ]
     },
     {
@@ -194,165 +192,166 @@
         "q": "fail2",
         "category": "prefix",
         "exhaustive": true,
-        "relevant": ["pkg:fail2ban"]
+        "relevant": [["pkg:fail2ban"]]
     },
     {
         "id": "g038",
         "q": "tailsc",
         "category": "prefix",
-        "relevant": ["pkg:tailscale"]
+        "relevant": [["pkg:tailscale"]]
     },
     {
         "id": "g039",
         "q": "nextcl",
         "category": "prefix",
-        "relevant": ["pkg:nextcloud32", "pkg:nextcloud33", "pkg:nextcloud34"]
+        "relevant": [
+            ["pkg:nextcloud34"],
+            ["pkg:nextcloud33"],
+            ["pkg:nextcloud32"]
+        ]
     },
     {
         "id": "g040",
         "q": "traef",
         "category": "prefix",
-        "relevant": ["pkg:traefik"]
+        "relevant": [["pkg:traefik"]]
     },
     {
         "id": "g041",
         "q": "cadd",
         "category": "prefix",
-        "relevant": ["pkg:caddy"]
+        "relevant": [["pkg:caddy"]]
     },
     {
         "id": "g042",
         "q": "transm",
         "category": "prefix",
-        "relevant": ["pkg:transmission_4"]
+        "relevant": [["pkg:transmission_4"]]
     },
     {
         "id": "g043",
         "q": "unbou",
         "category": "prefix",
-        "relevant": ["pkg:unbound"]
+        "relevant": [["pkg:unbound"]]
     },
     {
         "id": "g044",
         "q": "dnsma",
         "category": "prefix",
-        "relevant": ["pkg:dnsmasq"]
+        "relevant": [["pkg:dnsmasq"]]
     },
     {
         "id": "g045",
         "q": "neovi",
         "category": "prefix",
-        "relevant": ["pkg:neovim"]
+        "relevant": [["pkg:neovim"]]
     },
     {
         "id": "g046",
         "q": "thunder",
         "category": "prefix",
-        "relevant": ["pkg:thunderbird"]
+        "relevant": [["pkg:thunderbird"]]
     },
     {
         "id": "g047",
         "q": "chrom",
         "category": "prefix",
-        "relevant": ["pkg:chromium"]
+        "relevant": [["pkg:chromium"]]
     },
     {
         "id": "g048",
         "q": "borgb",
         "category": "prefix",
-        "relevant": ["pkg:borgbackup"]
+        "relevant": [["pkg:borgbackup"]]
     },
     {
         "id": "g049",
         "q": "mosqui",
         "category": "prefix",
-        "relevant": ["pkg:mosquitto"]
+        "relevant": [["pkg:mosquitto"]]
     },
     {
         "id": "g050",
         "q": "elastic",
         "category": "prefix",
-        "best": "pkg:elasticsearch",
-        "relevant": ["pkg:elasticsearch", "pkg:elasticsearch7"]
+        "relevant": [["pkg:elasticsearch"], ["pkg:elasticsearch7"]]
     },
     {
         "id": "g051",
         "q": "ngnix",
         "category": "typo",
-        "best": "pkg:nginx",
-        "relevant": ["pkg:nginx", "pkg:nginxStable", "pkg:nginxMainline"]
+        "relevant": [["pkg:nginx"], ["pkg:nginxStable", "pkg:nginxMainline"]]
     },
     {
         "id": "g052",
         "q": "postgrsql",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:postgresql",
         "relevant": [
-            "pkg:postgresql",
-            "pkg:postgresql_14",
-            "pkg:postgresql_15",
-            "pkg:postgresql_16",
-            "pkg:postgresql_17",
-            "pkg:postgresql_18",
-            "pkg:postgresql_jit",
-            "pkg:postgresql_14_jit",
-            "pkg:postgresql_15_jit",
-            "pkg:postgresql_16_jit",
-            "pkg:postgresql_17_jit",
-            "pkg:postgresql_18_jit",
-            "pkg:postgresql_19",
-            "pkg:postgresql_19_jit"
+            ["pkg:postgresql"],
+            [
+                "pkg:postgresql_14",
+                "pkg:postgresql_15",
+                "pkg:postgresql_16",
+                "pkg:postgresql_17",
+                "pkg:postgresql_18",
+                "pkg:postgresql_jit",
+                "pkg:postgresql_14_jit",
+                "pkg:postgresql_15_jit",
+                "pkg:postgresql_16_jit",
+                "pkg:postgresql_17_jit",
+                "pkg:postgresql_18_jit",
+                "pkg:postgresql_19",
+                "pkg:postgresql_19_jit"
+            ]
         ]
     },
     {
         "id": "g053",
         "q": "promethues",
         "category": "typo",
-        "relevant": ["pkg:prometheus"]
+        "relevant": [["pkg:prometheus"]]
     },
     {
         "id": "g054",
         "q": "grafan",
         "category": "typo",
-        "relevant": ["pkg:grafana"]
+        "relevant": [["pkg:grafana"]]
     },
     {
         "id": "g055",
         "q": "firefx",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:firefox",
         "relevant": [
-            "pkg:firefox",
-            "pkg:firefox-unwrapped",
-            "pkg:firefox-esr-140-unwrapped",
-            "pkg:firefox-esr-153-unwrapped"
+            ["pkg:firefox"],
+            [
+                "pkg:firefox-unwrapped",
+                "pkg:firefox-esr-140-unwrapped",
+                "pkg:firefox-esr-153-unwrapped"
+            ]
         ]
     },
     {
         "id": "g056",
         "q": "ripgrap",
         "category": "typo",
-        "relevant": ["pkg:ripgrep"]
+        "relevant": [["pkg:ripgrep"]]
     },
     {
         "id": "g057",
         "q": "jellifin",
         "category": "typo",
-        "relevant": ["pkg:jellyfin"]
+        "relevant": [["pkg:jellyfin"]]
     },
     {
         "id": "g060",
         "q": "samaba",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:samba",
         "relevant": [
-            "pkg:samba",
-            "pkg:samba4",
-            "pkg:samba4Full",
-            "pkg:sambaFull"
+            ["pkg:samba"],
+            ["pkg:samba4", "pkg:samba4Full", "pkg:sambaFull"]
         ]
     },
     {
@@ -360,61 +359,61 @@
         "q": "redsi",
         "category": "typo",
         "exhaustive": true,
-        "relevant": ["pkg:redis"]
+        "relevant": [["pkg:redis"]]
     },
     {
         "id": "g062",
         "q": "openssg",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:openssh",
         "relevant": [
-            "pkg:openssh",
-            "pkg:opensshWithKerberos",
-            "pkg:openssh_gssapi",
-            "pkg:openssh_hpn",
-            "pkg:openssh_hpnWithKerberos"
+            ["pkg:openssh"],
+            [
+                "pkg:opensshWithKerberos",
+                "pkg:openssh_gssapi",
+                "pkg:openssh_hpn",
+                "pkg:openssh_hpnWithKerberos"
+            ]
         ]
     },
     {
         "id": "g063",
         "q": "kubctl",
         "category": "typo",
-        "relevant": ["pkg:kubectl"]
+        "relevant": [["pkg:kubectl"]]
     },
     {
         "id": "g064",
         "q": "terrafrom",
         "category": "typo",
-        "best": "pkg:terraform",
-        "relevant": ["pkg:terraform", "pkg:terraform_1"]
+        "relevant": [["pkg:terraform"], ["pkg:terraform_1"]]
     },
     {
         "id": "g065",
         "q": "chromiun",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:chromium",
-        "relevant": ["pkg:chromium", "pkg:ungoogled-chromium"]
+        "relevant": [["pkg:chromium"], ["pkg:ungoogled-chromium"]]
     },
     {
         "id": "g066",
         "q": "thunderbrid",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:thunderbird",
         "relevant": [
-            "pkg:thunderbird",
-            "pkg:thunderbird-bin",
-            "pkg:thunderbird-esr",
-            "pkg:thunderbird-esr-bin",
-            "pkg:thunderbird-latest",
-            "pkg:thunderbird-latest-bin",
-            "pkg:thunderbird-140",
-            "pkg:thunderbird-153",
-            "pkg:thunderbird-latest-unwrapped",
-            "pkg:thunderbird-140-unwrapped",
-            "pkg:thunderbird-153-unwrapped"
+            ["pkg:thunderbird"],
+            [
+                "pkg:thunderbird-bin",
+                "pkg:thunderbird-esr",
+                "pkg:thunderbird-esr-bin",
+                "pkg:thunderbird-latest",
+                "pkg:thunderbird-latest-bin",
+                "pkg:thunderbird-140",
+                "pkg:thunderbird-153",
+                "pkg:thunderbird-latest-unwrapped",
+                "pkg:thunderbird-140-unwrapped",
+                "pkg:thunderbird-153-unwrapped"
+            ]
         ]
     },
     {
@@ -422,38 +421,40 @@
         "q": "dcoker",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:docker",
         "relevant": [
-            "pkg:docker",
-            "pkg:docker_25",
-            "pkg:docker_29",
-            "pkg:docker-client"
+            ["pkg:docker"],
+            ["pkg:docker_25", "pkg:docker_29", "pkg:docker-client"]
         ]
     },
     {
         "id": "g068",
         "q": "nextcoud",
         "category": "typo",
-        "relevant": ["pkg:nextcloud32", "pkg:nextcloud33", "pkg:nextcloud34"]
+        "relevant": [
+            ["pkg:nextcloud34"],
+            ["pkg:nextcloud33"],
+            ["pkg:nextcloud32"]
+        ]
     },
     {
         "id": "g069",
         "q": "gitae",
         "category": "typo",
-        "relevant": ["pkg:gitea"]
+        "relevant": [["pkg:gitea"]]
     },
     {
         "id": "g070",
         "q": "vaultwardn",
         "category": "typo",
         "exhaustive": true,
-        "best": "pkg:vaultwarden",
         "relevant": [
-            "pkg:vaultwarden",
-            "pkg:vaultwarden-mysql",
-            "pkg:vaultwarden-postgresql",
-            "pkg:vaultwarden-sqlite",
-            "pkg:vaultwarden-webvault"
+            ["pkg:vaultwarden"],
+            [
+                "pkg:vaultwarden-mysql",
+                "pkg:vaultwarden-postgresql",
+                "pkg:vaultwarden-sqlite",
+                "pkg:vaultwarden-webvault"
+            ]
         ]
     },
     {
@@ -461,137 +462,140 @@
         "q": "tailscle",
         "category": "typo",
         "exhaustive": true,
-        "relevant": ["pkg:tailscale"]
+        "relevant": [["pkg:tailscale"]]
     },
     {
         "id": "g072",
         "q": "fial2ban",
         "category": "typo",
         "exhaustive": true,
-        "relevant": ["pkg:fail2ban"]
+        "relevant": [["pkg:fail2ban"]]
     },
     {
         "id": "g073",
         "q": "mosquito",
         "category": "typo",
         "exhaustive": true,
-        "relevant": ["pkg:mosquitto"]
+        "relevant": [["pkg:mosquitto"]]
     },
     {
         "id": "g074",
         "q": "syncthign",
         "category": "typo",
         "exhaustive": true,
-        "relevant": ["pkg:syncthing"]
+        "relevant": [["pkg:syncthing"]]
     },
     {
         "id": "g075",
         "q": "cady",
         "category": "typo",
         "exhaustive": true,
-        "relevant": ["pkg:caddy"]
+        "relevant": [["pkg:caddy"]]
     },
     {
         "id": "g101",
         "q": "docker container",
         "category": "multiterm",
-        "best": "pkg:docker",
-        "relevant": ["pkg:docker", "pkg:docker_25", "pkg:docker_29"]
+        "relevant": [["pkg:docker"], ["pkg:docker_25", "pkg:docker_29"]]
     },
     {
         "id": "g102",
         "q": "ssh daemon",
         "category": "multiterm",
-        "best": "pkg:openssh",
         "relevant": [
-            "pkg:openssh",
-            "pkg:opensshWithKerberos",
-            "pkg:openssh_gssapi",
-            "pkg:openssh_hpn",
-            "pkg:openssh_hpnWithKerberos"
+            ["pkg:openssh"],
+            [
+                "pkg:opensshWithKerberos",
+                "pkg:openssh_gssapi",
+                "pkg:openssh_hpn",
+                "pkg:openssh_hpnWithKerberos"
+            ]
         ]
     },
     {
         "id": "g103",
         "q": "home assistant",
         "category": "multiterm",
-        "relevant": ["pkg:home-assistant"]
+        "relevant": [["pkg:home-assistant"]]
     },
     {
         "id": "g104",
         "q": "matrix synapse",
         "category": "multiterm",
-        "relevant": ["pkg:matrix-synapse"]
+        "relevant": [["pkg:matrix-synapse"]]
     },
     {
         "id": "g105",
         "q": "docker compose",
         "category": "multiterm",
-        "relevant": ["pkg:docker-compose"]
+        "relevant": [["pkg:docker-compose"]]
     },
     {
         "id": "g106",
         "q": "vault warden",
         "category": "multiterm",
-        "relevant": ["pkg:vaultwarden"]
+        "relevant": [["pkg:vaultwarden"]]
     },
     {
         "id": "g107",
         "q": "next cloud",
         "category": "multiterm",
-        "relevant": ["pkg:nextcloud32", "pkg:nextcloud33", "pkg:nextcloud34"]
+        "relevant": [
+            ["pkg:nextcloud34"],
+            ["pkg:nextcloud33"],
+            ["pkg:nextcloud32"]
+        ]
     },
     {
         "id": "g108",
         "q": "paperless ngx",
         "category": "multiterm",
-        "relevant": ["pkg:paperless-ngx"]
+        "relevant": [["pkg:paperless-ngx"]]
     },
     {
         "id": "g118",
         "q": "object storage",
         "category": "multiterm",
-        "relevant": ["pkg:minio"]
+        "relevant": [["pkg:minio"]]
     },
     {
         "id": "g119",
         "q": "secret management",
         "category": "multiterm",
-        "relevant": ["pkg:vault"]
+        "relevant": [["pkg:vault"]]
     },
     {
         "id": "g122",
         "q": "container runtime",
         "category": "multiterm",
         "relevant": [
-            "pkg:docker",
-            "pkg:docker_25",
-            "pkg:docker_29",
-            "pkg:podman"
+            ["pkg:docker", "pkg:docker_25", "pkg:docker_29", "pkg:podman"]
         ]
     },
     {
         "id": "g123",
         "q": "mesh vpn",
         "category": "multiterm",
-        "relevant": ["pkg:tailscale"]
+        "relevant": [["pkg:tailscale"]]
     },
     {
         "id": "g124",
         "q": "password manager",
         "category": "multiterm",
-        "relevant": ["pkg:vaultwarden"]
+        "relevant": [["pkg:vaultwarden"]]
     },
     {
         "id": "g126",
         "q": "web server",
         "category": "intent",
         "relevant": [
-            "pkg:nginx",
-            "pkg:nginxMainline",
-            "pkg:nginxStable",
-            "pkg:nginxShibboleth",
-            "pkg:caddy"
+            [
+                "pkg:nginx",
+                "pkg:nginxMainline",
+                "pkg:nginxStable",
+                "pkg:nginxShibboleth",
+                "pkg:caddy"
+            ]
         ]
     },
     {
@@ -599,208 +603,215 @@
         "q": "reverse proxy",
         "category": "intent",
         "relevant": [
-            "pkg:nginx",
-            "pkg:nginxMainline",
-            "pkg:nginxStable",
-            "pkg:nginxShibboleth",
-            "pkg:caddy",
-            "pkg:traefik"
+            [
+                "pkg:nginx",
+                "pkg:nginxMainline",
+                "pkg:nginxStable",
+                "pkg:nginxShibboleth",
+                "pkg:caddy",
+                "pkg:traefik"
+            ]
         ]
     },
     {
         "id": "g128",
         "q": "version control system",
         "category": "intent",
-        "relevant": ["pkg:git", "pkg:gitFull", "pkg:gitMinimal", "pkg:gitSVN"]
+        "relevant": [["pkg:git", "pkg:gitFull", "pkg:gitMinimal", "pkg:gitSVN"]]
     },
     {
         "id": "g129",
         "q": "interactive process viewer",
         "category": "intent",
-        "relevant": ["pkg:htop", "pkg:btop", "pkg:xfce4-taskmanager"]
+        "relevant": [["pkg:htop", "pkg:btop", "pkg:xfce4-taskmanager"]]
     },
     {
         "id": "g130",
         "q": "virtual private network",
         "category": "intent",
-        "relevant": ["pkg:tailscale"]
+        "relevant": [["pkg:tailscale"]]
     },
     {
         "id": "g131",
         "q": "self hosted password manager",
         "category": "intent",
-        "relevant": ["pkg:vaultwarden"]
+        "relevant": [["pkg:vaultwarden"]]
     },
     {
         "id": "g132",
         "q": "media streaming server",
         "category": "intent",
-        "relevant": ["pkg:jellyfin"]
+        "relevant": [["pkg:jellyfin"]]
     },
     {
         "id": "g133",
         "q": "backup tool",
         "category": "intent",
-        "relevant": ["pkg:restic", "pkg:borgbackup"]
+        "relevant": [["pkg:restic", "pkg:borgbackup"]]
     },
     {
         "id": "g134",
         "q": "file synchronization",
         "category": "intent",
-        "relevant": ["pkg:syncthing", "pkg:maestral"]
+        "relevant": [["pkg:syncthing", "pkg:maestral"]]
     },
     {
         "id": "g135",
         "q": "relational database server",
         "category": "intent",
         "relevant": [
-            "pkg:postgresql",
-            "pkg:postgresql_14",
-            "pkg:postgresql_15",
-            "pkg:postgresql_16",
-            "pkg:postgresql_17",
-            "pkg:postgresql_18",
-            "pkg:mariadb",
-            "pkg:mariadb_1011",
-            "pkg:mariadb_106",
-            "pkg:mariadb_114",
-            "pkg:mariadb_118",
-            "pkg:mysql84"
+            [
+                "pkg:postgresql",
+                "pkg:postgresql_14",
+                "pkg:postgresql_15",
+                "pkg:postgresql_16",
+                "pkg:postgresql_17",
+                "pkg:postgresql_18",
+                "pkg:mariadb",
+                "pkg:mariadb_1011",
+                "pkg:mariadb_106",
+                "pkg:mariadb_114",
+                "pkg:mariadb_118",
+                "pkg:mysql84"
+            ]
         ]
     },
     {
         "id": "g136",
         "q": "in memory key value store",
         "category": "intent",
-        "relevant": ["pkg:redis"]
+        "relevant": [["pkg:redis"]]
     },
     {
         "id": "g137",
         "q": "secret storage",
         "category": "intent",
-        "relevant": ["pkg:vault"]
+        "relevant": [["pkg:vault"]]
     },
     {
         "id": "g138",
         "q": "s3 compatible object storage",
         "category": "intent",
-        "relevant": ["pkg:minio"]
+        "relevant": [["pkg:minio"]]
     },
     {
         "id": "g139",
         "q": "metrics monitoring stack",
         "category": "intent",
-        "relevant": ["pkg:prometheus", "pkg:grafana"]
+        "relevant": [["pkg:prometheus", "pkg:grafana"]]
     },
     {
         "id": "g140",
         "q": "document management",
         "category": "intent",
-        "relevant": ["pkg:paperless-ngx"]
+        "relevant": [["pkg:paperless-ngx"]]
     },
     {
         "id": "g141",
         "q": "printing support",
         "category": "intent",
-        "relevant": ["pkg:cups"]
+        "relevant": [["pkg:cups"]]
     },
     {
         "id": "g143",
         "q": "caching dns resolver",
         "category": "intent",
-        "relevant": ["pkg:unbound", "pkg:dnsmasq"]
+        "relevant": [["pkg:unbound", "pkg:dnsmasq"]]
     },
     {
         "id": "g144",
         "q": "text editor",
         "category": "intent",
-        "relevant": ["pkg:emacs", "pkg:emacs30", "pkg:neovim", "pkg:vim"]
+        "relevant": [["pkg:emacs", "pkg:emacs30", "pkg:neovim", "pkg:vim"]]
     },
     {
         "id": "g145",
         "q": "graphical web browser",
         "category": "intent",
-        "relevant": ["pkg:firefox", "pkg:chromium"]
+        "relevant": [["pkg:firefox", "pkg:chromium"]]
     },
     {
         "id": "g146",
         "q": "desktop email client",
         "category": "intent",
-        "relevant": ["pkg:thunderbird"]
+        "relevant": [["pkg:thunderbird"]]
     },
     {
         "id": "g147",
         "q": "video player",
         "category": "intent",
-        "relevant": ["pkg:vlc", "pkg:mpv"]
+        "relevant": [["pkg:vlc", "pkg:mpv"]]
     },
     {
         "id": "g148",
         "q": "raster image editor",
         "category": "intent",
-        "relevant": ["pkg:gimp", "pkg:gimp2", "pkg:gimp2-with-plugins"]
+        "relevant": [["pkg:gimp", "pkg:gimp2", "pkg:gimp2-with-plugins"]]
     },
     {
         "id": "g149",
         "q": "bittorrent client",
         "category": "intent",
-        "relevant": ["pkg:transmission_4"]
+        "relevant": [["pkg:transmission_4"]]
     },
     {
         "id": "g150",
         "q": "terminal multiplexer",
         "category": "intent",
-        "relevant": ["pkg:tmux"]
+        "relevant": [["pkg:tmux"]]
     },
     {
         "id": "g151",
         "q": "continuwuity",
         "category": "exact",
         "exhaustive": true,
-        "relevant": ["pkg:matrix-continuwuity"]
+        "relevant": [["pkg:matrix-continuwuity"]]
     },
     {
         "id": "g152",
         "q": "node",
         "category": "exact",
         "exhaustive": true,
-        "best": "pkg:nodejs",
         "relevant": [
-            "pkg:nodejs",
-            "pkg:nodejs_latest",
-            "pkg:nodejs_26",
-            "pkg:nodejs_24",
-            "pkg:nodejs_22",
-            "pkg:nodejs_20",
-            "pkg:nodejs-slim",
-            "pkg:nodejs-slim_latest",
-            "pkg:nodejs-slim_26",
-            "pkg:nodejs-slim_24",
-            "pkg:nodejs-slim_22"
+            ["pkg:nodejs"],
+            [
+                "pkg:nodejs_latest",
+                "pkg:nodejs_26",
+                "pkg:nodejs_24",
+                "pkg:nodejs_22",
+                "pkg:nodejs_20"
+            ],
+            [
+                "pkg:nodejs-slim",
+                "pkg:nodejs-slim_latest",
+                "pkg:nodejs-slim_26",
+                "pkg:nodejs-slim_24",
+                "pkg:nodejs-slim_22"
+            ]
         ]
     },
     {
         "id": "g153",
         "q": "Dicomizer",
         "category": "exact",
-        "relevant": ["pkg:weasis"]
+        "relevant": [["pkg:weasis"]]
     },
     {
         "id": "g154",
         "q": "LibreVNA-GUI",
         "category": "exact",
-        "relevant": ["pkg:librevna"]
+        "relevant": [["pkg:librevna"]]
     },
     {
         "id": "g155",
         "q": "nfcDemoApp",
         "category": "exact",
-        "relevant": ["pkg:libnfc-nci"]
+        "relevant": [["pkg:libnfc-nci"]]
     },
     {
         "id": "g156",
         "q": "yodaStruct",
         "category": "exact",
-        "relevant": ["pkg:d-seams"]
+        "relevant": [["pkg:d-seams"]]
     }
 ]

--- a/frontend/benchmark/queries-packages.json
+++ b/frontend/benchmark/queries-packages.json
@@ -10,6 +10,7 @@
         "q": "htop",
         "category": "exact",
         "exhaustive": true,
+        "best": "pkg:htop",
         "relevant": ["pkg:htop", "pkg:htop-vim"]
     },
     {
@@ -47,6 +48,7 @@
         "id": "g008",
         "q": "nginx",
         "category": "exact",
+        "best": "pkg:nginx",
         "relevant": ["pkg:nginx", "pkg:nginxMainline", "pkg:nginxStable"]
     },
     {
@@ -66,6 +68,7 @@
         "q": "postgresql",
         "category": "exact",
         "exhaustive": true,
+        "best": "pkg:postgresql",
         "relevant": [
             "pkg:postgresql",
             "pkg:postgresql_14",
@@ -113,6 +116,7 @@
         "q": "postgres",
         "category": "prefix",
         "exhaustive": true,
+        "best": "pkg:postgresql",
         "relevant": [
             "pkg:postgresql",
             "pkg:postgresql_14",
@@ -164,6 +168,7 @@
         "id": "g035",
         "q": "ngin",
         "category": "prefix",
+        "best": "pkg:nginx",
         "relevant": [
             "pkg:nginx",
             "pkg:nginxMainline",
@@ -175,6 +180,7 @@
         "id": "g036",
         "q": "mariad",
         "category": "prefix",
+        "best": "pkg:mariadb",
         "relevant": [
             "pkg:mariadb",
             "pkg:mariadb_1011",
@@ -266,12 +272,14 @@
         "id": "g050",
         "q": "elastic",
         "category": "prefix",
+        "best": "pkg:elasticsearch",
         "relevant": ["pkg:elasticsearch", "pkg:elasticsearch7"]
     },
     {
         "id": "g051",
         "q": "ngnix",
         "category": "typo",
+        "best": "pkg:nginx",
         "relevant": ["pkg:nginx", "pkg:nginxStable", "pkg:nginxMainline"]
     },
     {
@@ -279,6 +287,7 @@
         "q": "postgrsql",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:postgresql",
         "relevant": [
             "pkg:postgresql",
             "pkg:postgresql_14",
@@ -313,6 +322,7 @@
         "q": "firefx",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:firefox",
         "relevant": [
             "pkg:firefox",
             "pkg:firefox-unwrapped",
@@ -337,6 +347,7 @@
         "q": "samaba",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:samba",
         "relevant": [
             "pkg:samba",
             "pkg:samba4",
@@ -356,6 +367,7 @@
         "q": "openssg",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:openssh",
         "relevant": [
             "pkg:openssh",
             "pkg:opensshWithKerberos",
@@ -374,6 +386,7 @@
         "id": "g064",
         "q": "terrafrom",
         "category": "typo",
+        "best": "pkg:terraform",
         "relevant": ["pkg:terraform", "pkg:terraform_1"]
     },
     {
@@ -381,6 +394,7 @@
         "q": "chromiun",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:chromium",
         "relevant": ["pkg:chromium", "pkg:ungoogled-chromium"]
     },
     {
@@ -388,6 +402,7 @@
         "q": "thunderbrid",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:thunderbird",
         "relevant": [
             "pkg:thunderbird",
             "pkg:thunderbird-bin",
@@ -407,6 +422,7 @@
         "q": "dcoker",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:docker",
         "relevant": [
             "pkg:docker",
             "pkg:docker_25",
@@ -431,6 +447,7 @@
         "q": "vaultwardn",
         "category": "typo",
         "exhaustive": true,
+        "best": "pkg:vaultwarden",
         "relevant": [
             "pkg:vaultwarden",
             "pkg:vaultwarden-mysql",
@@ -478,12 +495,14 @@
         "id": "g101",
         "q": "docker container",
         "category": "multiterm",
+        "best": "pkg:docker",
         "relevant": ["pkg:docker", "pkg:docker_25", "pkg:docker_29"]
     },
     {
         "id": "g102",
         "q": "ssh daemon",
         "category": "multiterm",
+        "best": "pkg:openssh",
         "relevant": [
             "pkg:openssh",
             "pkg:opensshWithKerberos",
@@ -745,13 +764,19 @@
         "q": "node",
         "category": "exact",
         "exhaustive": true,
+        "best": "pkg:nodejs",
         "relevant": [
             "pkg:nodejs",
             "pkg:nodejs_latest",
             "pkg:nodejs_26",
             "pkg:nodejs_24",
             "pkg:nodejs_22",
-            "pkg:nodejs_20"
+            "pkg:nodejs_20",
+            "pkg:nodejs-slim",
+            "pkg:nodejs-slim_latest",
+            "pkg:nodejs-slim_26",
+            "pkg:nodejs-slim_24",
+            "pkg:nodejs-slim_22"
         ]
     },
     {

--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -367,6 +367,70 @@ const table = (header, rows) =>
         ...rows.map((r) => `| ${r.join(" | ")} |`),
     ].join("\n");
 
+// Metric labels paired with the footnote GitHub renders at the bottom of the
+// report. Every table names a metric through `metric()`, so each definition is
+// written once and every table citing it links there.
+const METRICS = {
+    success: {
+        label: `Success@${K}`,
+        note: `Did the page hold an acceptable answer at all - 1 or 0 per
+            query.`,
+    },
+    mrr: {
+        label: "MRR",
+        note: `Mean reciprocal rank of the first acceptable answer: 1.000 if it
+            led, 0.500 second, 0.333 third, 0 if none made the page.`,
+    },
+    recall: {
+        label: `Recall@${K}`,
+        note: `What share of the acceptable answers the page held, over the most
+            it could have held at k.`,
+    },
+    rbp: {
+        label: `RBP (p=${P})`,
+        note: `Rank-biased precision (Moffat & Zobel 2008): how much of the page
+            a user is expected to find useful, pricing rank \`i\` at \`p^(i-1)\`
+            so junk near the top costs more than junk near the bottom. \`p\` is
+            the chance they read one more result; the denominator is the page we
+            returned, so a short clean page still reaches 1.000.`,
+    },
+    bestrr: {
+        label: "BestRR",
+        note: `Reciprocal rank of the one answer the query most wants: 1.000 if
+            it led, 0.500 second, 0 if it never appeared. Where MRR is satisfied
+            by any acceptable answer, this reads the ordering within that set -
+            on \`node\` MRR is 1.000 whether \`nodejs\` or \`nodejs-slim_26\`
+            led, and BestRR separates those pages 1.000 to 0.167. The gold set
+            is a list of tiers of ids tied at a rank; the best answer is a top
+            tier holding one id.`,
+    },
+    ndcg: {
+        label: `nDCG@${K}`,
+        note: `Normalized discounted cumulative gain (Jarvelin & Kekalainen
+            2002): the whole page priced against its ideal ordering, 1.000 when
+            nothing could have been ranked better. A hit in tier \`i\` of \`T\`
+            grades \`T - i\`, so a one-tier gold set is ordinary binary nDCG.`,
+    },
+    n: {
+        label: "n",
+        note: `How many queries the figure covers; the rest make no claim the
+            metric can read and drop out of its mean. RBP covers queries marked
+            \`"exhaustive": true\`, meaning the gold set lists every acceptable
+            answer so anything else is noise, that returned at least one hit.
+            BestRR covers queries whose gold set names a single best answer.`,
+    },
+};
+
+// A footnote definition has to be one line; wrap the source, not the output.
+const oneLine = (s) => s.trim().replace(/\s+/g, " ");
+
+// A metric named in a table, carrying its footnote marker.
+const metric = (key) => `${METRICS[key].label}[^${key}]`;
+
+const FOOTNOTES = Object.entries(METRICS).map(
+    ([key, { note }]) => `[^${key}]: ${oneLine(note)}`,
+);
+
 // One `## <label>` section: Overall + By-category tables for a single track.
 function section(label, results) {
     // RBP only covers the closed-set queries that returned something, BestRR
@@ -388,27 +452,27 @@ function section(label, results) {
     return [
         `## ${label}`,
         "",
-        `> ${results.length} queries, k=${K}.`,
+        `> ${results.length} queries.`,
         "",
         "### Overall",
         "",
         table(
-            ["metric", "value", "n"],
+            ["metric", "value", metric("n")],
             [
-                ["Success@" + K, overall.success.toFixed(3), results.length],
-                ["MRR", overall.mrr.toFixed(3), results.length],
-                ["Recall@" + K, overall.recall.toFixed(3), results.length],
+                [metric("success"), overall.success.toFixed(3), results.length],
+                [metric("mrr"), overall.mrr.toFixed(3), results.length],
+                [metric("recall"), overall.recall.toFixed(3), results.length],
                 [
-                    `RBP (p=${P})`,
+                    metric("rbp"),
                     overall.rbp === null ? "-" : overall.rbp.toFixed(3),
                     closed.length,
                 ],
                 [
-                    "BestRR",
+                    metric("bestrr"),
                     overall.bestrr === null ? "-" : overall.bestrr.toFixed(3),
                     ordinal.length,
                 ],
-                ["nDCG@" + K, overall.ndcg.toFixed(3), results.length],
+                [metric("ndcg"), overall.ndcg.toFixed(3), results.length],
             ],
         ),
         "",
@@ -417,13 +481,13 @@ function section(label, results) {
         table(
             [
                 "category",
-                "n",
-                "Success@" + K,
-                "MRR",
-                "Recall@" + K,
-                `RBP (p=${P})`,
-                "BestRR",
-                "nDCG@" + K,
+                metric("n"),
+                metric("success"),
+                metric("mrr"),
+                metric("recall"),
+                metric("rbp"),
+                metric("bestrr"),
+                metric("ndcg"),
             ],
             Object.entries(byCategory)
                 .sort(([a], [b]) => a.localeCompare(b))
@@ -462,21 +526,7 @@ const perQuery = [
 const lines = [
     "# Relevance benchmark: frontend query vs deployed ES",
     "",
-    `> Index: \`${INDEX}\`. metrics: (Success@${K}, MRR, Recall@${K}, RBP(p=${P}), BestRR, nDCG@${K}).`,
-    "",
-    `> \`RBP\` is rank-biased precision. It prices rank \`i\` at \`p^(i-1)\`. Junk near the`,
-    `> top therefore costs more than junk near the bottom. The denominator is the page`,
-    `> we returned, so a short page scores only on the hits it has. Pass`,
-    `> \`--persistence\` to change \`p\`. Only a query with \`"exhaustive": true\` gets a`,
-    "> score. A query with no hits drops out of the mean.",
-    "",
-    "> `BestRR` and `nDCG` read `relevant` as ranked tiers rather than as a flat",
-    "> set. A tier holds ids tied at that rank, so order between tiers is a claim",
-    "> and order within one is not, and a hit in tier `i` of `T` grades `T - i`.",
-    "> `BestRR` is the reciprocal rank of the best answer - the top tier's single",
-    "> id - so it reads how well we order results a user considers comparably",
-    "> relevant, which `MRR` cannot see. A query whose top tier is a tie makes no",
-    "> such claim and drops out of that mean.",
+    `> Index: \`${INDEX}\`, k=${K}. Metric definitions are in the footnotes.`,
     "",
     ...section("Packages", pkgResults),
     ...section("Options", optResults),
@@ -515,6 +565,8 @@ const lines = [
     ),
     "",
     "</details>",
+    "",
+    ...FOOTNOTES,
 ];
 
 console.log(lines.join("\n"));

--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -369,7 +369,7 @@ const table = (header, rows) =>
 
 // Metric labels paired with the footnote GitHub renders at the bottom of the
 // report. Every table names a metric through `metric()`, so each definition is
-// written once and every table citing it links there.
+// written once and the term links there where the report first uses it.
 const METRICS = {
     success: {
         label: `Success@${K}`,
@@ -424,8 +424,16 @@ const METRICS = {
 // A footnote definition has to be one line; wrap the source, not the output.
 const oneLine = (s) => s.trim().replace(/\s+/g, " ");
 
-// A metric named in a table, carrying its footnote marker.
-const metric = (key) => `${METRICS[key].label}[^${key}]`;
+// A metric named in a table. Only the first mention carries the footnote
+// marker - all seven land in the first `Overall` table - because the reference
+// is there to introduce the term, and repeating it on every table leaves the
+// reader looking past markers to reach the numbers.
+const cited = new Set();
+const metric = (key) => {
+    const first = !cited.has(key);
+    cited.add(key);
+    return METRICS[key].label + (first ? `[^${key}]` : "");
+};
 
 const FOOTNOTES = Object.entries(METRICS).map(
     ([key, { note }]) => `[^${key}]: ${oneLine(note)}`,

--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -12,14 +12,15 @@
  *   id          stable handle, also the sort key of the per-query table
  *   q           the search term, as a user would type it
  *   category    grouping for the by-category table, e.g. `typo` or `intent`
- *   relevant    ids we accept as answers, `pkg:`/`opt:` prefixed
+ *   relevant    tiers of ids we accept as answers, `pkg:`/`opt:` prefixed. Each
+ *               tier is a list of ids tied at that rank: order *between* tiers
+ *               is a claim, order *within* one is not. `[[a, b, c]]` states no
+ *               preference, `[[a], [b], [c]]` is a strict order, and
+ *               `[[a], [b, c]]` is a best answer followed by a tie. Only tier a
+ *               gold set where the ordering is real - `text editor` has no
+ *               business claiming `emacs` beats `vim`.
  *   exhaustive  optional; `relevant` enumerates *every* acceptable answer, so
  *               anything else on the page counts as noise. Required for RBP.
- *   best        optional; the single answer a user typing `q` is most likely
- *               after, which must be one of `relevant`. Required for BestRR
- *               unless `relevant` holds exactly one id. Leave it off where the
- *               gold set has no obvious winner - `text editor` has no business
- *               claiming `emacs` beats `vim`.
  */
 
 import { execSync } from "node:child_process";
@@ -151,6 +152,40 @@ function rankHits(hits, field, prefix, k) {
     return out;
 }
 
+// The gold set as ranked tiers, validated. A tier is a non-empty list of ids
+// tied at that rank, and an id belongs to exactly one of them.
+function tiers(q) {
+    if (!Array.isArray(q.relevant) || q.relevant.length === 0) {
+        throw new Error(`${q.id}: "relevant" must be a non-empty list of tiers`);
+    }
+    const seen = new Set();
+    for (const tier of q.relevant) {
+        if (!Array.isArray(tier) || tier.length === 0) {
+            throw new Error(
+                `${q.id}: every tier of "relevant" must be a non-empty list of ids, got ${JSON.stringify(tier)}`,
+            );
+        }
+        for (const id of tier) {
+            if (typeof id !== "string") {
+                throw new Error(
+                    `${q.id}: tier entry ${JSON.stringify(id)} is not a string`,
+                );
+            }
+            if (seen.has(id)) {
+                throw new Error(`${q.id}: ${id} appears in more than one tier`);
+            }
+            seen.add(id);
+        }
+    }
+    return q.relevant;
+}
+
+// The gold set flattened back to a plain set of acceptable answers, which is
+// what the membership metrics ask for.
+function flatRelevant(q) {
+    return tiers(q).flat();
+}
+
 function reciprocalRank(ranked, relevant) {
     const rel = new Set(relevant);
     for (let i = 0; i < ranked.length; i++) {
@@ -160,18 +195,13 @@ function reciprocalRank(ranked, relevant) {
 }
 
 // The one answer a user typing this query is most likely after, or `null` where
-// we decline to rank the gold set. A single-entry `relevant` needs no
-// annotation: with nothing to compare against, it is the best answer by
-// definition. Beyond that it takes an explicit `"best"`, so ordering claims are
-// only ever made where a curator wrote one down.
+// the gold set declines to name one. The top tier holds it whenever that tier
+// holds a single id - including the single-answer case, where with nothing to
+// compare against it is the best answer by definition. A tie at the top states
+// no preference, so there is no ordinal claim to score.
 function bestAnswer(q) {
-    if (q.best !== undefined) {
-        if (!q.relevant.includes(q.best)) {
-            throw new Error(`${q.id}: "best" ${q.best} is not in "relevant"`);
-        }
-        return q.best;
-    }
-    return q.relevant.length === 1 ? q.relevant[0] : null;
+    const top = tiers(q)[0];
+    return top.length === 1 ? top[0] : null;
 }
 
 // Reciprocal rank of the best answer, rather than of the first relevant hit.
@@ -191,27 +221,29 @@ function bestReciprocalRank(ranked, best) {
     return i === -1 ? 0 : 1 / (i + 1);
 }
 
-// Graded nDCG (Jarvelin & Kekalainen 2002) over two grades: the best answer
-// scores 2, any other relevant hit 1.
+// Graded nDCG (Jarvelin & Kekalainen 2002) over the gold set's tiers: a hit in
+// tier `i` of `T` grades `T - i`, and anything off the gold set grades 0.
 //
 // Where BestRR prices one position, this prices the whole page against its ideal
 // ordering, so demoting a variant below the canonical package pays off even when
-// the canonical package was already first. A query with no best answer keeps a
-// flat grade of 1 across its gold set, which is ordinary binary nDCG - it still
+// the canonical package was already first. A single-tier query keeps a flat
+// grade of 1 across its gold set, which is ordinary binary nDCG - it still
 // scores, it just states no preference within the set.
 function ndcgAtK(ranked, q, k) {
-    const best = bestAnswer(q);
-    const grade = (id) => (id === best ? 2 : q.relevant.includes(id) ? 1 : 0);
+    const gold = tiers(q);
+    const grades = new Map(
+        gold.flatMap((tier, i) => tier.map((id) => [id, gold.length - i])),
+    );
     const gain = (g, i) => g / Math.log2(i + 2);
 
     const dcg = ranked
         .slice(0, k)
-        .reduce((a, id, i) => a + gain(grade(id), i), 0);
-    const ideal = q.relevant
-        .map(grade)
-        .sort((a, b) => b - a)
-        .slice(0, k);
-    const idcg = ideal.reduce((a, g, i) => a + gain(g, i), 0);
+        .reduce((a, id, i) => a + gain(grades.get(id) ?? 0, i), 0);
+    // Tiers are already in descending grade order, so this is the ideal page.
+    const idcg = gold
+        .flatMap((tier, i) => tier.map(() => gold.length - i))
+        .slice(0, k)
+        .reduce((a, g, i) => a + gain(g, i), 0);
     return idcg > 0 ? dcg / idcg : 0;
 }
 
@@ -282,6 +314,7 @@ async function scoreTrack(queries, bodyKey, field, prefix) {
         const bodies = await nextBody(q.q, K);
         const data = await esSearch(bodies[bodyKey]);
         const ranked = rankHits(data.hits.hits, field, prefix, K);
+        const relevant = flatRelevant(q);
         results.push({
             id: q.id,
             q: q.q,
@@ -290,10 +323,10 @@ async function scoreTrack(queries, bodyKey, field, prefix) {
             ranked,
             matched: data.hits.total.value,
             matchedExact: data.hits.total.relation === "eq",
-            mrr: reciprocalRank(ranked, q.relevant),
-            success: successAtK(ranked, q.relevant, K),
-            recall: recallAtK(ranked, q.relevant, K),
-            rbp: q.exhaustive ? conditionalRBP(ranked, q.relevant, P) : null,
+            mrr: reciprocalRank(ranked, relevant),
+            success: successAtK(ranked, relevant, K),
+            recall: recallAtK(ranked, relevant, K),
+            rbp: q.exhaustive ? conditionalRBP(ranked, relevant, P) : null,
             bestrr: bestReciprocalRank(ranked, bestAnswer(q)),
             ndcg: ndcgAtK(ranked, q, K),
         });
@@ -437,12 +470,13 @@ const lines = [
     `> \`--persistence\` to change \`p\`. Only a query with \`"exhaustive": true\` gets a`,
     "> score. A query with no hits drops out of the mean.",
     "",
-    "> `BestRR` and `nDCG` grade the gold set instead of treating it as a flat",
-    "> set: the best answer counts double. `BestRR` is the reciprocal rank of that",
-    "> one answer, so it reads how well we order results a user considers",
-    "> comparably relevant, which `MRR` cannot see. It scores a query whose",
-    '> `relevant` holds one entry or which names a `"best"`, and drops the rest',
-    "> from the mean.",
+    "> `BestRR` and `nDCG` read `relevant` as ranked tiers rather than as a flat",
+    "> set. A tier holds ids tied at that rank, so order between tiers is a claim",
+    "> and order within one is not, and a hit in tier `i` of `T` grades `T - i`.",
+    "> `BestRR` is the reciprocal rank of the best answer - the top tier's single",
+    "> id - so it reads how well we order results a user considers comparably",
+    "> relevant, which `MRR` cannot see. A query whose top tier is a tie makes no",
+    "> such claim and drops out of that mean.",
     "",
     ...section("Packages", pkgResults),
     ...section("Options", optResults),

--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -7,6 +7,19 @@
  * Usage:
  *   node benchmark/run.mjs [--packages <path>] [--options <path>] [--channel <branch>] [--schema <n>] [--k <n>] [--persistence <f>]
  *
+ * Each curated query is an object:
+ *
+ *   id          stable handle, also the sort key of the per-query table
+ *   q           the search term, as a user would type it
+ *   category    grouping for the by-category table, e.g. `typo` or `intent`
+ *   relevant    ids we accept as answers, `pkg:`/`opt:` prefixed
+ *   exhaustive  optional; `relevant` enumerates *every* acceptable answer, so
+ *               anything else on the page counts as noise. Required for RBP.
+ *   best        optional; the single answer a user typing `q` is most likely
+ *               after, which must be one of `relevant`. Required for BestRR
+ *               unless `relevant` holds exactly one id. Leave it off where the
+ *               gold set has no obvious winner - `text editor` has no business
+ *               claiming `emacs` beats `vim`.
  */
 
 import { execSync } from "node:child_process";
@@ -146,6 +159,62 @@ function reciprocalRank(ranked, relevant) {
     return 0;
 }
 
+// The one answer a user typing this query is most likely after, or `null` where
+// we decline to rank the gold set. A single-entry `relevant` needs no
+// annotation: with nothing to compare against, it is the best answer by
+// definition. Beyond that it takes an explicit `"best"`, so ordering claims are
+// only ever made where a curator wrote one down.
+function bestAnswer(q) {
+    if (q.best !== undefined) {
+        if (!q.relevant.includes(q.best)) {
+            throw new Error(`${q.id}: "best" ${q.best} is not in "relevant"`);
+        }
+        return q.best;
+    }
+    return q.relevant.length === 1 ? q.relevant[0] : null;
+}
+
+// Reciprocal rank of the best answer, rather than of the first relevant hit.
+//
+// MRR asks "did we surface something usable", which a cluster gold set answers
+// trivially: on `node`, every `nodejs*` variant is relevant, so MRR reads 1.000
+// whether `nodejs` or `nodejs-slim_26` came first. BestRR asks the ordinal
+// question instead - "did the answer they wanted come first" - and separates
+// those two pages 1.000 to 0.167.
+//
+// It collapses to MRR on a single-answer query, so it only speaks up on the
+// cluster queries it was added for. Returns `null` when the query makes no
+// ordinal claim, which drops it from the mean.
+function bestReciprocalRank(ranked, best) {
+    if (best === null) return null;
+    const i = ranked.indexOf(best);
+    return i === -1 ? 0 : 1 / (i + 1);
+}
+
+// Graded nDCG (Jarvelin & Kekalainen 2002) over two grades: the best answer
+// scores 2, any other relevant hit 1.
+//
+// Where BestRR prices one position, this prices the whole page against its ideal
+// ordering, so demoting a variant below the canonical package pays off even when
+// the canonical package was already first. A query with no best answer keeps a
+// flat grade of 1 across its gold set, which is ordinary binary nDCG - it still
+// scores, it just states no preference within the set.
+function ndcgAtK(ranked, q, k) {
+    const best = bestAnswer(q);
+    const grade = (id) => (id === best ? 2 : q.relevant.includes(id) ? 1 : 0);
+    const gain = (g, i) => g / Math.log2(i + 2);
+
+    const dcg = ranked
+        .slice(0, k)
+        .reduce((a, id, i) => a + gain(grade(id), i), 0);
+    const ideal = q.relevant
+        .map(grade)
+        .sort((a, b) => b - a)
+        .slice(0, k);
+    const idcg = ideal.reduce((a, g, i) => a + gain(g, i), 0);
+    return idcg > 0 ? dcg / idcg : 0;
+}
+
 function successAtK(ranked, relevant, k) {
     const rel = new Set(relevant);
     return ranked.slice(0, k).some((id) => rel.has(id)) ? 1 : 0;
@@ -225,6 +294,8 @@ async function scoreTrack(queries, bodyKey, field, prefix) {
             success: successAtK(ranked, q.relevant, K),
             recall: recallAtK(ranked, q.relevant, K),
             rbp: q.exhaustive ? conditionalRBP(ranked, q.relevant, P) : null,
+            bestrr: bestReciprocalRank(ranked, bestAnswer(q)),
+            ndcg: ndcgAtK(ranked, q, K),
         });
     }
     return results;
@@ -265,13 +336,17 @@ const table = (header, rows) =>
 
 // One `## <label>` section: Overall + By-category tables for a single track.
 function section(label, results) {
-    // RBP only covers the closed-set queries that returned something.
+    // RBP only covers the closed-set queries that returned something, BestRR
+    // only the ones that name a best answer.
     const closed = results.filter((r) => r.rbp !== null);
+    const ordinal = results.filter((r) => r.bestrr !== null);
     const overall = {
         success: mean(results.map((r) => r.success)),
         mrr: mean(results.map((r) => r.mrr)),
         recall: mean(results.map((r) => r.recall)),
         rbp: closed.length ? mean(closed.map((r) => r.rbp)) : null,
+        bestrr: ordinal.length ? mean(ordinal.map((r) => r.bestrr)) : null,
+        ndcg: mean(results.map((r) => r.ndcg)),
     };
     const byCategory = {};
     for (const r of results) {
@@ -295,6 +370,12 @@ function section(label, results) {
                     overall.rbp === null ? "-" : overall.rbp.toFixed(3),
                     closed.length,
                 ],
+                [
+                    "BestRR",
+                    overall.bestrr === null ? "-" : overall.bestrr.toFixed(3),
+                    ordinal.length,
+                ],
+                ["nDCG@" + K, overall.ndcg.toFixed(3), results.length],
             ],
         ),
         "",
@@ -308,13 +389,16 @@ function section(label, results) {
                 "MRR",
                 "Recall@" + K,
                 `RBP (p=${P})`,
+                "BestRR",
+                "nDCG@" + K,
             ],
             Object.entries(byCategory)
                 .sort(([a], [b]) => a.localeCompare(b))
                 .map(([cat, rs]) => {
-                    // Cluster gold sets move Recall and RBP, not Success/MRR, so a
-                    // category is unreadable without all four.
+                    // Cluster gold sets move Recall, RBP and BestRR, not
+                    // Success/MRR, so a category is unreadable without them all.
                     const rbps = rs.filter((r) => r.rbp !== null);
+                    const ords = rs.filter((r) => r.bestrr !== null);
                     return [
                         cat,
                         String(rs.length),
@@ -324,6 +408,10 @@ function section(label, results) {
                         rbps.length
                             ? `${mean(rbps.map((r) => r.rbp)).toFixed(3)} (n=${rbps.length})`
                             : "-",
+                        ords.length
+                            ? `${mean(ords.map((r) => r.bestrr)).toFixed(3)} (n=${ords.length})`
+                            : "-",
+                        mean(rs.map((r) => r.ndcg)).toFixed(3),
                     ];
                 }),
         ),
@@ -341,13 +429,20 @@ const perQuery = [
 const lines = [
     "# Relevance benchmark: frontend query vs deployed ES",
     "",
-    `> Index: \`${INDEX}\`. metrics: (Success@${K}, MRR, Recall@${K}, RBP(p=${P})).`,
+    `> Index: \`${INDEX}\`. metrics: (Success@${K}, MRR, Recall@${K}, RBP(p=${P}), BestRR, nDCG@${K}).`,
     "",
     `> \`RBP\` is rank-biased precision. It prices rank \`i\` at \`p^(i-1)\`. Junk near the`,
     `> top therefore costs more than junk near the bottom. The denominator is the page`,
     `> we returned, so a short page scores only on the hits it has. Pass`,
     `> \`--persistence\` to change \`p\`. Only a query with \`"exhaustive": true\` gets a`,
     "> score. A query with no hits drops out of the mean.",
+    "",
+    "> `BestRR` and `nDCG` grade the gold set instead of treating it as a flat",
+    "> set: the best answer counts double. `BestRR` is the reciprocal rank of that",
+    "> one answer, so it reads how well we order results a user considers",
+    "> comparably relevant, which `MRR` cannot see. It scores a query whose",
+    '> `relevant` holds one entry or which names a `"best"`, and drops the rest',
+    "> from the mean.",
     "",
     ...section("Packages", pkgResults),
     ...section("Options", optResults),
@@ -365,6 +460,8 @@ const lines = [
             "success",
             "mrr",
             "RBP",
+            "BestRR",
+            "nDCG",
             "matched",
             "top-3 ranked",
         ],
@@ -376,6 +473,8 @@ const lines = [
             r.success.toFixed(0),
             r.mrr.toFixed(3),
             r.rbp === null ? "-" : r.rbp.toFixed(3),
+            r.bestrr === null ? "-" : r.bestrr.toFixed(3),
+            r.ndcg.toFixed(3),
             r.matched + (r.matchedExact ? "" : "+"),
             r.ranked.slice(0, 3).join(", "),
         ]),


### PR DESCRIPTION
Add two benchmarking metrics that read the gold set as *ranked* rather than as a flat set:

- **`BestRR`**, the reciprocal rank of the one answer the query most wants. It collapses to `MRR` on a single-answer query, so it only speaks up on the cluster queries it was added for. It reads **0.167** on the `node` page above.
- **`nDCG@10`**, which grades a hit in tier `i` of `T` at `T - i`, pricing the whole page against its ideal ordering rather than one position.

To express the ranking, `relevant` becomes a list of tiers, each tier a list of ids tied at that rank. Order *between* tiers is a claim, order *within* one is not: `[[a, b, c]]` states no preference, `[[a], [b], [c]]` is a strict order, and `[[a], [b, c]]` is a best answer followed by a tie. The best answer is the top tier's single id, or nothing at all where that tier is a tie - so ordering claims are only ever made where a curator wrote one down, which keeps them off the queries that cannot support one. `text editor` has no business ranking `emacs` over `vim`, and `container runtime` has no business ranking `docker` over `podman`. A query stating no preference drops out of the `BestRR` mean and keeps a flat gold set under `nDCG`, which is then ordinary binary nDCG.

The annotated groups are settled rather than judgment calls: packages where the query names a package and the gold set is that package plus its variants (`postgres` wants `postgresql`, `dcoker` wants `docker`), options where the query names a module and the gold set is its cluster with the `enable` option first - the thesis of #1512, and version families where the tiers are the releases, newest first (`nextcl` wants `nextcloud34`). Coverage lands at 85/99 package queries and 164/175 option queries. `intent` queries are left unannotated throughout.

| track | Success@10 | MRR | Recall@10 | RBP (p=0.8) | BestRR | nDCG@10 |
| --- | --- | --- | --- | --- | --- | --- |
| packages (n=99) | 0.768 | 0.659 | 0.715 | 0.675 (n=22) | 0.698 (n=85) | 0.660 |
| options (n=175) | 0.663 | 0.513 | 0.483 | 0.301 (n=92) | 0.531 (n=164) | 0.433 |

Closes #1515.

Assisted-by: Claude:claude-opus-5
