### PR TITLE
frontend/search: replace both rankings with an evolved query shape

### DIFF
--- a/frontend/src/List/Extra.elm
+++ b/frontend/src/List/Extra.elm
@@ -1,4 +1,4 @@
-module List.Extra exposing (find, unique)
+module List.Extra exposing (find, init, last, unique)
 
 import Set
 
@@ -15,6 +15,16 @@ find p list =
 
             else
                 find p t
+
+
+last : List a -> Maybe a
+last =
+    List.reverse >> List.head
+
+
+init : List a -> Maybe (List a)
+init =
+    List.reverse >> List.tail >> Maybe.map List.reverse
 
 
 unique : List comparable -> List comparable

--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -154,11 +154,12 @@ optionsBody types query from size sort =
 
 -- THE RANKING
 --
--- Neither of the two rankings below was chosen by hand. Both are the champion of
--- an evolutionary search over the clause structure, the fields and the boosts,
--- scored against `benchmark/run.mjs` on a held-out 30% of the curated queries.
--- Read them as found artefacts rather than as argued designs: the notes say what
--- the result does, not what anyone intended it to do.
+-- Almost nothing in the two rankings below was chosen by hand. Both are the
+-- champion of an evolutionary search over the clause structure, the fields and
+-- the boosts, scored against `benchmark/run.mjs` on a held-out 30% of the
+-- curated queries. Read them as found artefacts rather than as argued designs:
+-- the notes say what the result does, not what anyone intended it to do. The one
+-- exception is `fuzzyDescription` in `optionsRanking`, which is marked as such.
 --
 -- Every number here is a ranking decision, so changing one should come with a
 -- benchmark delta.
@@ -366,10 +367,12 @@ packagesRanking words =
 
 {-| How an option query is ranked.
 
-An option matches on its name alone. The `must` is one `dis_max` over two
-readings of that name - the dash-glued query as a prefix of `attr_path_reverse`,
-and each word as `*word*` against the edge-ngrams - so a description no longer
-decides whether a document matches at all, only where it ranks.
+An option matches on its name, or failing that on a misspelling of its
+description. The `must` is one `dis_max` over two readings of the name - the
+dash-glued query as a prefix of `attr_path_reverse`, and each word as `*word*`
+against the edge-ngrams - plus `fuzzyDescription` behind them at a boost three
+orders of magnitude smaller, which is what a query nothing else matched falls
+back to.
 
 The three `constant_score` clauses discard the score of what they wrap and return
 their own boost, which makes the large inner numbers - `option_name^630`,
@@ -472,6 +475,25 @@ optionsRanking words =
                     (lastWord words)
                 )
 
+        -- The one clause here that no search found. It sits at a boost small
+        -- enough that it cannot outrank any name match, so it only decides the
+        -- order of a page the name clauses left empty - which for a misspelled
+        -- query is every page. `ngnix` reaches `services.nginx.enable` through
+        -- the word `Nginx` in its description, because no subfield of
+        -- `option_name` ever yields that word as a token to be spelled wrong.
+        fuzzyDescription : List Clause
+        fuzzyDescription =
+            multiMatchClauses
+                { kind = "best_fields"
+                , between =
+                    [ ( "fuzziness", Json.Encode.string "1" )
+                    , ( "prefix_length", Json.Encode.int 1 )
+                    ]
+                , fields = [ "option_description^1" ]
+                , boost = Just 0.0001
+                }
+                (whole words)
+
         lastWordCrossFields : List Clause
         lastWordCrossFields =
             constantScore 0.0975
@@ -493,7 +515,7 @@ optionsRanking words =
         [ disMax
             { tieBreaker = Just 0.509
             , boost = Just 8.33
-            , queries = reversePathPrefix ++ nameSubstrings
+            , queries = reversePathPrefix ++ nameSubstrings ++ fuzzyDescription
             }
         ]
     , should =
@@ -536,6 +558,13 @@ whenTyped words derived =
 
     else
         []
+
+
+{-| The words joined by spaces, however many there are.
+-}
+whole : List String -> List String
+whole words =
+    [ String.join " " words ]
 
 
 {-| The words joined by spaces, but only where there is more than one. A phrase

--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -23,6 +23,26 @@ platforms =
     ]
 
 
+{-| One Elasticsearch clause, as the key/value pairs of its object.
+
+Left unwrapped so that a list of them goes straight into
+`Json.Encode.list Json.Encode.object`.
+
+-}
+type alias Clause =
+    List ( String, Json.Encode.Value )
+
+
+{-| The ranking half of the query: what a track contributes to the `bool`'s
+`must` and `should`. The rest of the body - the filters, the aggregations, the
+sort - is the same shape for both tracks.
+-}
+type alias Ranking =
+    { must : List Clause
+    , should : List Clause
+    }
+
+
 packagesBody :
     String
     -> Int
@@ -77,31 +97,19 @@ packagesBody query from size sort selectedBuckets =
             ]
     in
     encodeRequestBody
-        (String.trim query)
-        from
-        size
-        sort
-        [ "package" ]
-        "package_attr_name"
-        [ "package_pversion" ]
-        terms
-        filterByBuckets
-        [ "package_attr_name" ]
-        [ ( "package_attr_name", 9.0 )
-        , ( "package_programs", 9.0 )
-        , ( "package_mainProgram", 9.0 )
-        , ( "package_pname", 6.0 )
-        , ( "package_description", 1.3 )
-        , ( "package_longDescription", 1.0 )
-        , ( "flake_name", 0.5 )
-        ]
-        [ "package_attr_name", "package_pname", "package_programs", "package_mainProgram" ]
-        [ "package_description^3", "package_longDescription^1" ]
-        Nothing
-        [ { field = "package_repology_repos", pivot = 20.0 }
-        , { field = "package_dep_count", pivot = 1000.0 }
-        ]
-        (Just "package_attr_name")
+        { query = String.trim query
+        , from = from
+        , size = size
+        , sort = sort
+        , types = [ "package" ]
+        , sortField = "package_attr_name"
+        , otherSortFields = [ "package_pversion" ]
+        , terms = terms
+        , filterByBuckets = filterByBuckets
+        , negatedFields = [ "package_attr_name" ]
+        , ranking = packagesRanking
+        , rescore = Just { field = "package_attr_name", weight = 30.3 }
+        }
 
 
 filterByBucket : String -> String -> List ( String, Json.Encode.Value )
