### PR TITLE
frontend/search: rank a program-name match below the package name

### DIFF
--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -88,8 +88,8 @@ packagesBody query from size sort selectedBuckets =
         filterByBuckets
         [ "package_attr_name" ]
         [ ( "package_attr_name", 9.0 )
-        , ( "package_programs", 9.0 )
-        , ( "package_mainProgram", 9.0 )
+        , ( "package_programs", 8.0 )
+        , ( "package_mainProgram", 8.0 )
         , ( "package_pname", 6.0 )
         , ( "package_description", 1.3 )
         , ( "package_longDescription", 1.0 )


### PR DESCRIPTION
`package_programs` and `package_mainProgram` were both weighted 9.0, tied with `package_attr_name`. But `package_attr_name` is a `keyword`, so a partial query like `node` can only reach its `.edge` subfield at the 0.6 multiplier (5.4), whereas the two program fields are bare `keyword`s that take an exact, high-idf, norm-free term match at the full 9.0. "Ships a binary called `node`" therefore outscores "is named `node...`". This drops both to 8.0 so a program-name match sits below the package's own name.

The two have to move together. Leaving `package_mainProgram` at 9.0 keeps the ceiling exactly where it was, so the `node` page is unchanged from that alone, and it costs `firefx` 0.051 `RBP` on top.

## Measurement

All runs at k=10 against one frozen index, `nixos-51-unstable-0ae2bc1419c3f345984c2629e72e7a631820fa4d`, so no corpus drift between arms.

| metric | before | after | delta |
| --- | --- | --- | --- |
| Success@10 | 0.806 | 0.806 | +0.000 |
| MRR | 0.707 | 0.709 | +0.002 |
| RBP | 0.672 | 0.669 | -0.003 |
| BestRR | 0.749 | 0.760 | +0.011 |
| nDCG@10 | 0.706 | 0.707 | +0.001 |

The options track is the control and is untouched: all 175 queries score identically, which is expected since `optionsBody` does not use these field weights.

`BestRR` is where the change shows, because the aggregate is dominated by queries this does not touch. Five package queries move at all:

| id | q | category | metric | before | after |
| --- | --- | --- | --- | --- | --- |
| g152 | `node` | exact | BestRR | 0.167 | **1.000** |
| g152 | `node` | exact | nDCG@10 | 0.714 | 0.803 |
| g064 | `terrafrom` | typo | BestRR | 0.333 | 0.500 |
| g026 | `postgres` | prefix | RBP | 1.000 | 0.941 |
| g035 | `ngin` | prefix | nDCG@10 | 0.979 | 0.960 |
| g126 | `web server` | intent | - | 0.000 | 0.000 |

`node` is the query this was written for, and it is the largest single per-query move:

```
before  nodejs_22 nodejs_26 nodejs-slim nodejs-slim_22 nodejs-slim_26 nodejs nodejs_24 ...
after   nodejs nodejs_22 nodejs_26 nodejs-slim nodejs-slim_22 nodejs-slim_26 nodejs_24 ...
```

`nodejs` moves from rank 6 to rank 1. This is the page that `#1529` flagged as an unexplained regression and could not diagnose under the flat gold set; the ranked tiers added in `#1518` grade it directly.

The cost is two tail reorderings among near-identical variants. `postgres` loses `RBP` because `postgrest` enters at rank 7 and evicts `postgresql_17_jit`; `ngin` loses `nDCG@10` because `nginx-sso` climbs over `nginxMainline`. Both are reshuffles below the answer, and neither changes which package is first. `web server` reorders below the fold and scores 0.000 either way.

By category, packages:

| category | metric | before | after | delta |
| --- | --- | --- | --- | --- |
| exact | BestRR | 0.960 | 1.000 | +0.040 |
| typo | BestRR | 0.841 | 0.848 | +0.007 |
| prefix | nDCG@10 | 0.901 | 0.898 | -0.004 |

## Scope

This was measured as a 2x2 against `dep-count-boost`, which raises the `package_dep_count` popularity boost. The interaction term is 0.000 on every overall metric, so this change stands on its own and is not reported here in combination with anything else.

Assisted-by: Claude:claude-opus-5
