### PR TITLE
fix: make programs with capital letters searchable

### DIFF
--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -98,7 +98,14 @@ lazy_static! {
                     "type": "keyword"
                 },
                 "package_programs": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "normalizer": "lowercase",
+                    "fields": {"edge": {"type": "text", "analyzer": "edge"}},
+                },
+                "package_mainProgram": {
+                    "type": "keyword",
+                    "normalizer": "lowercase",
+                    "fields": {"edge": {"type": "text", "analyzer": "edge"}},
                 },
                 "package_description": {
                     "type": "text",

--- a/frontend/benchmark/queries-packages.json
+++ b/frontend/benchmark/queries-packages.json
@@ -753,5 +753,29 @@
             "pkg:nodejs_22",
             "pkg:nodejs_20"
         ]
+    },
+    {
+        "id": "g153",
+        "q": "Dicomizer",
+        "category": "exact",
+        "relevant": ["pkg:weasis"]
+    },
+    {
+        "id": "g154",
+        "q": "LibreVNA-GUI",
+        "category": "exact",
+        "relevant": ["pkg:librevna"]
+    },
+    {
+        "id": "g155",
+        "q": "nfcDemoApp",
+        "category": "exact",
+        "relevant": ["pkg:libnfc-nci"]
+    },
+    {
+        "id": "g156",
+        "q": "yodaStruct",
+        "category": "exact",
+        "relevant": ["pkg:d-seams"]
     }
 ]

--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -89,12 +89,13 @@ packagesBody query from size sort selectedBuckets =
         [ "package_attr_name" ]
         [ ( "package_attr_name", 9.0 )
         , ( "package_programs", 9.0 )
+        , ( "package_mainProgram", 9.0 )
         , ( "package_pname", 6.0 )
         , ( "package_description", 1.3 )
         , ( "package_longDescription", 1.0 )
         , ( "flake_name", 0.5 )
         ]