@@ -128,28 +136,686 @@ optionsBody :
     -> Json.Encode.Value
 optionsBody types query from size sort =
     encodeRequestBody
-        (String.trim query)
-        from
-        size
-        sort
-        types
-        "option_name"
-        []
-        []
-        []
-        [ "option_name", "option_name_query" ]
-        [ ( "option_name", 6.0 )
-        , ( "option_name_query", 6.0 )
-        , ( "option_description", 1.0 )
-        , ( "flake_name", 0.5 )
-        , ( "service_package", 3.0 )
-        , ( "service_packages", 3.0 )
+        { query = String.trim query
+        , from = from
+        , size = size
+        , sort = sort
+        , types = types
+        , sortField = "option_name"
+        , otherSortFields = []
+        , terms = []
+        , filterByBuckets = []
+        , negatedFields = [ "option_name" ]
+        , ranking = optionsRanking
+        , rescore = Just { field = "option_name", weight = 22.3 }
+        }
+
+
+
+-- THE RANKING
+--
+-- Neither of the two rankings below was chosen by hand. Both are the champion of
+-- an evolutionary search over the clause structure, the fields and the boosts,
+-- scored against `benchmark/run.mjs` on a held-out 30% of the curated queries.
+-- Read them as found artefacts rather than as argued designs: the notes say what
+-- the result does, not what anyone intended it to do.
+--
+-- Every number here is a ranking decision, so changing one should come with a
+-- benchmark delta.
+
+
+{-| How a package query is ranked.
+
+A package can match on its description alone. The `must` is a `dis_max` over a
+`constant_score` phrase on the descriptions, a fuzzy `best_fields` on the last
+word of the query, and each word as `*word*` against the attribute name. The
+shape this replaced reached the descriptions only through `should`, so a query
+that named no package matched nothing at all, which is where it was losing.
+
+Two of the `should` clauses look like they should be inert and are not. The
+`log` `rank_feature` reads `package_repology_repos`, the same field the
+`saturation` below it already reads, and the `bool` carries a `rank_feature` in
+its `must` next to a lone scoring `should`. Removing them costs 0.014 and 0.007
+nDCG respectively, so they stand because they were measured rather than because
+they read well.
+
+-}
+packagesRanking : List String -> Ranking
+packagesRanking words =
+    let
+        -- The whole query as a phrase over both description fields.
+        descriptionPhrase : List Clause
+        descriptionPhrase =
+            constantScore 110.0
+                (multiMatchClauses
+                    { kind = "phrase"
+                    , between = []
+                    , fields =
+                        [ "package_description^7.42"
+                        , "package_longDescription^1"
+                        ]
+                    , boost = Nothing
+                    }
+                    (multiWordWhole words)
+                )
+
+        -- The last word only, spelled approximately: `fierfix` still finds
+        -- `firefox`.
+        fuzzyLastWord : List Clause
+        fuzzyLastWord =
+            multiMatchClauses
+                { kind = "best_fields"
+                , between =
+                    [ ( "fuzziness", Json.Encode.string "1" )
+                    , ( "prefix_length", Json.Encode.int 1 )
+                    , ( "minimum_should_match", Json.Encode.string "20%" )
+                    , ( "_name", Json.Encode.string ("fuzzy_" ++ String.join "_" words) )
+                    ]
+                , fields =
+                    [ "package_attr_name^0.378"
+                    , "package_programs^0.441"
+                    , "package_mainProgram^0.413"
+                    , "package_pname^0.30000000000000004"
+                    ]
+                , boost = Nothing
+                }
+                (lastWord words)
+
+        -- Each word as a substring of the attribute name. On the plain keyword
+        -- rather than its edge-ngrams: the ngram subfield scored a hair better
+        -- and cost 34 ms per query.
+        attrNameSubstrings : List Clause
+        attrNameSubstrings =
+            keywordClauses
+                { kind = "wildcard"
+                , field = "package_attr_name"
+                , boost = Nothing
+                , caseInsensitive = True
+                }
+                (perWord { variants = True, surround = True } words)
+
+        -- The words glued back into one attribute name, exactly and as a prefix.
+        exactName : List Clause
+        exactName =
+            keywordClauses
+                { kind = "term"
+                , field = "package_attr_name"
+                , boost = Just 127.0
+                , caseInsensitive = False
+                }
+                (glued "-" words)
+
+        namePrefix : List Clause
+        namePrefix =
+            keywordClauses
+                { kind = "prefix"
+                , field = "package_attr_name"
+                , boost = Just 16.4
+                , caseInsensitive = True
+                }
+                (glued "" words)
+
+        pnamePrefix : List Clause
+        pnamePrefix =
+            keywordClauses
+                { kind = "prefix"
+                , field = "package_pname"
+                , boost = Just 10.1
+                , caseInsensitive = True
+                }
+                (glued "" words)
+
+        -- Everything but the last word, which for `python http server` is the
+        -- part that qualifies rather than names.
+        leadingWords : List Clause
+        leadingWords =
+            multiMatchClauses
+                { kind = "cross_fields"
+                , between = [ ( "analyzer", Json.Encode.string "keyword" ) ]
+                , fields =
+                    [ "package_pname.edge^3.52"
+                    , "package_description^1.17"
+                    , "package_programs^117"
+                    ]
+                , boost = Nothing
+                }
+                (allButLast words)
+
+        -- Popularity, read twice from the same field.
+        popularity : List Clause
+        popularity =
+            [ rankFeature
+                { field = "package_repology_repos"
+                , boost = Just 328.0
+                , name = Nothing
+                , fn = logFn 5140.0
+                }
+            , rankFeature
+                { field = "package_repology_repos"
+                , boost = Just 5.0
+                , name = Just "popularity_package_repology_repos"
+                , fn = saturationFn 13.5
+                }
+            ]
+
+        -- Dependency count beside a weak per-word match on the long description,
+        -- the attribute set and the attribute name's edge-ngrams.
+        depCountAndText : List Clause
+        depCountAndText =
+            [ [ ( "bool"
+                , Json.Encode.object
+                    [ ( "must"
+                      , Json.Encode.list Json.Encode.object
+                            [ rankFeature
+                                { field = "package_dep_count"
+                                , boost = Nothing
+                                , name = Nothing
+                                , fn = sigmoidFn 7580.0 0.434
+                                }
+                            ]
+                      )
+                    , ( "should"
+                      , Json.Encode.list Json.Encode.object
+                            (multiMatchClauses
+                                { kind = "best_fields"
+                                , between = [ ( "analyzer", Json.Encode.string "lowercase" ) ]
+                                , fields =
+                                    [ "package_longDescription.edge^12"
+                                    , "package_attr_set^2.97"
+                                    , "package_attr_name.edge^0.307"
+                                    ]
+                                , boost = Just 0.128
+                                }
+                                (perWord { variants = False, surround = False } words)
+                            )
+                      )
+                    , ( "boost", Json.Encode.float 0.364 )
+                    ]
+                )
+              ]
+            ]
+
+        -- The query read as a program path: `python.http.server`.
+        programPath : List Clause
+        programPath =
+            keywordClauses
+                { kind = "wildcard"
+                , field = "package_programs"
+                , boost = Just 12.8
+                , caseInsensitive = True
+                }
+                (dotted words)
+    in
+    { must =
+        [ disMax
+            { tieBreaker = Just 0.387
+            , boost = Nothing
+            , queries = descriptionPhrase ++ fuzzyLastWord ++ attrNameSubstrings
+            }
         ]
-        [ "option_name", "service_package", "service_packages" ]
-        [ "option_description^3" ]
-        (Just "option_name.attr_path_reverse")
+    , should =
+        exactName
+            ++ namePrefix
+            ++ leadingWords
+            ++ pnamePrefix
+            ++ popularity
+            ++ depCountAndText
+            ++ programPath
+    }
+
+
+{-| How an option query is ranked.
+
+An option matches on its name alone. The `must` is one `dis_max` over two
+readings of that name - the dash-glued query as a prefix of `attr_path_reverse`,
+and each word as `*word*` against the edge-ngrams - so a description no longer
+decides whether a document matches at all, only where it ranks.
+
+The three `constant_score` clauses discard the score of what they wrap and return
+their own boost, which makes the large inner numbers - `option_name^630`,
+`option_name.attr_path_reverse^682` - inert, and the small outer boost the weight
+the clause actually carries. They stand as found rather than tidied into
+something that would no longer be the shape that was measured.
+
+-}
+optionsRanking : List String -> Ranking
+optionsRanking words =
+    let
+        -- The whole query as a prefix of the name read back-to-front, so
+        -- `nginx.enable` reaches `services.nginx.enable`.
+        reversePathPrefix : List Clause
+        reversePathPrefix =
+            keywordClauses
+                { kind = "prefix"
+                , field = "option_name.attr_path_reverse"
+                , boost = Just 26.4
+                , caseInsensitive = False
+                }
+                (glued "-" words)
+
+        nameSubstrings : List Clause
+        nameSubstrings =
+            keywordClauses
+                { kind = "wildcard"
+                , field = "option_name.edge"
+                , boost = Nothing
+                , caseInsensitive = False
+                }
+                (perWord { variants = True, surround = True } words)
+
+        -- The words read as an attribute path, forwards and backwards.
+        forwardPath : List Clause
+        forwardPath =
+            keywordClauses
+                { kind = "wildcard"
+                , field = "option_name.attr_path"
+                , boost = Just 0.546
+                , caseInsensitive = False
+                }
+                (dotted words)
+
+        leadingWords : List Clause
+        leadingWords =
+            keywordClauses
+                { kind = "prefix"
+                , field = "option_name.attr_path_reverse"
+                , boost = Just 206.0
+                , caseInsensitive = True
+                }
+                (allButLast words)
+
+        -- The module entry point: `postgresql` reaches
+        -- `services.postgresql.package`.
+        packageLeaf : List Clause
+        packageLeaf =
+            keywordClauses
+                { kind = "wildcard"
+                , field = "option_name.attr_path_reverse"
+                , boost = Just 0.111
+                , caseInsensitive = False
+                }
+                (dottedPlus ".package" words)
+
+        -- A literal the shape carries rather than one the user typed: options
+        -- named `enable` are what most option queries are after.
+        enableLeaf : List Clause
+        enableLeaf =
+            constantScore 0.128
+                (multiMatchClauses
+                    { kind = "phrase_prefix"
+                    , between = [ ( "operator", Json.Encode.string "or" ) ]
+                    , fields =
+                        [ "service_packages.edge^373"
+                        , "option_name.edge^11.6"
+                        , "service_packages.edge^0.839"
+                        , "option_name.attr_path_reverse^682"
+                        ]
+                    , boost = Just 5.45
+                    }
+                    (fixed "enable" words)
+                )
+
+        lastWordPhrase : List Clause
+        lastWordPhrase =
+            constantScore 0.0682
+                (multiMatchClauses
+                    { kind = "phrase"
+                    , between = []
+                    , fields =
+                        [ "service_packages.edge^206"
+                        , "option_description^11.6"
+                        , "option_description.*^0.65"
+                        , "option_name^630"
+                        ]
+                    , boost = Just 105.0
+                    }
+                    (lastWord words)
+                )
+
+        lastWordCrossFields : List Clause
+        lastWordCrossFields =
+            constantScore 0.0975
+                (multiMatchClauses
+                    { kind = "cross_fields"
+                    , between = []
+                    , fields =
+                        [ "service_packages.edge^384"
+                        , "option_name.edge^11.6"
+                        , "option_description.*^0.542"
+                        , "option_name.attr_path_reverse^746"
+                        ]
+                    , boost = Just 39.3
+                    }
+                    (lastWord words)
+                )
+    in
+    { must =
+        [ disMax
+            { tieBreaker = Just 0.509
+            , boost = Just 8.33
+            , queries = reversePathPrefix ++ nameSubstrings
+            }
+        ]
+    , should =
+        forwardPath
+            ++ leadingWords
+            ++ packageLeaf
+            ++ enableLeaf
+            ++ lastWordPhrase
+            ++ lastWordCrossFields
+    }
+
+
+
+-- THE QUERY TEXT
+--
+-- A clause does not take the query verbatim, it takes one derivation of it, and
+-- a derivation can yield several spellings or none at all. `postgresql enable`
+-- is `postgresql-enable` glued, `postgresql.enable` dotted, `enable` as its last
+-- word, and `*postgresql*` and `*enable*` per word.
+
+
+{-| Did the user type anything?
+
+An empty search box splits into one empty word rather than into no words, so this
+is a question about the words' contents and not about how many there are.
+
+-}
+typed : List String -> Bool
+typed words =
+    List.any (String.isEmpty >> not) words
+
+
+{-| Derivations that only make sense against text the user typed. `Glued` is the
+exception: an empty attribute name is still a name to ask about.
+-}
+whenTyped : List String -> List String -> List String
+whenTyped words derived =
+    if typed words then
+        derived
+
+    else
         []
-        Nothing
+
+
+{-| The words joined by spaces, but only where there is more than one. A phrase
+over a single word is that word, which the clauses that name it already cover.
+-}
+multiWordWhole : List String -> List String
+multiWordWhole words =
+    if List.length words > 1 then
+        [ String.join " " words ]
+
+    else
+        []
+
+
+{-| The words joined with no separator, a `-` or a `_`. A keyword field holds a
+name as one token, so a multi-word query only reaches one glued back together.
+-}
+glued : String -> List String -> List String
+glued separator words =
+    [ String.join separator words ]
+
+
+{-| The words as an attribute path.
+-}
+dotted : List String -> List String
+dotted words =
+    whenTyped words [ String.join "." words ]
+
+
+{-| The words as an attribute path with a literal leaf appended, which turns
+`postgresql` into `postgresql.package`.
+-}
+dottedPlus : String -> List String -> List String
+dottedPlus suffix words =
+    whenTyped words [ String.join "." words ++ suffix ]
+
+
+{-| The last word of `nginx virtual hosts`, which is the one that names.
+-}
+lastWord : List String -> List String
+lastWord words =
+    whenTyped words
+        (List.Extra.last words
+            |> Maybe.map List.singleton
+            |> Maybe.withDefault []
+        )
+
+
+{-| Everything before the last word, which is the part that qualifies.
+-}
+allButLast : List String -> List String
+allButLast words =
+    whenTyped words
+        (case List.Extra.init words of
+            Just [] ->
+                []
+
+            Just leading ->
+                [ String.join " " leading ]
+
+            Nothing ->
+                []
+        )
+
+
+{-| A literal the ranking carries rather than one the user typed. It fires only
+next to a derived clause, never on an empty search box of its own.
+-}
+fixed : String -> List String -> List String
+fixed value words =
+    whenTyped words [ value ]
+
+
+{-| One spelling per word: optionally per dash/underscore spelling of each word,
+optionally wrapped in `*` for a substring match.
+-}
+perWord : { variants : Bool, surround : Bool } -> List String -> List String
+perWord spec words =
+    words
+        |> (if spec.variants then
+                List.concatMap dashUnderscoreVariants
+
+            else
+                identity
+           )
+        |> List.Extra.unique
+        |> List.map
+            (if spec.surround then
+                \word -> "*" ++ word ++ "*"
+
+             else
+                identity
+            )
+
+
+dashUnderscoreVariants : String -> List String
+dashUnderscoreVariants word =
+    [ String.replace "_" "-" word
+    , String.replace "-" "_" word
+    , word
+    ]
+
+
+
+-- THE CLAUSES
+--
+-- One builder per Elasticsearch clause the rankings use. Each takes the
+-- spellings a derivation produced and returns one clause per spelling, so a
+-- derivation that produced nothing contributes nothing.
+
+
+{-| A `term`, `prefix` or `wildcard` against a single keyword field.
+-}
+keywordClauses :
+    { kind : String
+    , field : String
+    , boost : Maybe Float
+    , caseInsensitive : Bool
+    }
+    -> List String
+    -> List Clause
+keywordClauses spec texts =
+    texts
+        |> List.map
+            (\text ->
+                [ ( spec.kind
+                  , Json.Encode.object
+                        [ ( spec.field
+                          , Json.Encode.object
+                                (( "value", Json.Encode.string text )
+                                    :: optionalFloat "boost" spec.boost
+                                    ++ (if spec.caseInsensitive then
+                                            [ ( "case_insensitive", Json.Encode.bool True ) ]
+
+                                        else
+                                            []
+                                       )
+                                )
+                          )
+                        ]
+                  )
+                ]
+            )
+
+
+{-| A `multi_match` over weighted fields. `between` carries whatever the clause
+sets between the query and the fields - an analyzer, a fuzziness, a name.
+-}
+multiMatchClauses :
+    { kind : String
+    , between : List ( String, Json.Encode.Value )
+    , fields : List String
+    , boost : Maybe Float
+    }
+    -> List String
+    -> List Clause
+multiMatchClauses spec texts =
+    texts
+        |> List.map
+            (\text ->
+                [ ( "multi_match"
+                  , Json.Encode.object
+                        ([ ( "type", Json.Encode.string spec.kind )
+                         , ( "query", Json.Encode.string text )
+                         ]
+                            ++ spec.between
+                            ++ [ ( "fields", Json.Encode.list Json.Encode.string spec.fields ) ]
+                            ++ optionalFloat "boost" spec.boost
+                        )
+                  )
+                ]
+            )
+
+
+{-| The best of several readings rather than the sum of them, so a document that
+matches two of them is not thereby twice as good a hit.
+-}
+disMax :
+    { tieBreaker : Maybe Float
+    , boost : Maybe Float
+    , queries : List Clause
+    }
+    -> Clause
+disMax spec =
+    [ ( "dis_max"
+      , Json.Encode.object
+            (optionalFloat "tie_breaker" spec.tieBreaker
+                ++ [ ( "queries", Json.Encode.list Json.Encode.object spec.queries ) ]
+                ++ optionalFloat "boost" spec.boost
+            )
+      )
+    ]
+
+
+{-| Discard the score of what is wrapped and return a fixed boost instead, which
+makes the clause a yes/no rather than a how-well.
+-}
+constantScore : Float -> List Clause -> List Clause
+constantScore boost inner =
+    inner
+        |> List.map
+            (\one ->
+                [ ( "constant_score"
+                  , Json.Encode.object
+                        [ ( "filter", Json.Encode.object one )
+                        , ( "boost", Json.Encode.float boost )
+                        ]
+                  )
+                ]
+            )
+
+
+{-| A numeric signal the index carries as a `rank_feature`, read through one of
+the saturating functions Elasticsearch offers.
+-}
+rankFeature :
+    { field : String
+    , boost : Maybe Float
+    , name : Maybe String
+    , fn : ( String, Json.Encode.Value )
+    }
+    -> Clause
+rankFeature spec =
+    [ ( "rank_feature"
+      , Json.Encode.object
+            (( "field", Json.Encode.string spec.field )
+                :: optionalFloat "boost" spec.boost
+                ++ (case spec.name of
+                        Just name ->
+                            [ ( "_name", Json.Encode.string name ) ]
+
+                        Nothing ->
+                            []
+                   )
+                ++ [ spec.fn ]
+            )
+      )
+    ]
+
+
+saturationFn : Float -> ( String, Json.Encode.Value )
+saturationFn pivot =
+    ( "saturation"
+    , Json.Encode.object [ ( "pivot", Json.Encode.float pivot ) ]
+    )
+
+
+logFn : Float -> ( String, Json.Encode.Value )
+logFn scalingFactor =
+    ( "log"
+    , Json.Encode.object [ ( "scaling_factor", Json.Encode.float scalingFactor ) ]
+    )
+
+
+sigmoidFn : Float -> Float -> ( String, Json.Encode.Value )
+sigmoidFn pivot exponent =
+    ( "sigmoid"
+    , Json.Encode.object
+        [ ( "pivot", Json.Encode.float pivot )
+        , ( "exponent", Json.Encode.float exponent )
+        ]
+    )
+
+
+optionalFloat : String -> Maybe Float -> List ( String, Json.Encode.Value )
+optionalFloat key value =
+    case value of
+        Just float ->
+            [ ( key, Json.Encode.float float ) ]
+
+        Nothing ->
+            []
+
+
+
+-- THE ENVELOPE
+--
+-- Which documents are eligible, how they are paged and sorted, and what is
+-- counted alongside them. None of this is ranking, and none of it differs
+-- between the two tracks except in the values the callers above pass in.
 
 
 toAggregations :
@@ -269,232 +935,15 @@ filterByType types =
             ]
 
 
