### PR TITLE
feat: show failure summary for flake PR check as well

### DIFF
--- a/.github/workflows/check-flake-files.yml
+++ b/.github/workflows/check-flake-files.yml
@@ -34,7 +34,7 @@ jobs:
           do
             echo "::group::Group \"$(basename $flake_group .toml)\""
 
-            nix run --accept-flake-config .#flake-info -- --json group "$flake_group" "$(basename "$flake_group" .toml)" --report --with-gc
+            nix run --accept-flake-config .#flake-info -- --json --save-summary $GITHUB_STEP_SUMMARY group "$flake_group" "$(basename "$flake_group" .toml)" --report --with-gc
 
             if [[ -f "./report.txt" ]]
             then


### PR DESCRIPTION
I just now noticed that we have some duplicate functionality between `--save-summary` and `--report`, but `--report` doesn't seem to work AFAICT(?). To investigate and deduplicate later.