### PR TITLE
Publish `repology-counts.json` as a workflow artifact

### DIFF
--- a/.github/workflows/update-repology-counts.yml
+++ b/.github/workflows/update-repology-counts.yml
@@ -46,6 +46,15 @@ jobs:
           # run publish fresh data. The `v1` prefix allows format bumps.
           key: repology-counts-v1-${{ steps.date.outputs.date }}
 
+      - name: Upload Repology counts as artifact
+        if: github.repository_owner == 'NixOS'
+        uses: actions/upload-artifact@v7
+        with:
+          name: repology-counts
+          path: repology-counts.json
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Create issue if failed
         if: failure() && github.repository_owner == 'NixOS'
         env:


### PR DESCRIPTION
The daily Repology counts only land in the Actions cache. Cache contents have no REST download endpoint -- the blob is reachable only from inside a workflow run -- so the only way to read the file today is to open a fork PR that restores the cache and prints it.

Artifacts, by contrast, are downloadable through the REST API (`GET /repos/{owner}/{repo}/actions/artifacts/{id}/zip`) by any authenticated GitHub user with no rights on the repo. So this uploads the same file alongside the existing cache save.

- Retention is 7 days: the file is regenerated daily, and a week is ample grace if a run fails.
- The cache save is unchanged, since `import-to-elasticsearch.yml` restores from it.
- No `permissions:` change -- `upload-artifact` authenticates with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`.
- The step is owner-guarded like every other step in the job, so forks stay a no-op.

Anonymous (tokenless) access would need a release asset or a data branch, which is out of scope here.

Assisted-by: Claude:claude-opus-5

Inspired by https://discourse.nixos.org/t/nix-software-a-website-for-convenient-package-search/74114/22.
