### PR TITLE
flake-info: make the User-Agent an overridable default

### DIFF
--- a/flake-info/README.md
+++ b/flake-info/README.md
@@ -35,6 +35,10 @@ OPTIONS:
     -k, --kind <kind>
             Kind of data to extract (packages|options|apps|all) [default: all]
 
+        --user-agent <user-agent>
+            Override the User-Agent sent to repology.org, the GitHub API and channels.nixos.org. Defaults to `nixos-
+            search (https://github.com/NixOS/nixos-search)` [env: FI_USER_AGENT=]
+
 
 ARGS:
     <extra>...    Extra arguments that are passed to nix as it

--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -40,6 +40,15 @@ struct Args {
     )]
     save_summary: Option<String>,
 
+    #[structopt(
+        long = "user-agent",
+        env = "FI_USER_AGENT",
+        help = "Override the User-Agent sent to repology.org, the GitHub API and \
+                channels.nixos.org. Defaults to \
+                `nixos-search (https://github.com/NixOS/nixos-search)`"
+    )]
+    user_agent: Option<String>,
+
     #[structopt(flatten)]
     elastic: ElasticOpts,
 
@@ -210,6 +219,7 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     let args = Args::from_args();
+    let user_agent = args.user_agent.clone();
 
     let summary = match args.save_summary {
         Some(filename) => Some(
@@ -227,9 +237,11 @@ async fn main() -> Result<()> {
         // `get_repology_repo_counts` uses `reqwest::blocking`, whose internal
         // runtime must not be dropped on the `#[tokio::main]` block_on thread.
         // Run it on a blocking-permitted thread instead.
-        let counts = tokio::task::spawn_blocking(flake_info::commands::get_repology_repo_counts)
-            .await
-            .context("Repology counts task panicked")??;
+        let counts = tokio::task::spawn_blocking(move || {
+            flake_info::commands::get_repology_repo_counts(user_agent.as_deref())
+        })
+        .await
+        .context("Repology counts task panicked")??;
         let json = serde_json::to_string(&counts)?;
         match output {
             Some(path) => std::fs::write(path, json)?,
@@ -243,7 +255,13 @@ async fn main() -> Result<()> {
         "at least one of --push or --json must be specified"
     );
 
-    let (exports, ident, partial_error) = run_command(args.command, args.kind, &args.extra).await?;
+    let (exports, ident, partial_error) = run_command(
+        args.command,
+        args.kind,
+        &args.extra,
+        args.user_agent.as_deref(),
+    )
+    .await?;
 
     if args.elastic.enable {
         if let Err(e) = push_to_elastic(&args.elastic, exports, ident).await {
@@ -292,6 +310,7 @@ async fn run_command(
     command: Command,
     kind: Kind,
     extra: &[String],
+    user_agent: Option<&str>,
 ) -> Result<
     (
         LazyExports,
@@ -337,7 +356,7 @@ async fn run_command(
             packages_json_url,
             repology_counts_file,
         } => {
-            let nixpkgs = Source::nixpkgs(channel)
+            let nixpkgs = Source::nixpkgs(channel, user_agent)
                 .await
                 .map_err(FlakeInfoError::Nixpkgs)?;
             let ident = (
@@ -354,6 +373,8 @@ async fn run_command(
                 kind
             };
 
+            let user_agent = user_agent.map(str::to_owned);
+
             Ok((
                 Box::new(move || {
                     flake_info::process_nixpkgs(
@@ -362,6 +383,7 @@ async fn run_command(
                         &attribute,
                         &packages_json_url,
                         &repology_counts_file,
+                        &user_agent,
                     )
                     .map_err(FlakeInfoError::Nixpkgs)
                 }),
@@ -388,6 +410,8 @@ async fn run_command(
                 kind
             };
 
+            let user_agent = user_agent.map(str::to_owned);
+
             Ok((
                 Box::new(move || {
                     flake_info::process_nixpkgs(
@@ -396,6 +420,7 @@ async fn run_command(
                         &attribute,
                         &None,
                         &None,
+                        &user_agent,
                     )
                     .map_err(FlakeInfoError::Nixpkgs)
                 }),
@@ -415,12 +440,13 @@ async fn run_command(
                 tokio::fs::remove_file("report.txt").await?;
             }
 
+            let user_agent = user_agent.map(str::to_owned);
             let sources = Source::read_sources_file(&targets)?;
             let (exports_and_hashes, errors) = sources
                 .iter()
                 .map(|source| match source {
                     Source::Nixpkgs(nixpkgs) => {
-                        flake_info::process_nixpkgs(source, &kind, &None, &None, &None)
+                        flake_info::process_nixpkgs(source, &kind, &None, &None, &None, &user_agent)
                             .with_context(|| {
                                 format!(
                                     "While processing nixpkgs archive {}",
@@ -637,5 +663,21 @@ mod tests {
     fn push_requires_schema_version() {
         let args = Args::from_iter_safe(["flake-info", "--push", "group", "f.toml", "name"]);
         assert!(args.is_err());
+    }
+
+    /// The user-agent override is declared on the top level, so it parses ahead of
+    /// any subcommand. The absent case is deliberately not asserted: `FI_USER_AGENT`
+    /// may be set in the environment running the tests.
+    #[test]
+    fn user_agent_override_is_parsed() {
+        let args = Args::from_iter_safe([
+            "flake-info",
+            "--json",
+            "--user-agent",
+            "custom/1.0",
+            "repology-counts",
+        ])
+        .expect("parses");
+        assert_eq!(args.user_agent.as_deref(), Some("custom/1.0"));
     }
 }

--- a/flake-info/src/commands/nixpkgs_info.rs
+++ b/flake-info/src/commands/nixpkgs_info.rs
@@ -19,6 +19,7 @@ pub fn get_nixpkgs_info(
     attribute: &Option<String>,
     packages_json_url: &Option<String>,
     repology_counts_file: &Option<PathBuf>,
+    user_agent: &Option<String>,
 ) -> Result<Vec<NixpkgsEntry>> {
     let nixpkgs = match nixpkgs {
         Source::Nixpkgs(nixpkgs) => nixpkgs,
@@ -36,7 +37,9 @@ pub fn get_nixpkgs_info(
     });
     log::info!("Fetching packages from {}", url);
 
-    let response = reqwest::blocking::Client::new()
+    let response = reqwest::blocking::Client::builder()
+        .user_agent(crate::user_agent::resolve(user_agent.as_deref()))
+        .build()?
         .get(&url)
         .send()
         .with_context(|| format!("Failed to download {}", url))?
@@ -68,7 +71,7 @@ pub fn get_nixpkgs_info(
     let repology_counts = if attribute.is_some() {
         HashMap::new()
     } else {
-        resolve_repology_counts(repology_counts_file)
+        resolve_repology_counts(repology_counts_file, user_agent.as_deref())
     };
 
     Ok(attr_set
@@ -97,7 +100,10 @@ pub fn get_nixpkgs_info(
 /// Repology counts for a full import: from a pre-fetched file when provided
 /// (missing/unreadable -> warn + empty, per the daily-cache design), otherwise
 /// a live best-effort crawl (local/dev/manual and archive/group paths).
-fn resolve_repology_counts(file: &Option<PathBuf>) -> HashMap<String, u64> {
+fn resolve_repology_counts(
+    file: &Option<PathBuf>,
+    user_agent: Option<&str>,
+) -> HashMap<String, u64> {
     match file {
         Some(path) => match super::load_repology_repo_counts(path) {
             Ok(counts) => {
@@ -117,7 +123,7 @@ fn resolve_repology_counts(file: &Option<PathBuf>) -> HashMap<String, u64> {
                 HashMap::new()
             }
         },
-        None => super::get_repology_repo_counts().unwrap_or_else(|err| {
+        None => super::get_repology_repo_counts(user_agent).unwrap_or_else(|err| {
             log::warn!("Skipping Repology repository counts: {:#}", err);
             HashMap::new()
         }),

--- a/flake-info/src/commands/repology.rs
+++ b/flake-info/src/commands/repology.rs
@@ -10,7 +10,6 @@ use serde::Deserialize;
 
 const API_BASE: &str = "https://repology.org/api/v1/projects/";
 const REPOLOGY_REPO: &str = "nix_unstable";
-const USER_AGENT: &str = "nixos-search (https://github.com/NixOS/nixos-search)";
 const REQUEST_DELAY: Duration = Duration::from_secs(1);
 
 /// Subset of a Repology package entry.
@@ -26,11 +25,11 @@ type RepologyPage = HashMap<String, Vec<RepologyPackage>>;
 /// the `package_repology_repos` popularity signal. Always queries the
 /// unstable nixpkgs repository, since the signal only reflects overall
 /// popularity, not the exact channel contents.
-pub fn get_repology_repo_counts() -> Result<HashMap<String, u64>> {
+pub fn get_repology_repo_counts(user_agent: Option<&str>) -> Result<HashMap<String, u64>> {
     info!("Fetching Repology repository counts for {}", REPOLOGY_REPO);
 
     let client = reqwest::blocking::Client::builder()
-        .user_agent(USER_AGENT)
+        .user_agent(crate::user_agent::resolve(user_agent))
         .build()?;
 
     let mut counts: HashMap<String, u64> = HashMap::new();

--- a/flake-info/src/data/source.rs
+++ b/flake-info/src/data/source.rs
@@ -105,7 +105,7 @@ impl Source {
         }
     }
 
-    pub async fn nixpkgs(channel: String) -> Result<Nixpkgs> {
+    pub async fn nixpkgs(channel: String, user_agent: Option<&str>) -> Result<Nixpkgs> {
         #[derive(Deserialize, Debug)]
         struct ApiResult {
             commit: Commit,
@@ -117,7 +117,7 @@ impl Source {
         }
 
         let request = reqwest::Client::builder()
-            .user_agent("nixos-search")
+            .user_agent(crate::user_agent::resolve(user_agent))
             .build()?
             .get(format!(
                 "https://api.github.com/repos/nixos/nixpkgs/branches/nixos-{}",

--- a/flake-info/src/lib.rs
+++ b/flake-info/src/lib.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 pub mod commands;
 pub mod data;
+pub mod user_agent;
 
 #[cfg(feature = "elastic")]
 pub mod elastic;
@@ -56,9 +57,16 @@ pub fn process_nixpkgs(
     attribute: &Option<String>,
     packages_json_url: &Option<String>,
     repology_counts_file: &Option<PathBuf>,
+    user_agent: &Option<String>,
 ) -> Result<Vec<Export>, anyhow::Error> {
     let drvs = if matches!(kind, Kind::All | Kind::Package) {
-        commands::get_nixpkgs_info(nixpkgs, attribute, packages_json_url, repology_counts_file)?
+        commands::get_nixpkgs_info(
+            nixpkgs,
+            attribute,
+            packages_json_url,
+            repology_counts_file,
+            user_agent,
+        )?
     } else {
         Vec::new()
     };

--- a/flake-info/src/user_agent.rs
+++ b/flake-info/src/user_agent.rs
@@ -1,0 +1,25 @@
+//! The `User-Agent` every outbound HTTP client in flake-info identifies with.
+
+/// Sent to repology.org, the GitHub API and channels.nixos.org. Forks and
+/// one-off runs should override it rather than impersonate nixos-search.
+pub const DEFAULT_USER_AGENT: &str = "nixos-search (https://github.com/NixOS/nixos-search)";
+
+/// Resolve a caller-supplied override against the default.
+pub fn resolve(user_agent: Option<&str>) -> &str {
+    user_agent.unwrap_or(DEFAULT_USER_AGENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_falls_back_to_default() {
+        assert_eq!(resolve(None), DEFAULT_USER_AGENT);
+    }
+
+    #[test]
+    fn resolve_prefers_override() {
+        assert_eq!(resolve(Some("x")), "x");
+    }
+}


### PR DESCRIPTION
The `User-Agent` sent while crawling repology.org was hard-coded, so a fork, a mirror or a one-off manual run cannot identify itself honestly -- which matters, because Repology's crawl etiquette is keyed on the agent string. A second, different literal went to the GitHub API, and the `packages.json` client sent none at all.

The string now lives in one `user_agent` module and is shared by all three clients, overridable with `--user-agent` or `FI_USER_AGENT` (the flag is top-level, so it covers `nixpkgs`, `nixpkgs-archive`, `group` and `repology-counts`). The default is byte-identical to the old repology one, so CI keeps sending what it sent before and no workflow changes.

Verified on the wire against a local listener: the override and the default each arrive as the `user-agent` header, and live `repology-counts` runs with the default, the env var and the flag all crawl at HTTP 200.

Assisted-by: Claude:claude-opus-5

Inspired by https://discourse.nixos.org/t/nix-software-a-website-for-convenient-package-search/74114/22.