### PR TITLE
frontend: update index schema version to 51

### DIFF
--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -360,38 +360,54 @@ shouldClauses primaryField positiveWords phraseFields =
 
     else
         let
-            joined : String
-            joined =
-                String.concat positiveWords
-
-            termClause : List ( String, Json.Encode.Value )
-            termClause =
-                [ ( "term"
-                  , Json.Encode.object
-                        [ ( primaryField
-                          , Json.Encode.object
-                                [ ( "value", Json.Encode.string joined )
-                                , ( "boost", Json.Encode.float 100.0 )
-                                ]
-                          )
-                        ]
-                  )
+            -- `primaryField` is a keyword, so a multi-word query only reaches an
+            -- attribute name once the words are glued back together. Package names
+            -- separate words with `-` or `_` as often as they concatenate, and no
+            -- analysed field splits those apart, so try all three spellings.
+            joinedVariants : List String
+            joinedVariants =
+                [ String.concat positiveWords
+                , String.join "-" positiveWords
+                , String.join "_" positiveWords
                 ]
+                    |> List.Extra.unique
 
-            prefixClause : List ( String, Json.Encode.Value )
-            prefixClause =
-                [ ( "prefix"
-                  , Json.Encode.object
-                        [ ( primaryField
-                          , Json.Encode.object
-                                [ ( "value", Json.Encode.string joined )
-                                , ( "boost", Json.Encode.float 20.0 )
-                                , ( "case_insensitive", Json.Encode.bool True )
-                                ]
-                          )
-                        ]
-                  )
-                ]
+            termClauses : List (List ( String, Json.Encode.Value ))
+            termClauses =
+                joinedVariants
+                    |> List.map
+                        (\joined ->
+                            [ ( "term"
+                              , Json.Encode.object
+                                    [ ( primaryField
+                                      , Json.Encode.object
+                                            [ ( "value", Json.Encode.string joined )
+                                            , ( "boost", Json.Encode.float 100.0 )
+                                            ]
+                                      )
+                                    ]
+                              )
+                            ]
+                        )
+
+            prefixClauses : List (List ( String, Json.Encode.Value ))
+            prefixClauses =
+                joinedVariants
+                    |> List.map
+                        (\joined ->
+                            [ ( "prefix"
+                              , Json.Encode.object
+                                    [ ( primaryField
+                                      , Json.Encode.object
+                                            [ ( "value", Json.Encode.string joined )
+                                            , ( "boost", Json.Encode.float 20.0 )
+                                            , ( "case_insensitive", Json.Encode.bool True )
+                                            ]
+                                      )
+                                    ]
+                              )
+                            ]
+                        )
 
             phraseClause : List (List ( String, Json.Encode.Value ))
             phraseClause =
@@ -418,7 +434,7 @@ shouldClauses primaryField positiveWords phraseFields =
                 else
                     []
         in
-        termClause :: prefixClause :: phraseClause
+        termClauses ++ prefixClauses ++ phraseClause
 
 
 moduleEntryPoint : String -> List String -> List (List ( String, Json.Encode.Value ))

--- a/version.nix
+++ b/version.nix
@@ -8,5 +8,5 @@
 
   # Frontend index version used by the UI when querying Elasticsearch
   # Keep this at the old version while 'import' populates a new index, then update to switch traffic
-  frontend = "50";
+  frontend = "51";
 }


### PR DESCRIPTION
Completes the two-step rollout begun in #1528. That PR bumped `import` to 51 and deliberately left `frontend` at 50 so the new index could be populated first; this PR points the UI at it, which is what actually makes the fix for #1524 visible to users. Searching `Dicomizer` on search.nixos.org still returns "No packages found!" until this lands.

The second commit is a query fix that the benchmark turned up while validating the bump -- see below.

## Gate

The 16:05 UTC import run was the first on `import = "51"`. Before flipping, all three aliases the frontend can query had to exist, since it builds index names as `latest-<frontend>-<branch>`:

```
latest-51-nixos-unstable   nixos-51-unstable-e5bdc4a41d4c072fe1e3787eaa0320a384741d44
latest-51-nixos-26.05      nixos-51-26.05-02e08985a27c65ffd33d434eeb2e660a2e4dc84d
latest-51-group-manual     group-51-manual-e129196f6e5ea4f6e9f8985ca0518dd33faa29b8da4a9069c4de40de58b930d1
```

The mapping landed as intended -- both fields are now `keyword` with the `lowercase` normalizer and an `edge` subfield, and `package_mainProgram` is no longer the dynamically mapped `text` + `.keyword` pair it was on 50:

```json
"package_programs":    {"type": "keyword", "normalizer": "lowercase", "fields": {"edge": {"type": "text", "analyzer": "edge"}}},
"package_mainProgram": {"type": "keyword", "normalizer": "lowercase", "fields": {"edge": {"type": "text", "analyzer": "edge"}}}
```

The normalizer rewrites indexed terms only, so stored data keeps its original capitalisation. Querying `{"term": {"package_programs": "dicomizer"}}` returns `weasis` with `_source.package_programs` still `["Weasis", "Dicomizer"]`.

## Benchmark

`.github/workflows/benchmark.yml` does not trigger on `version.nix`, so these were run locally. Against `latest-51-nixos-unstable`, versus the index 50 baseline:

| packages (103 q) | Success@10 | MRR | Recall@10 | RBP (p=0.8, n=22) |
| --- | --- | --- | --- | --- |
| 50 baseline | 0.767 | 0.659 | 0.720 | 0.598 |
| 51 | 0.786 | 0.675 | 0.738 | 0.656 |
| 51 + query fix | **0.806** | **0.707** | **0.757** | **0.656** |

| options (175 q) | Success@10 | MRR | Recall@10 | RBP (p=0.8, n=92) |
| --- | --- | --- | --- | --- |
| 50 baseline | 0.663 | 0.513 | 0.483 | 0.301 |
| 51 + query fix | 0.663 | 0.513 | 0.483 | 0.301 |

The options track is identical to three decimals, as expected for a change confined to package fields.

Both target queries are fixed: `Dicomizer -> weasis` and `nfcDemoApp -> libnfc-nci` each go from zero matches to rank 1. The packages RBP dip documented in #1528 closed, since `package_mainProgram` is no longer tokenized and so no longer pulls unrelated packages onto typo result pages -- `chromiun` 0.738 -> 1.000, `fial2ban` 0.556 -> 1.000, `cady` 0.556 -> 1.000.

### Why the second commit

Index 50 and 51 were built from the same evaluation on the 26.05 channel (`02e08985`) but different ones on unstable, so I re-ran the comparison on 26.05 to separate the mapping from two hours of nixpkgs drift. Every delta reproduced, and no option query changed at all -- so the movement is the mapping, not the corpus.

That isolated run showed the bump alone regressing multiterm MRR, 0.356 -> 0.315:

- `docker compose` dropped `docker-compose` from rank 5 to rank 13, off the first page entirely.
- `paperless ngx` dropped `paperless-ngx` from rank 1 to rank 3.

Both losers have a hyphenated `package_mainProgram`. While it was dynamically mapped as `text` it was the only analysed field that split those names into separate tokens, which is what let a two-word query match them. `attr_path` splits on `.` only, and `edge` keeps punctuation inside the token, so its ngrams cover `docker` but never `compose`. Giving the field an explicit keyword mapping was right, but it removed that path.

`shouldClauses` already glued the query words back together and tried the result as a term and a prefix, in its concatenated spelling only (`dockercompose`). The fix also tries the `-` and `_` joins, which is how attribute names are spelled at least as often. On the fixed 26.05 corpus that takes multiterm to 0.692 / 0.572 / 0.631, well above the 50 baseline of 0.538 / 0.356 / 0.477, and it lifts every headline package metric.

Net per-query effect against the 50 baseline, same corpus: 12 queries improve, 1 moves mixed. `docker compose`, `matrix synapse` and `home assistant` all reach rank 1, the last two from having missed the first page on 50.

The one non-improvement is `node`, whose RBP goes 0.573 -> 0.535 while Success@10 and MRR both stay at 1.000 -- the relevant `nodejs*` packages hold their positions and the page composition below them shifts slightly. It is the sole reason the `exact` category RBP reads 0.564 -> 0.557 (n=6); that same category's Success, MRR and Recall rise from 0.905 / 0.905 / 0.892 to 1.000 / 1.000 / 0.979.

Since this PR touches `Query.elm`, the benchmark workflow will also run in CI.

## Checks

`nix fmt -- --fail-on-change` reports 0 changed, and `nix build .#frontend` succeeds.

## After merge

Worth confirming on search.nixos.org once Netlify deploys: `Dicomizer` returns `weasis` and `LibreVNA-GUI` returns `librevna`; `nfcDemoApp` returns `libnfc-nci` and `yodaStruct` returns `d-seams`, covering the new `package_mainProgram` mapping; the `weasis` package page still lists *Programs provided* as `Dicomizer` and `Weasis` with original capitalisation, with `Weasis` bolded as the main program; and the 26.05 channel and Flakes tab both work, since those query the other two aliases.

Assisted-by: Claude:claude-opus-5
