### PR TITLE
feat(flakes): add Algorithmiq/monoprop

### DIFF
--- a/flakes/manual.toml
+++ b/flakes/manual.toml
@@ -74,6 +74,11 @@ repo = "swiftformat-nix"
 
 [[sources]]
 type = "github"
+owner = "Algorithmiq"
+repo = "monoprop"
+
+[[sources]]
+type = "github"
 owner = "anpandey"
 repo = "numen-nix"
 


### PR DESCRIPTION
Adds the [Algorithmiq/monoprop](https://github.com/Algorithmiq/monoprop) flake to `flakes/manual.toml` so it is picked up by the search index.  It is not packaged in `nixpkgs`, and the flake exposes packages/devShells with proper description and license metadata.                                                              
                                                                                                                                                                                             
Verified with:                                                                                 
                                                                                               
```                                                                                            
  nix run github:nixos/nixos-search#flake-info -- --json flake github:Algorithmiq/monoprop     
```  