### PR TITLE
Index how popular an option's package is

### DIFF
--- a/flake-info/src/data/export.rs
+++ b/flake-info/src/data/export.rs
@@ -246,6 +246,10 @@ pub enum Derivation {
         option_example: Option<DocValue>,
 
         option_flake: Option<ModulePath>,
+
+        option_package: Option<String>,
+
+        option_popularity: Option<u64>,
     },
     #[serde(rename = "service")]
     Service {
@@ -256,6 +260,8 @@ pub enum Derivation {
         option_default: Option<DocValue>,
         option_example: Option<DocValue>,
         option_flake: Option<ModulePath>,
+        option_package: Option<String>,
+        option_popularity: Option<u64>,
         service_package: Option<String>,
         service_module: Option<String>,
         service_packages: Vec<String>,
@@ -269,6 +275,8 @@ pub enum Derivation {
         option_default: Option<DocValue>,
         option_example: Option<DocValue>,
         option_flake: Option<ModulePath>,
+        option_package: Option<String>,
+        option_popularity: Option<u64>,
     },
     #[serde(rename = "darwin-option")]
     DarwinOption {
@@ -279,6 +287,8 @@ pub enum Derivation {
         option_default: Option<DocValue>,
         option_example: Option<DocValue>,
         option_flake: Option<ModulePath>,
+        option_package: Option<String>,
+        option_popularity: Option<u64>,
     },
 }
 
@@ -497,6 +507,8 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     default,
                     example,
                     flake,
+                    package,
+                    popularity,
                     service_package,
                     service_module,
                     service_packages,
@@ -509,6 +521,8 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                     option_example: example,
                     option_flake: flake,
                     option_type,
+                    option_package: package,
+                    option_popularity: popularity,
                     service_package,
                     service_module,
                     service_packages,
@@ -522,6 +536,8 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 default,
                 example,
                 flake,
+                package,
+                popularity,
                 ..
             }) => Derivation::HomeManagerOption {
                 option_source: declarations.get(0).map(Clone::clone),
@@ -531,6 +547,8 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 option_example: example,
                 option_flake: flake,
                 option_type,
+                option_package: package,
+                option_popularity: popularity,
             },
             import::NixpkgsEntry::DarwinOption(NixOption {
                 declarations,
@@ -540,6 +558,8 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 default,
                 example,
                 flake,
+                package,
+                popularity,
                 ..
             }) => Derivation::DarwinOption {
                 option_source: declarations.get(0).map(Clone::clone),
@@ -549,6 +569,8 @@ impl TryFrom<import::NixpkgsEntry> for Derivation {
                 option_example: example,
                 option_flake: flake,
                 option_type,
+                option_package: package,
+                option_popularity: popularity,
             },
         })
     }
@@ -566,6 +588,8 @@ impl TryFrom<import::NixOption> for Derivation {
             default,
             example,
             flake,
+            package,
+            popularity,
             ..
         }: import::NixOption,
     ) -> Result<Self, Self::Error> {
@@ -577,6 +601,8 @@ impl TryFrom<import::NixOption> for Derivation {
             option_example: example,
             option_flake: flake,
             option_type,
+            option_package: package,
+            option_popularity: popularity,
         })
     }
 }

--- a/flake-info/src/data/import.rs
+++ b/flake-info/src/data/import.rs
@@ -72,6 +72,14 @@ pub struct NixOption {
     /// If defined in a flake, contains defining flake and optionally a module
     pub flake: Option<ModulePath>,
 
+    /// The package this option's module configures, and how many distribution
+    /// repositories carry it. Both are derived by [`crate::data::popularity`]
+    /// after the fact rather than read out of the nix output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub popularity: Option<u64>,
+
     /// For modular service options: the canonical package attrname providing this service
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_package: Option<String>,
@@ -155,6 +163,17 @@ impl Serialize for DocString {
                     md.to_owned()
                 })),
             DocString::Literal(literal) => serializer.serialize_str(&render_literal(literal)),
+        }
+    }
+}
+
+impl DocValue {
+    /// The value as it is written to the index, so that anything reading it
+    /// back sees what a user of the search sees.
+    pub fn as_text(&self) -> String {
+        match self {
+            DocValue::Literal(literal) => render_literal(literal),
+            DocValue::Value(v) => print_value(v),
         }
     }
 }