-        [ "package_attr_name", "package_pname", "package_programs" ]
+        [ "package_attr_name", "package_pname", "package_programs", "package_mainProgram" ]
         [ "package_description^3", "package_longDescription^1" ]
         Nothing
         [ { field = "package_repology_repos", pivot = 20.0 }

--- a/version.nix
+++ b/version.nix
@@ -4,7 +4,7 @@
   # When making backwards-incompatible schema changes,
   # change the code for the import job first, updating this version number.
   # Only after the new index has been populated, update the frontend.
-  import = "50";
+  import = "51";
 
   # Frontend index version used by the UI when querying Elasticsearch
   # Keep this at the old version while 'import' populates a new index, then update to switch traffic


### PR DESCRIPTION
Fixes #1524.

Searching for a name listed under *Programs provided* returns "No packages found!" whenever that program name contains an upper-case letter. Reproducers from the issue thread: `Dicomizer` (from `weasis`), `LibreVNA-GUI` (from `librevna`). Lower-case program names (`showfoto`, `odasrv`) work fine. 902 packages in `nixos-unstable` have at least one program name containing a capital letter.

This is not a regression -- `package_programs` has been a bare keyword since #610, and `String.toLower query` predates it (#538). Capitalised program names have never been searchable.

## Root cause

Two facts combine:

1. `flake-info/src/elastic.rs` maps the field as a bare keyword with no normalizer and no subfields. Values are indexed verbatim from the derivation, so `Dicomizer` is stored as `Dicomizer`. Every sibling name field (`package_attr_name`, `package_pname`, `package_attr_set`) carries an `.edge` subfield whose analyzer applies the `lowercase` filter; `package_programs` carries nothing.
2. `frontend/src/Search/Query.elm` lower-cases the whole user query before building any clause. `package_programs` is only reachable through the `cross_fields` and fuzzy `multi_match` clauses. Neither supports `case_insensitive`, and the `package_programs.*` field expansion resolves to nothing because there are no subfields. The `wildcard` and `prefix` clauses that *do* set `case_insensitive: true` run against `mainFields`, which for packages is `[ "package_attr_name" ]` only.

Net effect: a lower-cased query term can never match a keyword term containing capitals.

Against the live index today:

| query | hits |
|---|---|
| `{"term": {"package_programs": "Dicomizer"}}` | 1 (`weasis`) |
| `{"term": {"package_programs": "dicomizer"}}` | 0 |
| `{"term": {"package_programs": {"value": "dicomizer", "case_insensitive": true}}}` | 1 (`weasis`) |

## Why not fix this in the frontend

`multi_match` has no `case_insensitive` option, so a frontend-only fix means adding per-word `term`/`wildcard` clauses on `package_programs`. Those land in the single `dis_max` under `must`, where any one alternative matching satisfies the whole clause. A per-word clause would therefore make a two-word query match documents that only match one of the words through a program name -- a relevance regression. The mapping is the right place.

## Change

`package_programs` gets the `lowercase` normalizer, which was already defined in the index settings and referenced by zero fields -- it was evidently added for exactly this purpose. A normalizer rewrites only the indexed terms, not `_source`, so `Page/Packages.elm` keeps rendering the original capitalisation under *Programs provided*, and the `mainProgram` bolding comparison is unaffected. Neither field is used in an aggregation, sort, or `docvalue_fields` request.

A mapping change forces a reindex, so two adjacent gaps in program search ride along in the same schema bump:

- **No prefix matching on program names.** `searchFields` already emits `package_programs.*^5.4`, but it resolved to nothing because the field had no subfields. An `.edge` subfield (as on `package_pname`) makes that expansion meaningful.
- **`package_mainProgram` was not searchable at all.** It had no explicit mapping, so Elasticsearch dynamically mapped it as `text` + `.keyword`, and `Query.elm` never queried it. 7430 packages in `nixos-unstable` have a `mainProgram` but an empty `package_programs` (the `programs.sqlite` database does not cover them); those are the ones rendered as "Only the main program of this package is known". Their program names were unreachable by any query.

`version.nix` bumps `import` to `51`, leaving `frontend` at `50`, per the documented two-step: the import job populates index 51 while the UI keeps serving 50, and a follow-up PR flips `frontend` to `51` once the new index is live.

## Verification

Verified end-to-end against the ephemeral OpenSearch VM (`nix run .#opensearch-vm`), with the index created from the real `MAPPING` in the built `flake-info` binary, plus an exact replica of the pre-change index as a control. The queries are the real bodies `Query.elm` produces, generated through `benchmark/run.mjs`:

| query | pre-change index | post-change index |
|---|---|---|
| `Dicomizer` | 0 hits | `weasis` @1 |
| `dicomizer` | 0 hits | `weasis` @1 |
| `LibreVNA-GUI` | `librevna` @1 | `librevna` @1 |
| `ZaphodBeeblebrox` (`mainProgram`, empty `programs`) | `some-obscure-attr` @1 | `some-obscure-attr` @1 |
| `showfoto` (lower-case control) | `digikam` @1 | `digikam` @1 |

`_source` still returns `["Dicomizer", "Weasis"]` on the post-change index, confirming the normalizer changed the indexed terms but not the stored document.

## Relevance impact of the `Query.elm` change

The `Query.elm` change is not inert before the frontend bump: `package_mainProgram` is dynamically mapped as `text` on index 50, so querying it already makes main programs searchable. Full 103-query benchmark against live index 50, with and without the `Query.elm` change:

| metric | without | with |
|---|---|---|
| Success@10 | 0.738 | **0.767** |
| MRR | 0.634 | **0.659** |
| Recall@10 | 0.687 | **0.720** |
| RBP (p=0.8, n=22) | 0.659 | 0.598 |

The RBP dip is confined to typo queries (`chromiun`, `fial2ban`, `cady`, `tailscle`). The correct package still ranks #1 in every one of them -- success and MRR are unchanged -- but extra loosely-related packages join the top-10. The cause is fuzzy matching against the *tokenized* dynamic `text` mapping (`chromium-bsu` -> `["chromium", "bsu"]`, which `chromiun~1` reaches). On index 51 `package_mainProgram` is a keyword, so that path closes.

Dropping `package_mainProgram` from `fuzzyFieldNames` was measured as an alternative: RBP recovers to 0.660, but `LibreVNA-GUI` then misses on index 50, and it leaves `package_mainProgram` inconsistent with `package_programs`. Keeping it is the better trade.

## Benchmark cases

Four entries added, two of which fail today:

- `g153 Dicomizer -> weasis` and `g155 nfcDemoApp -> libnfc-nci` -- currently 0 hits; the `package_programs` normalizer cases.
- `g154 LibreVNA-GUI -> librevna` and `g156 yodaStruct -> d-seams` -- currently reachable only via the new `package_mainProgram` field; `d-seams` shares nothing with `yodaStruct`, so it isolates that field cleanly.

The benchmark runs against the *frontend* schema version, so the two `package_programs` cases will report as misses until the follow-up frontend bump lands -- that is the intended signal.

## Follow-up

Once the 2-hourly import has populated index 51, re-run the benchmark against it (`node frontend/benchmark/run.mjs --schema 51`) to confirm the RBP dip closes, then open the PR bumping `frontend` to `51`.

Assisted-by: Claude:claude-opus-5