-{-| Scales the field weights of the fuzzy clause down to a fallback.
+{-| Nudge shorter names up, once the ranking has settled on a page of them.
+
+A rescore only reorders the window it is given, so it is a tie-break among hits
+the query already liked rather than a scoring signal of its own. Documents
+without the field score 0 instead of dividing by nothing.
+
 -}
-fuzzyFallbackWeight : Float
-fuzzyFallbackWeight =
-    0.05
-
-
-searchFields :
-    List String
-    -> List String
-    -> List ( String, Float )
-    -> List String
-    -> List (List ( String, Json.Encode.Value ))
-searchFields positiveWords mainFields fields fuzzyFieldNames =
-    let
-        allFields : List String
-        allFields =
-            fields
-                |> List.concatMap
-                    (\( field, score ) ->
-                        [ field ++ "^" ++ String.fromFloat score
-                        , field ++ ".*^" ++ String.fromFloat (score * 0.6)
-                        ]
-                    )
-
-        queryWordsWildCard : List String
-        queryWordsWildCard =
-            positiveWords
-                |> List.concatMap dashUnderscoreVariants
-                |> List.Extra.unique
-
-        multiMatch : List ( String, Json.Encode.Value )
-        multiMatch =
-            [ ( "multi_match"
-              , Json.Encode.object
-                    [ ( "type", Json.Encode.string "cross_fields" )
-                    , ( "query", Json.Encode.string (String.join " " positiveWords) )
-                    , ( "analyzer", Json.Encode.string "whitespace" )
-                    , ( "auto_generate_synonyms_phrase_query", Json.Encode.bool False )
-                    , ( "operator", Json.Encode.string "and" )
-                    , ( "_name", Json.Encode.string <| "multi_match_" ++ String.join "_" positiveWords )
-                    , ( "fields", Json.Encode.list Json.Encode.string allFields )
-                    ]
-              )
-            ]
-
-        fuzzyFields : List String
-        fuzzyFields =
-            fields
-                |> List.filter (\( field, _ ) -> List.member field fuzzyFieldNames)
-                |> List.map
-                    (\( field, score ) ->
-                        field ++ "^" ++ String.fromFloat (score * fuzzyFallbackWeight)
-                    )
-
-        fuzzyMatch : List (List ( String, Json.Encode.Value ))
-        fuzzyMatch =
-            if List.isEmpty fuzzyFields then
-                []
-
-            else
-                [ [ ( "multi_match"
-                    , Json.Encode.object
-                        [ ( "type", Json.Encode.string "best_fields" )
-                        , ( "query", Json.Encode.string (String.join " " positiveWords) )
-                        , ( "fuzziness", Json.Encode.string "1" )
-                        , ( "prefix_length", Json.Encode.int 1 )
-                        , ( "operator", Json.Encode.string "and" )
-                        , ( "_name", Json.Encode.string <| "fuzzy_" ++ String.join "_" positiveWords )
-                        , ( "fields", Json.Encode.list Json.Encode.string fuzzyFields )
-                        ]
-                    )
-                  ]
-                ]
-    in
-    multiMatch
-        :: fuzzyMatch
-        ++ List.concatMap (\mf -> List.map (toWildcardQuery mf) queryWordsWildCard) mainFields
-
-
-shouldClauses :
-    String
-    -> List String
-    -> List String
-    -> List (List ( String, Json.Encode.Value ))
-shouldClauses primaryField positiveWords phraseFields =
-    if List.isEmpty positiveWords then
-        []
-
-    else
-        let
-            -- `primaryField` is a keyword, so a multi-word query only reaches an
-            -- attribute name once the words are glued back together. Package names
-            -- separate words with `-` or `_` as often as they concatenate, and no
-            -- analysed field splits those apart, so try all three spellings.
-            joinedVariants : List String
-            joinedVariants =
-                [ String.concat positiveWords
-                , String.join "-" positiveWords
-                , String.join "_" positiveWords
-                ]
-                    |> List.Extra.unique
-
-            termClauses : List (List ( String, Json.Encode.Value ))
-            termClauses =
-                joinedVariants
-                    |> List.map
-                        (\joined ->
-                            [ ( "term"
-                              , Json.Encode.object
-                                    [ ( primaryField
-                                      , Json.Encode.object
-                                            [ ( "value", Json.Encode.string joined )
-                                            , ( "boost", Json.Encode.float 100.0 )
-                                            ]
-                                      )
-                                    ]
-                              )
-                            ]
-                        )
-
-            prefixClauses : List (List ( String, Json.Encode.Value ))
-            prefixClauses =
-                joinedVariants
-                    |> List.map
-                        (\joined ->
-                            [ ( "prefix"
-                              , Json.Encode.object
-                                    [ ( primaryField
-                                      , Json.Encode.object
-                                            [ ( "value", Json.Encode.string joined )
-                                            , ( "boost", Json.Encode.float 20.0 )
-                                            , ( "case_insensitive", Json.Encode.bool True )
-                                            ]
-                                      )
-                                    ]
-                              )
-                            ]
-                        )
-
-            phraseClause : List (List ( String, Json.Encode.Value ))
-            phraseClause =
-                if List.length positiveWords > 1 then
-                    [ [ ( "constant_score"
-                        , Json.Encode.object
-                            [ ( "filter"
-                              , Json.Encode.object
-                                    [ ( "multi_match"
-                                      , Json.Encode.object
-                                            [ ( "type", Json.Encode.string "phrase" )
-                                            , ( "query", Json.Encode.string (String.join " " positiveWords) )
-                                            , ( "fields", Json.Encode.list Json.Encode.string phraseFields )
-                                            ]
-                                      )
-                                    ]
-                              )
-                            , ( "boost", Json.Encode.float 80.0 )
-                            ]
-                        )
-                      ]
-                    ]
-
-                else
-                    []
-        in
-        termClauses ++ prefixClauses ++ phraseClause
-
-
-moduleEntryPoint : String -> List String -> List (List ( String, Json.Encode.Value ))
-moduleEntryPoint field positiveWords =
-    let
-        path : String
-        path =
-            String.join "." positiveWords
-    in
-    if String.isEmpty path then
-        []
-
-    else
-        [ leafTerm field (path ++ ".enable") 100.0 "module_entry_point"
-        , leafTerm field "enable" 10.0 "module_enable_leaf"
-        ]
-
-
-leafTerm : String -> String -> Float -> String -> List ( String, Json.Encode.Value )
-leafTerm field value boost name =
-    [ ( "term"
-      , Json.Encode.object
-            [ ( field
-              , Json.Encode.object
-                    [ ( "value", Json.Encode.string value )
-                    , ( "boost", Json.Encode.float boost )
-                    , ( "_name", Json.Encode.string name )
-                    ]
-              )
-            ]
-      )
-    ]
-
-
-type alias PopularitySignal =
-    { field : String, pivot : Float }
-
-
-popularityClauses : List PopularitySignal -> List (List ( String, Json.Encode.Value ))
-popularityClauses signals =
-    List.map
-        (\{ field, pivot } ->
-            [ ( "rank_feature"
-              , Json.Encode.object
-                    [ ( "field", Json.Encode.string field )
-                    , ( "boost", Json.Encode.float 5.0 )
-                    , ( "_name", Json.Encode.string ("popularity_" ++ field) )
-                    , ( "saturation"
-                      , Json.Encode.object
-                            [ ( "pivot", Json.Encode.float pivot ) ]
-                      )
-                    ]
-              )
-            ]
-        )
-        signals
-
-
-rescoreQuery : String -> ( String, Json.Encode.Value )
-rescoreQuery field =
+rescoreQuery : { field : String, weight : Float } -> ( String, Json.Encode.Value )
+rescoreQuery { field, weight } =
     ( "rescore"
     , Json.Encode.object
         [ ( "window_size", Json.Encode.int 100 )
@@ -509,7 +958,13 @@ rescoreQuery field =
                                         [ ( "script"
                                           , Json.Encode.object
                                                 [ ( "source"
-                                                  , Json.Encode.string ("1.0 / doc['" ++ field ++ "'].value.length()")
+                                                  , Json.Encode.string
+                                                        ("doc['"
+                                                            ++ field
+                                                            ++ "'].size() == 0 ? 0 : 1.0 / doc['"
+                                                            ++ field
+                                                            ++ "'].value.length()"
+                                                        )
                                                   )
                                                 ]
                                           )
@@ -519,7 +974,7 @@ rescoreQuery field =
                           )
                         ]
                   )
-                , ( "rescore_query_weight", Json.Encode.float 20.0 )
+                , ( "rescore_query_weight", Json.Encode.float weight )
                 ]
           )
         ]