--- a/flake-info/src/data/mod.rs
+++ b/flake-info/src/data/mod.rs
@@ -2,6 +2,7 @@ mod export;
 mod flake;
 pub mod import;
 mod pandoc;
+pub mod popularity;
 mod prettyprint;
 mod source;
 mod utility;

--- a/flake-info/src/data/popularity.rs
+++ b/flake-info/src/data/popularity.rs
@@ -1,0 +1,337 @@
+//! Carry a package's popularity across to the options that configure it.
+//!
+//! A package document is ranked partly on `package_repology_repos`, the number
+//! of distribution repositories that carry the package. An option document has
+//! no comparable signal: nothing in the index says that `services.nginx.enable`
+//! is asked for more often than `services.lighttpd.enable`, so a query that
+//! matches both can only be broken apart by name length or by Lucene's tie
+//! order.
+//!
+//! The link between the two is a convention nixpkgs already follows. A module
+//! that wraps a package declares which one under `<module path>.package`, with
+//! the package itself as the default:
+//!
+//! ```text
+//! services.nginx.package    default: pkgs.nginxStable
+//! services.postgresql.package    default: pkgs.postgresql_15
+//! ```
+//!
+//! So every option under `services.nginx` can be attributed to `nginxStable`
+//! by walking up its own name until a `.package` sibling is found, and take
+//! that package's repository count as its own. Modular service options say it
+//! directly through `service_package` and skip the walk.
+
+use std::collections::HashMap;
+
+use crate::data::import::{NixOption, NixpkgsEntry};
+
+/// The prefix of a `<...>.package` option, i.e. the module it belongs to.
+const PACKAGE_LEAF: &str = ".package";
+
+/// The attribute path a `pkgs.` reference opens with: `pkgs.nginxStable`,
+/// `pkgs.postgresql_15`, `pkgs.php83Packages.composer`. A default that is not
+/// a plain reference - a function call, a `let`, a conditional - has no one
+/// package to name, and yields none.
+///
+/// What comes back is what was written, which for `pkgs.hello.override { }` is
+/// `hello.override`. Telling a nested attribute from a method call is not a
+/// job for a parser this size, so [`resolve`] settles it against the packages
+/// that actually exist.
+fn pkgs_attribute(default: &str) -> Option<&str> {
+    let rest = default.strip_prefix("pkgs.")?;
+    let end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || "._'-".contains(c)))
+        .unwrap_or(rest.len());
+    let attribute = rest[..end].trim_end_matches('.');
+    (!attribute.is_empty()).then_some(attribute)
+}
+
+/// The longest prefix of a dotted attribute path that names a real package, so
+/// `hello.override` finds `hello` while `php83Packages.composer` stays whole.
+fn resolve<'a>(attribute: &'a str, packages: &HashMap<&str, Option<u64>>) -> Option<&'a str> {
+    std::iter::once(attribute)
+        .chain(ancestors(attribute))
+        .find(|candidate| packages.contains_key(candidate))
+}
+
+/// Every ancestor of an option name, longest first, so the nearest enclosing
+/// module wins: `services.nginx.virtualHosts.foo.root` tries
+/// `services.nginx.virtualHosts.foo`, then `services.nginx.virtualHosts`, then
+/// `services.nginx`, then `services`.
+fn ancestors(name: &str) -> impl Iterator<Item = &str> {
+    name.char_indices()
+        .filter(|(_, c)| *c == '.')
+        .map(|(i, _)| &name[..i])
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+}
+
+/// `<module> -> <package attribute>`, read off the `*.package` options.
+fn module_packages<'a>(options: impl Iterator<Item = &'a NixOption>) -> HashMap<&'a str, String> {
+    let mut modules = HashMap::new();
+    for option in options {
+        let Some(module) = option.name.strip_suffix(PACKAGE_LEAF) else {
+            continue;
+        };
+        // `types.package` only. A `nullOr package` or a list of them does not
+        // name one idiomatic package, and `str` under a `.package` name is
+        // something else entirely.
+        if option.option_type.as_deref() != Some("package") {
+            continue;
+        }
+        let Some(default) = option.default.as_ref().map(|d| d.as_text()) else {
+            continue;
+        };
+        if let Some(attribute) = pkgs_attribute(&default) {
+            modules.insert(module, attribute.to_owned());
+        }
+    }
+    modules
+}
+
+/// Attribute the options in `entries` to a package and stamp each one with that
+/// package's repository count, in place.
+pub fn assign(entries: &mut [NixpkgsEntry]) {
+    let packages: HashMap<&str, Option<u64>> = entries
+        .iter()
+        .filter_map(|entry| match entry {
+            NixpkgsEntry::Derivation {
+                attribute,
+                repology_repos,
+                ..
+            } => Some((attribute.as_str(), *repology_repos)),
+            _ => None,
+        })
+        .collect();
+
+    let modules = module_packages(entries.iter().filter_map(option_of));
+
+    let mut assignments = Vec::with_capacity(entries.len());
+    for entry in entries.iter() {
+        assignments.push(option_of(entry).and_then(|option| {
+            // A modular service names its package outright; everything else is
+            // attributed to the nearest module that declares one.
+            let written = match option.service_package.as_deref() {
+                Some(package) => package,
+                None => ancestors(&option.name)
+                    .find_map(|module| modules.get(module))
+                    .map(String::as_str)?,
+            };
+            let attribute = resolve(written, &packages)?;
+            Some((attribute.to_owned(), packages[attribute]))
+        }));
+    }
+
+    for (entry, assignment) in entries.iter_mut().zip(assignments) {
+        let Some((package, popularity)) = assignment else {
+            continue;
+        };
+        if let Some(option) = option_of_mut(entry) {
+            option.package = Some(package);
+            option.popularity = popularity;
+        }
+    }
+}
+
+fn option_of(entry: &NixpkgsEntry) -> Option<&NixOption> {
+    match entry {
+        NixpkgsEntry::Option(option)
+        | NixpkgsEntry::Service(option)
+        | NixpkgsEntry::HomeManagerOption(option)
+        | NixpkgsEntry::DarwinOption(option) => Some(option),
+        NixpkgsEntry::Derivation { .. } => None,
+    }
+}
+
+fn option_of_mut(entry: &mut NixpkgsEntry) -> Option<&mut NixOption> {
+    match entry {
+        NixpkgsEntry::Option(option)
+        | NixpkgsEntry::Service(option)
+        | NixpkgsEntry::HomeManagerOption(option)
+        | NixpkgsEntry::DarwinOption(option) => Some(option),
+        NixpkgsEntry::Derivation { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::import::{DocValue, Literal};
+
+    fn option(name: &str, option_type: Option<&str>, default: Option<&str>) -> NixOption {
+        NixOption {
+            declarations: vec![],
+            description: None,
+            name: name.to_owned(),
+            option_type: option_type.map(str::to_owned),
+            default: default.map(|d| DocValue::Literal(Literal::LiteralExpression(d.to_owned()))),
+            example: None,
+            flake: None,
+            package: None,
+            popularity: None,
+            service_package: None,
+            service_module: None,
+            service_packages: vec![],
+        }
+    }
+
+    fn derivation(attribute: &str, repology_repos: Option<u64>) -> NixpkgsEntry {
+        NixpkgsEntry::Derivation {
+            attribute: attribute.to_owned(),
+            package: serde_json::from_str(r#"{"pname":"p","version":"1","system":"x86_64-linux"}"#)
+                .unwrap(),
+            programs: vec![],
+            modular_services: vec![],
+            dep_count: None,
+            repology_repos,
+        }
+    }
+
+    #[test]
+    fn reads_an_attribute_out_of_a_default() {
+        assert_eq!(pkgs_attribute("pkgs.nginxStable"), Some("nginxStable"));
+        assert_eq!(pkgs_attribute("pkgs.postgresql_15"), Some("postgresql_15"));
+        assert_eq!(
+            pkgs_attribute("pkgs.php83Packages.composer"),
+            Some("php83Packages.composer")
+        );
+        assert_eq!(
+            pkgs_attribute("pkgs.hello.override { }"),
+            Some("hello.override")
+        );
+        assert_eq!(pkgs_attribute("config.boot.kernelPackages"), None);
+        assert_eq!(pkgs_attribute("pkgs."), None);
+        assert_eq!(pkgs_attribute("null"), None);
+    }
+
+    #[test]
+    fn resolves_a_method_call_back_to_its_package() {
+        let packages = HashMap::from([("hello", Some(200)), ("php83Packages.composer", Some(20))]);
+        assert_eq!(resolve("hello.override", &packages), Some("hello"));
+        assert_eq!(
+            resolve("php83Packages.composer", &packages),
+            Some("php83Packages.composer")
+        );
+        assert_eq!(resolve("notInNixpkgs", &packages), None);
+    }
+
+    #[test]
+    fn walks_ancestors_nearest_first() {
+        assert_eq!(
+            ancestors("services.nginx.virtualHosts.foo").collect::<Vec<_>>(),
+            vec!["services.nginx.virtualHosts", "services.nginx", "services"]
+        );
+        assert!(ancestors("services").next().is_none());
+    }
+
+    #[test]
+    fn attributes_an_option_to_its_nearest_module() {
+        let mut entries = vec![
+            derivation("nginxStable", Some(149)),
+            derivation("nginxMainline", Some(3)),
+            NixpkgsEntry::Option(option(
+                "services.nginx.package",
+                Some("package"),
+                Some("pkgs.nginxStable"),
+            )),
+            NixpkgsEntry::Option(option("services.nginx.enable", Some("boolean"), None)),
+            NixpkgsEntry::Option(option(
+                "services.nginx.virtualHosts.<name>.root",
+                Some("path"),
+                None,
+            )),
+            NixpkgsEntry::Option(option("services.lighttpd.enable", Some("boolean"), None)),
+        ];
+        assign(&mut entries);
+
+        let assigned = |i: usize| {
+            option_of(&entries[i])
+                .map(|o| (o.package.clone(), o.popularity))
+                .unwrap()
+        };
+        assert_eq!(assigned(3), (Some("nginxStable".to_owned()), Some(149)));
+        assert_eq!(assigned(4), (Some("nginxStable".to_owned()), Some(149)));
+        // No module below it declares a package, so it stays unattributed
+        // rather than inheriting one from `services`.
+        assert_eq!(assigned(5), (None, None));
+    }
+
+    #[test]
+    fn prefers_the_innermost_module() {
+        let mut entries = vec![
+            derivation("php", Some(80)),
+            derivation("composer", Some(20)),
+            NixpkgsEntry::Option(option(
+                "services.php.package",
+                Some("package"),
+                Some("pkgs.php"),
+            )),
+            NixpkgsEntry::Option(option(
+                "services.php.composer.package",
+                Some("package"),
+                Some("pkgs.composer"),
+            )),
+            NixpkgsEntry::Option(option(
+                "services.php.composer.enable",
+                Some("boolean"),
+                None,
+            )),
+        ];
+        assign(&mut entries);
+        assert_eq!(
+            option_of(&entries[4]).map(|o| (o.package.clone(), o.popularity)),
+            Some((Some("composer".to_owned()), Some(20)))
+        );
+    }
+
+    #[test]
+    fn a_modular_service_names_its_own_package() {
+        let mut entries = vec![derivation("nginx", Some(149)), {
+            let mut option = option("autoconnect.settings", Some("attrs"), None);
+            option.service_package = Some("nginx".to_owned());
+            NixpkgsEntry::Service(option)
+        }];
+        assign(&mut entries);
+        assert_eq!(
+            option_of(&entries[1]).map(|o| (o.package.clone(), o.popularity)),
+            Some((Some("nginx".to_owned()), Some(149)))
+        );
+    }
+
+    #[test]
+    fn keeps_the_package_when_repology_has_no_count_for_it() {
+        let mut entries = vec![
+            derivation("obscure", None),
+            NixpkgsEntry::Option(option(
+                "services.obscure.package",
+                Some("package"),
+                Some("pkgs.obscure"),
+            )),
+            NixpkgsEntry::Option(option("services.obscure.enable", Some("boolean"), None)),
+        ];
+        assign(&mut entries);
+        assert_eq!(
+            option_of(&entries[2]).map(|o| (o.package.clone(), o.popularity)),
+            Some((Some("obscure".to_owned()), None))
+        );
+    }
+
+    #[test]
+    fn ignores_a_package_option_that_is_not_one() {
+        let mut entries = vec![
+            derivation("nginx", Some(149)),
+            NixpkgsEntry::Option(option(
+                "services.nginx.package",
+                Some("null or package"),
+                Some("pkgs.nginx"),
+            )),
+            NixpkgsEntry::Option(option("services.nginx.enable", Some("boolean"), None)),
+        ];
+        assign(&mut entries);
+        assert_eq!(
+            option_of(&entries[2]).map(|o| (o.package.clone(), o.popularity)),
+            Some((None, None))
+        );
+    }
+}

--- a/flake-info/src/elastic.rs
+++ b/flake-info/src/elastic.rs
@@ -181,6 +181,13 @@ lazy_static! {
                 "option_default": {"type": "text"},
                 "option_example": {"type": "text"},
                 "option_source": {"type": "keyword"},
+                // The package the option's module configures, and how many
+                // distribution repositories carry it. `option_popularity` is
+                // the one signal an option document has for how sought-after
+                // it is; `option_package` is what makes it auditable, since a
+                // `rank_feature` cannot be sorted, aggregated or scripted.
+                "option_package": {"type": "keyword"},
+                "option_popularity": {"type": "rank_feature"},
                 // Modular service fields
                 "service_package": {
                     "type": "keyword",

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -93,6 +93,10 @@ pub fn process_nixpkgs(
     all.append(&mut hm_options);
     all.append(&mut darwin_options);
 
+    // Packages and options are only in scope together here, which is the one
+    // place the popularity of the former can be carried over to the latter.
+    data::popularity::assign(&mut all);
+
     let exports = all
         .into_iter()
         .map(Export::nixpkgs)


### PR DESCRIPTION
Give option documents the popularity signal package documents already have, derived from the package their module configures.

A package carries `package_repology_repos`, the number of distribution repositories that ship it, and the query reads it as a `rank_feature` to settle ties between otherwise equally good matches. An option carries nothing comparable: the index does not say that `services.nginx.enable` is wanted more often than `services.lighttpd.enable`, so a query matching both is decided on name length or on Lucene's tie order.

Nixpkgs already draws the link. A module that wraps a package declares which one under `<module path>.package`, with the package as the default:

```
services.nginx.package         default: pkgs.nginxStable
services.postgresql.package    default: pkgs.postgresql_15
```

So an option can be attributed to a package by walking up its own name until a `.package` sibling is found, and inherit that package's count. Modular services name theirs outright through `service_package` and skip the walk.

## Coverage

Against the current nixpkgs index (`nixos-51-unstable-ffb3c9b700e759be2ef13237c9d8f953b32a1e46`, 24897 option documents):

| | |
| --- | --- |
| `*.package` options of `types.package` | 1291 |
| of those, with a `pkgs.<attr>` default | 1271 |
| option documents attributed to a package | 18276 (73.4%) |
| distinct packages they land on | 1226 |
| of those, with a repology count | 1188 |
| option documents that end up with a value | 17858 (71.7%) |

The counts spread widely enough to rank on: min 1, p25 7, median 21, p75 88, p90 123, max 172.

## Two fields

`option_popularity` is the `rank_feature`. `option_package` is the attribute it came from, mapped as a `keyword`, because a `rank_feature` cannot be sorted, aggregated or scripted - without the keyword beside it there is no way to ask the index which package an option was attributed to, and so no way to check the derivation on real data.

## No query uses them yet

A `rank_feature` clause on `option_popularity` was fitted against #1536's benchmark. On the full corpus it looks like a win - nDCG@10 0.717 -> 0.728, Success@10 0.857 -> 0.874 - but on the 70/30 held-out split that #1541's shape was selected under, every pivot and boost tried gains on train and loses on test:

| variant | train fitness | test fitness | test nDCG@10 |
| --- | --- | --- | --- |
| no clause | 0.7271 | 0.7620 | 0.807 |
| `saturation` pivot 50, boost 0.05 | 0.7323 | 0.7566 | 0.799 |
| `saturation` pivot 50, boost 0.2 | 0.7357 | 0.7554 | 0.796 |
| `saturation` pivot 50, boost 0.5 | 0.7421 | 0.7549 | 0.795 |
| `saturation` pivot 21, boost 0.2 | 0.7356 | 0.7574 | 0.799 |
| `saturation` pivot 150, boost 0.3 | 0.7357 | 0.7552 | 0.796 |

The category it was meant to help - `intent`, describing a capability rather than naming a module - stays at 0.114 nDCG@10 in every variant. So the clause is not shipped and only the signal is, for the next run of the query search to consider.

## Deployment

No `version.nix` bump. An import writes a fresh `nixos-<schema>-<channel>-<rev>` index with the current mapping and moves the alias to it, the two fields are additive, and no existing query names them.

Assisted-by: Claude:claude-opus-5
Claude-Session: https://claude.ai/code/session_01JfWqryqG18MLe4hP5Se9N1
