### PR TITLE
Benchmark: allow targeting a concrete index

### DIFF
--- a/frontend/benchmark/run.mjs
+++ b/frontend/benchmark/run.mjs
@@ -5,7 +5,11 @@
  * scores curated queries against our live ES instance.
  *
  * Usage:
- *   node benchmark/run.mjs [--packages <path>] [--options <path>] [--channel <branch>] [--schema <n>] [--k <n>] [--persistence <f>]
+ *   node benchmark/run.mjs [--packages <path>] [--options <path>] [--channel <branch>] [--schema <n>] [--index <name>] [--k <n>] [--persistence <f>]
+ *
+ * `--index` names a concrete index instead of the `latest-<schema>-<channel>`
+ * alias, which pins an A/B to one nixpkgs evaluation once the alias has moved
+ * on to a newer one.
  *
  * Each curated query is an object:
  *
@@ -58,6 +62,7 @@ const { values: args } = parseArgs({
         },
         channel: { type: "string", default: "nixos-unstable" },
         schema: { type: "string" },
+        index: { type: "string" },
         k: { type: "string", default: "10" },
         persistence: { type: "string", default: "0.8" },
     },
@@ -68,7 +73,7 @@ const { values: args } = parseArgs({
 const K = parseInt(args.k, 10);
 const P = parseFloat(args.persistence);
 const SCHEMA = args.schema ?? frontendSchema();
-const INDEX = `latest-${SCHEMA}-${args.channel}`;
+const INDEX = args.index ?? `latest-${SCHEMA}-${args.channel}`;
 const ES_URL =
     process.env.ELASTICSEARCH_URL || "https://search.nixos.org/backend";
 const ES_USER = process.env.ELASTICSEARCH_USERNAME || "aWVSALXpZv";


### PR DESCRIPTION
`run.mjs` always queried the `latest-<schema>-<channel>` alias, so an index the alias no longer points at was unreachable. `--index` names one directly, which pins an A/B to a single nixpkgs evaluation once the alias has moved on.

Default behaviour is unchanged, and CI re-runs the benchmark against `latest-51-nixos-unstable` through the default path, which is the regression test for the flag itself.

The flag is the only code change. Its justification is the measurement below, which it made possible.

## Why now

The mapping change and the `Query.elm` `-`/`_` join change shipped together, so neither was ever reported on its own, and the numbers at the time predated ranked tiers, `BestRR` and `nDCG@10`. Both changes can still be isolated, because the same nixpkgs evaluation exists as a concrete index under both schema versions:

```
nixos-50-26.05-02e08985a27c65ffd33d434eeb2e660a2e4dc84d   built 2026-08-14T22:07Z
nixos-51-26.05-02e08985a27c65ffd33d434eeb2e660a2e4dc84d   built 2026-08-16T16:07Z
```

Both hold 458313 docs. The only import-side commits between the two builds are the mapping and a CI argument-handling change with no effect on indexed content, so the delta between the pair is the mapping and nothing else. `{"term": {"package_programs": "dicomizer"}}` returns `weasis` on the 51 index and zero hits on the 50 index.

The 51 copy is unaliased and the Monday prune deletes it, after which index 50 stays frozen at its 2026-08-14 evaluation while 51 tracks nixpkgs, so no controlled pair remains.

## Setup

Four runs, all against evaluation `02e08985`, all with today's benchmark code and tiered gold sets. The query-side arms are `main` with the `Query.elm` change reverted.

| arm | index | `Query.elm` |
| --- | --- | --- |
| A | 50 | reverted |
| B | 51 | reverted |
| C | 50 | `main` |
| D | 51 | `main` |

Each report header records its index, and all four agree on `k=10`. `Dicomizer` returns nothing in arms A and C and `weasis` in arms B and D, as expected.

## Overall, packages track (103 queries)

| metric | A | B | C | D | B-A (mapping) | C-A (query, old mapping) | D-B (query, new mapping) | D-A (shipped) |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Success@10 | 0.757 | 0.777 | 0.777 | 0.796 | +0.019 | +0.019 | +0.019 | +0.039 |
| MRR | 0.650 | 0.665 | 0.677 | 0.698 | +0.016 | +0.027 | +0.032 | +0.048 |
| RBP | 0.614 | 0.669 | 0.614 | 0.669 | +0.055 | 0.000 | 0.000 | +0.055 |
| BestRR | 0.695 | 0.700 | 0.727 | 0.737 | +0.005 | +0.031 | +0.037 | +0.042 |
| nDCG@10 | 0.654 | 0.666 | 0.679 | 0.696 | +0.013 | +0.025 | +0.029 | +0.042 |

Both changes are positive on their own and the shipped combination is the best of the four. They also barely overlap: the mapping carries all of the `RBP` gain and none of the multiterm gain, the query change carries all of the multiterm gain and moves nothing else at all.

## Options track: the control

All 175 option queries score identically in all four arms, per-query and top-3 included. The corpus pair is as controlled as the index names suggest.

## nDCG@10 by category, packages

| category | n | A | B | C | D | B-A | C-A | D-B | D-A |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| exact | 21 | 0.846 | 0.935 | 0.846 | 0.935 | +0.089 | 0.000 | 0.000 | +0.089 |
| intent | 24 | 0.188 | 0.191 | 0.188 | 0.191 | +0.003 | 0.000 | 0.000 | +0.003 |
| multiterm | 13 | 0.392 | 0.360 | 0.593 | 0.590 | -0.033 | +0.201 | +0.231 | +0.198 |
| prefix | 22 | 0.909 | 0.901 | 0.909 | 0.901 | -0.007 | 0.000 | 0.000 | -0.007 |
| typo | 23 | 0.869 | 0.866 | 0.869 | 0.866 | -0.003 | 0.000 | 0.000 | -0.003 |

`BestRR` on multiterm tells the same story more sharply: A 0.386, B 0.331, C 0.619, D 0.608, so `C-A` is +0.233 and `D-B` is +0.278.

## The interaction: the causal story does not hold

The claim was that `docker compose` reached `docker-compose` only because `package_mainProgram` had been dynamically mapped as `text`, which predicts the query change barely moves multiterm in arm C.

It moves it almost as much as in arm D: +0.201 versus +0.231 on `nDCG@10`, +0.233 versus +0.278 on `BestRR`. The fix stands on its own. What the mapping did was make multiterm worse (-0.033), so arm D simply had slightly more to recover.

Per query, multiterm `nDCG@10`:

| id | q | A | B | C | D | reading |
| --- | --- | --- | --- | --- | --- | --- |
| g103 | `home assistant` | 0.000 | 0.000 | 1.000 | 1.000 | query change alone, mapping irrelevant |
| g104 | `matrix synapse` | 0.000 | 0.500 | 1.000 | 1.000 | both help, query change sufficient |
| g105 | `docker compose` | 0.387 | 0.000 | 1.000 | 1.000 | mapping broke it, query change fixes it either way |
| g108 | `paperless ngx` | 1.000 | 0.500 | 1.000 | 1.000 | mapping regressed it, query change restores it |
| g107 | `next cloud` | 0.568 | 0.530 | 0.568 | 0.530 | mapping regression the query change does not reach |

`docker compose` is the sharpest case. Without the query change the mapping took it from rank 5 to nothing on the page; with the query change `docker-compose` is rank 1 under both mappings. So the mapping did make the failure worse, but it did not create the need for the fix.

## The typo cluster

`chromiun`, `fial2ban` and `cady` were credited to `package_mainProgram` no longer being tokenized. Measured as a pure `B-A` contrast, that holds: `RBP` 0.738 -> 1.000, 0.556 -> 1.000, 0.556 -> 1.000, with `C-A` and `D-B` at zero for all three. Typo `RBP` overall is +0.095 from the mapping and +0.000 from the query change.

Note the split within the category: typo `RBP` is up +0.095 while typo `nDCG@10` is down -0.003 and `BestRR` down -0.011. The mapping cleans noise off closed-set typo pages without improving where the best answer sits.

## The `node` verdict

`node` was the one query flagged as an unexplained regression, and it is the mapping alone: identical in A versus C and in B versus D.

| metric | index 50 | index 51 |
| --- | --- | --- |
| Success@10 | 1.000 | 1.000 |
| MRR | 1.000 | 1.000 |
| BestRR | 0.167 | 0.167 |
| RBP | 1.000 | 0.885 |
| nDCG@10 | 0.850 | 0.714 |

The full page, now that the tiers grade it:

```
50: nodejs_22, nodejs_26, nodejs-slim, nodejs-slim_22, nodejs-slim_26,
    nodejs, nodejs_24, nodejs-slim_24, nodejs_latest, nodejs-slim_latest
51: nodejs_22, nodejs_26, nodejs-slim, nodejs-slim_22, nodejs-slim_26,
    nodejs, nodejs_24, nodeenv, nodenv, nodehun
```

The page did get worse, and it is a tail effect. Ranks 1 through 7 are unchanged, `nodejs` sits at rank 6 in both, which is why `Success`, `MRR` and `BestRR` cannot see it. Ranks 8 through 10 lose `nodejs-slim_24`, `nodejs_latest` and `nodejs-slim_latest` to `nodeenv`, `nodenv` and `nodehun`, which are not the same software. The match set grows from 285 to 302.

## Other movement from the mapping

Wins, all pure `B-A`:

- `Dicomizer` -> `weasis` and `nfcDemoApp` -> `libnfc-nci`, both 0.000 -> 1.000. These are what the mapping was for.
- `exact` `BestRR` +0.095 and `nDCG@10` +0.089 overall.

Regressions, also pure `B-A`, all in the versioned nextcloud family, where the mapping reorders near-identical variants and the gold set names the newest:

- `nextcl`: `nextcloud34, nextcloud32, nextcloud33` -> `nextcloud32, nextcloud33, nextcloud34`, `BestRR` 1.000 -> 0.333.
- `nextcoud`: `BestRR` 0.500 -> 0.250.
- `next cloud`: `nDCG@10` 0.568 -> 0.530.

## Summary

- The mapping on its own is a net win (`nDCG@10` +0.013, `RBP` +0.055) driven by exact-match and typo pages, at the cost of a multiterm regression (-0.033), the `node` tail, and a nextcloud-variant reorder.
- The query change on its own is a net win (`nDCG@10` +0.025) confined entirely to multiterm, and it works with or without the mapping.
- The two are close to independent, and shipping them together was right even though the reasoning given at the time was not.

Assisted-by: Claude:claude-opus-5
