### PR TITLE
fix(ci): let --save-summary work without --elastic-schema-version

### DIFF
--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -36,8 +36,7 @@ struct Args {
 
     #[structopt(
         long = "save-summary",
-        help = "Save markdown summary of failures to this file",
-        requires("elastic-schema-version")
+        help = "Save markdown summary of failures to this file"
     )]
     save_summary: Option<String>,
 
@@ -608,4 +607,35 @@ async fn push_to_elastic(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `--save-summary` writes a markdown file and never touches elasticsearch, so it
+    /// must not require `--elastic-schema-version`. This is the invocation shape used
+    /// by the `Check Flake Groups` workflow.
+    #[test]
+    fn save_summary_without_schema_version() {
+        let args = Args::from_iter_safe([
+            "flake-info",
+            "--json",
+            "--save-summary",
+            "s.md",
+            "group",
+            "f.toml",
+            "name",
+            "--report",
+            "--with-gc",
+        ]);
+        assert!(args.is_ok(), "{:?}", args.err());
+    }
+
+    /// `--push` does read `elastic_schema_version`, so it keeps demanding one.
+    #[test]
+    fn push_requires_schema_version() {
+        let args = Args::from_iter_safe(["flake-info", "--push", "group", "f.toml", "name"]);
+        assert!(args.is_err());
+    }
 }


### PR DESCRIPTION
The `Check Flake Groups` job has failed on every `flakes/**.toml` PR since #1521 added `--save-summary $GITHUB_STEP_SUMMARY` to `.github/workflows/check-flake-files.yml`. That job runs `--json` and never `--push`, so it has no schema version to pass, and clap rejects the invocation before any work happens:

```
error: The following required arguments were not provided:
    --elastic-schema-version <elastic-schema-version>
```

Latest failure, on #1525 (whose only change is `flakes/manual.toml`): https://github.com/NixOS/nixos-search/actions/runs/31910644680

`--save-summary` had picked up `requires("elastic-schema-version")` as a copy of the constraint on `--push`, where it is genuine: `push_to_elastic` calls `elastic.elastic_schema_version.unwrap()`. Writing a markdown summary of failures reads no elasticsearch config, so the constraint is dropped here. The one on `--push` stays.

Two tests cover the CLI contract: the workflow's invocation shape parses, and `--push` still demands a schema version. `flake-info/default.nix` runs `cargo test`, so the `Build flake-info` workflow catches a regression.

Follow-up, not addressed here: #1521 notes that `--save-summary` and `--report` overlap and that `--report` may not work.

Assisted-by: Claude:claude-opus-5