### PR TITLE
frontend: improve keyboard navigation of buttons 

### DIFF
--- a/frontend/src/scss/_mixins.scss
+++ b/frontend/src/scss/_mixins.scss
@@ -5,7 +5,16 @@
   padding: 0;
 
   input[type="radio"] {
-    display: none;
+    position: absolute;
+    opacity: 0;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+  }
+
+  label:has(:focus-visible) {
+    outline: 2px solid var(--dark-blue);
+    outline-offset: -2px;
   }
 }
 

--- a/frontend/src/scss/components/button.scss
+++ b/frontend/src/scss/components/button.scss
@@ -17,12 +17,13 @@
   text-shadow: 0 1px 1px hsla(0,0%,100%,.75);
   vertical-align: middle;
 
-  &.active, &.disabled, &:active, &:focus, &:hover, &[disabled] {
+  &.active, &.disabled, &:active, &:focus, &:has(:focus-visible), &:hover, &[disabled] {
     background-color: #e6e6e6;
     color: #333
   }
 
   &:focus,
+  &:has(:focus-visible),
   &:hover {
     background-position: 0 -15px;
     color: #333;


### PR DESCRIPTION
This PR 

- makes the channel selection radio buttons keyboard-focusable
- adds a ring border to the radio button selection items on keyboard focus
- treats keyboard focus as hover on the `Sort:` selection button

Assisted-By: Gemini 3.7 Flash

<details>
<summary>Copilot summary:</summary>

This pull request focuses on improving accessibility and user experience for form elements and buttons in the frontend styles. The main changes enhance keyboard navigation and visual feedback for focused elements.

**Accessibility and focus improvements:**

* In `_mixins.scss`, updated radio inputs to be visually hidden but still accessible for screen readers and keyboard navigation by setting them to `position: absolute`, `opacity: 0`, and minimal size. Also, added a style so that labels containing a focused input (`:has(:focus-visible)`) receive a visible outline for better accessibility.
* In `button.scss`, improved button focus states by adding styles for `:has(:focus-visible)` to ensure buttons show appropriate visual feedback when focused, enhancing accessibility for keyboard users.

</details>