@@ -527,47 +982,44 @@ rescoreQuery field =
 
 
 encodeRequestBody :
-    String
-    -> Int
-    -> Int
-    -> Sort
-    -> List String
-    -> String
-    -> List String
-    -> List Terms
-    -> List ( String, Json.Encode.Value )
-    -> List String
-    -> List ( String, Float )
-    -> List String
-    -> List String
-    -> Maybe String
-    -> List PopularitySignal
-    -> Maybe String
+    { query : String
+    , from : Int
+    , size : Int
+    , sort : Sort
+    , types : List String
+    , sortField : String
+    , otherSortFields : List String
+    , terms : List Terms
+    , filterByBuckets : List ( String, Json.Encode.Value )
+    , negatedFields : List String
+    , ranking : List String -> Ranking
+    , rescore : Maybe { field : String, weight : Float }
+    }
     -> Json.Encode.Value
-encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms filterByBuckets mainFields fields fuzzyFieldNames phraseFields entryPointField popularitySignals rescoreField =
+encodeRequestBody request =
     let
         -- you can not request more then 10000 results otherwise it will return 404
         size =
-            if from + sizeRaw > 10000 then
-                10000 - from
+            if request.from + request.size > 10000 then
+                10000 - request.from
 
             else
-                sizeRaw
+                request.size
 
         ( negativeWords, positiveWords ) =
