### PR TITLE
feat(flake): github:rat-nix/open5gs.nix, github:rat-nix/ueransim.nix, github:rat-nix/free5gc.nix

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -462,6 +462,21 @@ repo = "srsran.nix"
 
 [[sources]]
 type = "github"
+owner = "rat-nix"
+repo = "open5gs.nix"
+
+[[sources]]
+type = "github"
+owner = "rat-nix"
+repo = "ueransim.nix"
+
+[[sources]]
+type = "github"
+owner = "rat-nix"
+repo = "free5gc.nix"
+
+[[sources]]
+type = "github"
 owner = "ryantm"
 repo = "agenix"
 

--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -216,11 +216,6 @@ repo = "eza"
 
 [[sources]]
 type = "github"
-owner = "felbinger"
-repo = "srsran.nix"
-
-[[sources]]
-type = "github"
 owner = "fort-nix"
 repo = "nix-bitcoin"
 
@@ -459,6 +454,11 @@ repo = "pyproject.nix"
 type = "github"
 owner = "pyproject-nix"
 repo = "uv2nix"
+
+[[sources]]
+type = "github"
+owner = "rat-nix"
+repo = "srsran.nix"
 
 [[sources]]
 type = "github"


### PR DESCRIPTION
The srsran.nix repository got moved into the organization https://github.com/rat-nix

I also started creating nixos modules for open5gs and free5gc, which implement core network components for 5g and ueransim which simulates the radio access network of 5g.

As with srsran I'm not planning of contributing the modules their, because it's a niche module most users don't need.

If you think that the flake lacks relevance (which may be true), feel free to close this pr.