### PR TITLE
flake-info: collect exports on a blocking thread

### DIFF
--- a/flake-info/src/bin/flake-info.rs
+++ b/flake-info/src/bin/flake-info.rs
@@ -212,7 +212,18 @@ struct ElasticOpts {
     no_alias: bool,
 }
 
-type LazyExports = Box<dyn FnOnce() -> Result<Vec<Export>, FlakeInfoError>>;
+type LazyExports = Box<dyn FnOnce() -> Result<Vec<Export>, FlakeInfoError> + Send>;
+
+/// Collecting exports shells out and fetches over HTTP through
+/// `reqwest::blocking`, which builds a runtime of its own. Dropping such a
+/// runtime on the `#[tokio::main]` thread panics with "Cannot drop a runtime in
+/// a context where blocking is not allowed", so the thunk runs on a thread where
+/// blocking is permitted instead.
+async fn collect_exports(exports: LazyExports) -> Result<Vec<Export>> {
+    Ok(tokio::task::spawn_blocking(exports)
+        .await
+        .context("Collecting exports panicked")??)
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -276,7 +287,10 @@ async fn main() -> Result<()> {
             return Err(e);
         }
     } else if args.elastic.json {
-        println!("{}", serde_json::to_string(&exports()?)?);
+        println!(
+            "{}",
+            serde_json::to_string(&collect_exports(exports).await?)?
+        );
     }
 
     // Surface partial failures (e.g. some group members failed to evaluate) as a
@@ -601,7 +615,7 @@ async fn push_to_elastic(
     // guard it anyway.
     let created_index = !matches!(elastic.elastic_exists, ExistsStrategy::Ignore);
 
-    let successes = exports()?;
+    let successes = collect_exports(exports).await?;
 
     info!("Pushing to elastic");
     if let Err(e) = es.push_exports(&config, &successes).await {


### PR DESCRIPTION
`--json` and `--push` both call the export thunk directly on the `#[tokio::main]` thread. Collecting exports fetches over HTTP through `reqwest::blocking`, which builds a runtime of its own, and dropping such a runtime where blocking is not allowed panics with `Cannot drop a runtime in a context where blocking is not allowed`.

The thunk now runs through `spawn_blocking`, on a thread where blocking is permitted. This is what the `repology-counts` subcommand already does for its own call to `get_repology_repo_counts`. `LazyExports` gains a `Send` bound, which every thunk satisfies already.

The 2-hourly import does not take this path today: it passes `--repology-counts-file`, so `resolve_repology_counts` loads the file and never builds the client that crawls Repology. A run without that flag does build it, and aborts.

Found while working on desktop entry indexing. It is independent of that work, so it is here on its own.

Assisted-by: Claude:claude-opus-5