-            String.toLower query
+            String.toLower request.query
                 |> String.words
                 |> List.partition (String.startsWith "-")
                 |> Tuple.mapFirst (List.map (String.dropLeft 1))
 
-        primaryField : String
-        primaryField =
-            List.head mainFields |> Maybe.withDefault ""
+        ranking : Ranking
+        ranking =
+            request.ranking positiveWords
 
         -- only emit `rescore` for the `Relevance` sort.
         rescoreActive : Bool
         rescoreActive =
-            case ( sort, rescoreField ) of
+            case ( request.sort, request.rescore ) of
                 ( Relevance, Just _ ) ->
                     True
 
@@ -583,26 +1035,17 @@ encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms 
                 )
 
             else
-                toSortQuery sort sortField otherSortFields
-
-        entryPointClauses : List (List ( String, Json.Encode.Value ))
-        entryPointClauses =
-            case entryPointField of
-                Just field ->
-                    moduleEntryPoint field positiveWords
-
-                Nothing ->
-                    []
+                toSortQuery request.sort request.sortField request.otherSortFields
     in
     Json.Encode.object
         ([ ( "from"
-           , Json.Encode.int from
+           , Json.Encode.int request.from
            )
          , ( "size"
            , Json.Encode.int size
            )
          , sortQuery
-         , toAggregations terms
+         , toAggregations request.terms
          , ( "query"
            , Json.Encode.object
                 [ ( "bool"
@@ -610,12 +1053,12 @@ encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms 
                         [ ( "filter"
                           , Json.Encode.list Json.Encode.object
                                 (List.append
-                                    [ filterByType types ]
-                                    (if List.isEmpty filterByBuckets then
+                                    [ filterByType request.types ]
+                                    (if List.isEmpty request.filterByBuckets then
                                         []
 
                                      else
-                                        [ filterByBuckets ]
+                                        [ request.filterByBuckets ]
                                     )
                                 )
                           )
@@ -624,38 +1067,24 @@ encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms 
                                 (negativeWords
                                     |> List.concatMap dashUnderscoreVariants
                                     |> List.Extra.unique
-                                    |> List.concatMap (\w -> List.map (\mf -> toWildcardQuery mf w) mainFields)
+                                    |> List.concatMap
+                                        (\word ->
+                                            List.map
+                                                (\field -> toWildcardQuery field word)
+                                                request.negatedFields
+                                        )
                                 )
                           )
-                        , ( "must"
-                          , Json.Encode.list Json.Encode.object
-                                [ [ ( "dis_max"
-                                    , Json.Encode.object
-                                        [ ( "tie_breaker", Json.Encode.float 0.7 )
-                                        , ( "queries"
-                                          , Json.Encode.list Json.Encode.object
-                                                (searchFields positiveWords mainFields fields fuzzyFieldNames)
-                                          )
-                                        ]
-                                    )
-                                  ]
-                                ]
-                          )
-                        , ( "should"
-                          , Json.Encode.list Json.Encode.object
-                                (shouldClauses primaryField positiveWords phraseFields
-                                    ++ entryPointClauses
-                                    ++ popularityClauses popularitySignals
-                                )
-                          )
+                        , ( "must", Json.Encode.list Json.Encode.object ranking.must )
+                        , ( "should", Json.Encode.list Json.Encode.object ranking.should )
                         ]
                   )
                 ]
            )
          ]
-            ++ (case ( rescoreActive, rescoreField ) of
-                    ( True, Just field ) ->
-                        [ rescoreQuery field ]
+            ++ (case ( rescoreActive, request.rescore ) of
+                    ( True, Just rescore ) ->
+                        [ rescoreQuery rescore ]
 
                     _ ->
                         []
@@ -663,19 +1092,11 @@ encodeRequestBody query from sizeRaw sort types sortField otherSortFields terms 
         )
 
 
-dashUnderscoreVariants : String -> List String
-dashUnderscoreVariants word =
-    [ String.replace "_" "-" word
-    , String.replace "-" "_" word
-    , word
-    ]
-
-
 toWildcardQuery : String -> String -> List ( String, Json.Encode.Value )
-toWildcardQuery mainField queryWord =
+toWildcardQuery field queryWord =
     [ ( "wildcard"
       , Json.Encode.object
-            [ ( mainField
+            [ ( field
               , Json.Encode.object
                     [ ( "value", Json.Encode.string ("*" ++ queryWord ++ "*") )
                     , ( "case_insensitive", Json.Encode.bool True )

--- a/frontend/src/Search/Query.elm
+++ b/frontend/src/Search/Query.elm
@@ -448,9 +448,7 @@ optionsRanking words =
                     { kind = "phrase_prefix"
                     , between = [ ( "operator", Json.Encode.string "or" ) ]
                     , fields =
-                        [ "service_packages.edge^373"
-                        , "option_name.edge^11.6"
-                        , "service_packages.edge^0.839"
+                        [ "option_name.edge^11.6"
                         , "option_name.attr_path_reverse^682"
                         ]
                     , boost = Just 5.45
@@ -465,8 +463,7 @@ optionsRanking words =
                     { kind = "phrase"
                     , between = []
                     , fields =
-                        [ "service_packages.edge^206"
-                        , "option_description^11.6"
+                        [ "option_description^11.6"
                         , "option_description.*^0.65"
                         , "option_name^630"
                         ]
@@ -501,8 +498,7 @@ optionsRanking words =
                     { kind = "cross_fields"
                     , between = []
                     , fields =
-                        [ "service_packages.edge^384"
-                        , "option_name.edge^11.6"
+                        [ "option_name.edge^11.6"
                         , "option_description.*^0.542"
                         , "option_name.attr_path_reverse^746"
                         ]


### PR DESCRIPTION
Use an ElasticSearch query optimized by an [evolutionary search](https://github.com/NixOS/nixos-search/compare/main...KiaraGrouwstra:evo-hyperparam-search), evaluated on `0.8 * nDCG@10 + 0.2 * RBP (p=0.8)` using #1536's benchmark on a held-out 30% of the curated queries, and transcribed here as ordinary `Json.Encode` Elm.

This was then further improved with a (`0.001`) fuzzy fallback on `option_description`.

## Result

Measured with `npm --prefix frontend run benchmark` against the live cluster, index `nixos-51-unstable-ffb3c9b700e759be2ef13237c9d8f953b32a1e46`.

| track | metric | n | before | after | delta |
| --- | --- | --- | --- | --- | --- |
| packages | nDCG@10 | 103 | 0.708 | 0.774 | +0.066 |
| packages | Success@10 | 103 | 0.806 | 0.835 | +0.029 |
| packages | MRR | 103 | 0.707 | 0.788 | +0.081 |
| packages | Recall@10 | 103 | 0.757 | 0.796 | +0.039 |
| packages | RBP (p=0.8) | 22 | 0.672 | 0.704 | +0.032 |
| packages | BestRR | 89 | 0.752 | 0.828 | +0.076 |
| options | nDCG@10 | 175 | 0.433 | 0.717 | +0.284 |
| options | Success@10 | 175 | 0.663 | 0.857 | +0.194 |
| options | MRR | 175 | 0.513 | 0.782 | +0.269 |
| options | Recall@10 | 175 | 0.483 | 0.726 | +0.243 |
| options | RBP (p=0.8) | 92 | 0.301 | 0.484 | +0.183 |
| options | BestRR | 164 | 0.531 | 0.820 | +0.289 |

Per category, by nDCG@10:

| track | category | n | before | after | delta |
| --- | --- | --- | --- | --- | --- |
| options | typo | 18 | 0.035 | 0.701 | +0.666 |
| options | scoped | 37 | 0.240 | 0.834 | +0.594 |
| options | prefix | 19 | 0.739 | 0.981 | +0.242 |
| options | multiterm | 23 | 0.335 | 0.550 | +0.215 |
| options | exact | 34 | 0.654 | 0.777 | +0.123 |
| options | dotted | 28 | 0.703 | 0.811 | +0.108 |
| options | intent | 16 | 0.168 | 0.102 | -0.066 |
| packages | multiterm | 13 | 0.593 | 0.750 | +0.157 |
| packages | intent | 24 | 0.191 | 0.307 | +0.116 |
| packages | typo | 23 | 0.871 | 0.929 | +0.058 |
| packages | prefix | 22 | 0.907 | 0.930 | +0.023 |
| packages | exact | 21 | 0.983 | 0.989 | +0.006 |

## The one regression

Option `intent` queries - the ones that describe a capability rather than name a module - lose 0.066. This is the result of #1536's assumption these would account for just 5% of queries, and as a result should not necessarily be optimized at the expense of the more directed queries.

<details>
<summary>
## What it costs the cluster
</summary>

Request bodies are no larger.
Server load for the package category remains unchanged, while for options it roughly doubles, be it from a much lower base:

| shape | mean | median | p95 | max | mean hits |
| --- | --- | --- | --- | --- | --- |
| today | 11.5 | 10 | 24 | 43 | 495 |
| evolved | 24.4 | 17 | 52 | 79 | 480 |
| evolved + fuzzy fallback | 25.1 | 17 | 54 | 88 | 889 |

Nearly all of it is the evolved shape itself. That said, at ~25 ms an option search remains well under the ~86 ms a package search already costs.
</details>

<details>
<summary>
## What changed in the ranking
</summary>

- A package can match on its description alone. The `must` is a `dis_max` over a `constant_score` phrase on the descriptions, a fuzzy `best_fields` on the last word, and each word as `*word*` against the attribute name. The shape this replaces reached the descriptions only through `should`, so a query that named no package matched nothing - which is where `multiterm` and `intent` were losing.
- An option matches on its name, through a `dis_max` over the dash-glued query as a prefix of `attr_path_reverse` and each word as `*word*` against the edge-ngrams.
- Behind those, at `boost: 0.0001`, a fuzzy `best_fields` on `option_description`. No subfield of `option_name` ever yields a bare path segment as a token - `attr_path` and `attr_path_reverse` are `path_hierarchy`, `edge` is an `edge_ngram` over the whole dotted string - so there is nothing shaped like `nginx` for `ngnix` to be within one edit of, and 17 of the 18 option typo queries used to match no document at all. The description carries the word, and the boost is small enough that the branch can only order a page the name clauses left empty. Fifteen queries newly return an acceptable answer, none stops doing so, and the packages track is byte-identical.
- `package_dep_count` is read through a `sigmoid` rather than a `saturation`, and `package_repology_repos` through both a `log` and a `saturation`.
- The shortest-name rescore stays on both tracks, at weight 30.3 and 22.3 rather than 20, and is now null-safe: a document without the field scores 0 instead of dividing by nothing.

Three fields are dropped as unmatchable. `option_name_query` is in no index mapping at all, and `flake_name` is mapped as bare `text`, so the `flake_name.*` companion the old `searchFields` paired it with resolves to no field. Both were checked against every live index rather than against the nixpkgs family alone. `flake_name` itself is kept. `service_packages` is mapped, but only ever set on `type: service` documents - 35 of the index's 180,975 - and an option search filters that type out before scoring, so the four clauses the evolutionary search grew against it could never contribute. Removing them leaves the benchmark report byte-identical.

Several clauses look inert and are not, so they stand as found rather than tidied. The `log` `rank_feature` reads the same field as the `saturation` below it, the `bool` carries a `rank_feature` in its `must` beside a lone scoring `should`, and the three option `constant_score` wrappers discard the score of the large inner boosts they carry. Removing the first two costs 0.014 and 0.007 nDCG, measured one at a time over the full corpus.

The clause vocabulary only the hand-written shapes used is gone with them: `searchFields`, `shouldClauses`, `moduleEntryPoint`, `leafTerm`, `popularityClauses` and `fuzzyFallbackWeight`. `encodeRequestBody` takes a record rather than sixteen positional arguments, and the envelope it builds - paging, sorting, aggregations, the type and bucket filters, the negated-word `must_not` - is unchanged.
</details>

Assisted-by: Claude:claude-opus-5
Claude-Session: https://claude.ai/code/session_01JfWqryqG18MLe4hP5Se9N1
